### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used. 

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesInternal.java
@@ -35,13 +35,13 @@ import java.io.OutputStream;
 import java.io.UTFDataFormatException;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
 import static net.openhft.chronicle.core.util.StringUtils.extractChars;
 import static net.openhft.chronicle.core.util.StringUtils.setCount;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
  * Utility methods to support common functionality in this package. This is not intended to be
@@ -50,11 +50,11 @@ import static net.openhft.chronicle.core.util.StringUtils.setCount;
 enum BytesInternal {
     ;
     static final char[] HEXI_DECIMAL = "0123456789ABCDEF".toCharArray();
-    private static final byte[] MIN_VALUE_TEXT = ("" + Long.MIN_VALUE).getBytes();
+    private static final byte[] MIN_VALUE_TEXT = ("" + Long.MIN_VALUE).getBytes(ISO_8859_1);
     private static final StringBuilderPool SBP = new StringBuilderPool();
     private static final StringInterner SI = new StringInterner(4096);
-    private static final byte[] Infinity = "Infinity".getBytes();
-    private static final byte[] NaN = "NaN".getBytes();
+    private static final byte[] Infinity = "Infinity".getBytes(ISO_8859_1);
+    private static final byte[] NaN = "NaN".getBytes(ISO_8859_1);
     private static final long MAX_VALUE_DIVIDE_5 = Long.MAX_VALUE / 5;
     private static final ThreadLocal<byte[]> NUMBER_BUFFER = ThreadLocal.withInitial(() -> new byte[20]);
     private static final long MAX_VALUE_DIVIDE_10 = Long.MAX_VALUE / 10;
@@ -1999,7 +1999,7 @@ enum BytesInternal {
         }
         long date = timeInMS / 86400000;
         if (dateCache.lastDay != date) {
-            dateCache.lastDateStr = dateCache.dateFormat.format(new Date(timeInMS)).getBytes(StandardCharsets.ISO_8859_1);
+            dateCache.lastDateStr = dateCache.dateFormat.format(new Date(timeInMS)).getBytes(ISO_8859_1);
             dateCache.lastDay = date;
 
         } else {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
@@ -23,11 +23,13 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.IntSupplier;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
 /**
  * Implementation of a reference to a 32-bit in in text wire format.
  */
 public class TextIntReference implements IntValue, Byteable {
-    private static final byte[] template = "!!atomic { locked: false, value: 0000000000 }".getBytes();
+    private static final byte[] template = "!!atomic { locked: false, value: 0000000000 }".getBytes(ISO_8859_1);
     private static final int FALSE = 'f' | ('a' << 8) | ('l' << 16) | ('s' << 24);
     private static final int TRUE = ' ' | ('t' << 8) | ('r' << 16) | ('u' << 24);
     private static final int INT_TRUE = 1;

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -19,7 +19,10 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.values.LongValue;
+
 import org.jetbrains.annotations.NotNull;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /*
 The format for a long array in text is
@@ -27,11 +30,11 @@ The format for a long array in text is
  */
 
 public class TextLongArrayReference implements ByteableLongArrayValues {
-    private static final byte[] SECTION1 = "{ capacity: ".getBytes();
-    private static final byte[] SECTION2 = ", values: [ ".getBytes();
-    private static final byte[] SECTION3 = " ] }\n".getBytes();
-    private static final byte[] ZERO = "00000000000000000000".getBytes();
-    private static final byte[] SEP = ", ".getBytes();
+    private static final byte[] SECTION1 = "{ capacity: ".getBytes(ISO_8859_1);
+    private static final byte[] SECTION2 = ", values: [ ".getBytes(ISO_8859_1);
+    private static final byte[] SECTION3 = " ] }\n".getBytes(ISO_8859_1);
+    private static final byte[] ZERO = "00000000000000000000".getBytes(ISO_8859_1);
+    private static final byte[] SEP = ", ".getBytes(ISO_8859_1);
 
     private static final int DIGITS = ZERO.length;
     private static final int CAPACITY = SECTION1.length;

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
@@ -22,12 +22,14 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.LongSupplier;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
 /**
  * reference to an array fo 32-bit in values in Text wire format.
  */
 public class TextLongReference implements LongReference {
     static final int VALUE = 33;
-    private static final byte[] template = "!!atomic { locked: false, value: 00000000000000000000 }".getBytes();
+    private static final byte[] template = "!!atomic { locked: false, value: 00000000000000000000 }".getBytes(ISO_8859_1);
     private static final int FALSE = BytesUtil.asInt("fals");
     private static final int TRUE = BytesUtil.asInt(" tru");
     private static final long UNINITIALIZED = 0x0L;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
 
Please let me know if you have any questions.
 
 
Faisal Hameed