### PR TITLE
General code quality fix-2

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
@@ -30,6 +30,11 @@ import java.nio.BufferUnderflowException;
  * Created by peter on 30/08/15.
  */
 public class AppendableUtil {
+	
+	private AppendableUtil() {
+		
+	}
+	
     public static void setCharAt(@NotNull Appendable sb, int index, char ch)
             throws IllegalArgumentException, BufferOverflowException, IORuntimeException {
         if (sb instanceof StringBuilder)

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytesStore.java
@@ -220,9 +220,7 @@ public class NativeBytesStore<Underlying>
     }
 
     long translate(long offset) {
-        long offset2 = offset - start();
-//        assert checkTranslatedBounds(offset2);
-        return offset2;
+        return offset - start();
     }
 
     public long start() {

--- a/src/main/java/net/openhft/chronicle/bytes/util/Compression.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Compression.java
@@ -23,7 +23,7 @@ public interface Compression {
                 break;
             case 's':
                 if (StringUtils.isEqual("snappy", cs)) {
-                    Compressions.Snappy.compress(uncompressed, compressed);
+                    Compressions.SNAPPY.compress(uncompressed, compressed);
                     return;
                 }
                 break;
@@ -36,7 +36,7 @@ public interface Compression {
             default:
                 break;
         }
-        Compressions.Binary.compress(uncompressed, compressed);
+        Compressions.BINARY.compress(uncompressed, compressed);
     }
 
     static void uncompress(CharSequence cs, Bytes from, Bytes to) {
@@ -44,7 +44,7 @@ public interface Compression {
             case 'b':
             case '!':
                 if (StringUtils.isEqual("binary", cs) || StringUtils.isEqual("!binary", cs)) {
-                    Compressions.Binary.uncompress(from, to);
+                    Compressions.BINARY.uncompress(from, to);
                     return;
                 }
 
@@ -57,7 +57,7 @@ public interface Compression {
                 break;
             case 's':
                 if (StringUtils.isEqual("snappy", cs)) {
-                    Compressions.Snappy.uncompress(from, to);
+                    Compressions.SNAPPY.uncompress(from, to);
                     return;
                 }
                 break;
@@ -78,7 +78,7 @@ public interface Compression {
             case 'b':
             case '!':
                 if (StringUtils.isEqual("binary", cs) || StringUtils.isEqual("!binary", cs))
-                    return Compressions.Binary.uncompress(bytes.apply(t));
+                    return Compressions.BINARY.uncompress(bytes.apply(t));
 
                 break;
             case 'l':
@@ -87,7 +87,7 @@ public interface Compression {
                 break;
             case 's':
                 if (StringUtils.isEqual("snappy", cs))
-                    return Compressions.Snappy.uncompress(bytes.apply(t));
+                    return Compressions.SNAPPY.uncompress(bytes.apply(t));
                 break;
             case 'g':
                 if (StringUtils.isEqual("gzip", cs))

--- a/src/main/java/net/openhft/chronicle/bytes/util/Compressions.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Compressions.java
@@ -14,7 +14,7 @@ import java.util.zip.*;
  * Created by peter.lawrey on 09/12/2015.
  */
 public enum Compressions implements Compression {
-    Binary {
+    BINARY {
         @Override
         public byte[] compress(byte[] bytes) throws IORuntimeException {
             return bytes;
@@ -76,7 +76,7 @@ public enum Compressions implements Compression {
             }
         }
     },
-    Snappy {
+    SNAPPY {
         @Override
         public byte[] compress(byte[] bytes) throws IORuntimeException {
             try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1118 - Utility classes should not have public constructors.
squid:S00115 - Constant names should comply with a naming convention.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S00115

Please let me know if you have any questions.
 
Faisal Hameed