### PR TITLE
Fixed issue on (bulk) write from direct ByteBuffer

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytesStore.java
@@ -430,7 +430,7 @@ public class NativeBytesStore<Underlying>
     public void write(
             long offsetInRDO, @NotNull ByteBuffer bytes, int offset, int length) {
         if (bytes.isDirect()) {
-            memory.copyMemory(((DirectBuffer) bytes).address(),
+            memory.copyMemory(((DirectBuffer) bytes).address() + offset,
                     address + translate(offsetInRDO), length);
 
         } else {


### PR DESCRIPTION
In the previous version of the method, when the ByteBuffer is direct the copy will start ever on address without considering the offset parameter.
Fixed adding offset to the address in order to perform the copy starting from the right position of the buffer.