### PR TITLE
support readOnly from MappedBytes static factories

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
@@ -65,8 +65,13 @@ public class MappedBytes extends AbstractBytes<Void> implements Closeable {
 
     @NotNull
     public static MappedBytes mappedBytes(@NotNull File file, long chunkSize, long overlapSize) throws FileNotFoundException, IllegalStateException {
-        MappedFile rw = MappedFile.of(file, chunkSize, overlapSize, false);
-        return mappedBytes(rw);
+        return mappedBytes(file, chunkSize, overlapSize, false);
+    }
+
+    @NotNull
+    public static MappedBytes mappedBytes(@NotNull File file, long chunkSize, long overlapSize, boolean readOnly) throws FileNotFoundException, IllegalStateException {
+        MappedFile mf = MappedFile.of(file, chunkSize, overlapSize, readOnly);
+        return mappedBytes(mf);
     }
 
     @NotNull

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
@@ -21,6 +21,7 @@ import net.openhft.chronicle.core.threads.ThreadDump;
 import org.junit.*;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 
@@ -110,5 +111,10 @@ public class MappedFileTest {
         try (MappedBytes bytes = MappedBytes.readOnly(file)) {
             Assert.assertEquals(0x12345678L, bytes.readLong(3L << 30));
         }
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void readOnlyCantCreateNonExistentFile() throws IOException {
+        MappedBytes.mappedBytes(new File("non_existent_file"), OS.pageSize(), OS.pageSize(), true);
     }
 }


### PR DESCRIPTION
This is required for the PR I am working up for Chronicle Queue for https://github.com/OpenHFT/Chronicle-Queue/issues/266

Chronicle Queue needs a new function in this PR. If you approve this PR and merge it will OpenHFT guys cut a new release of Chronicle-Bytes and chronicle-bom? Then I can send you the PR for Chronicle Queue.

Cheers