### PR TITLE
Synchronize MappedBytes.acquireNextByteStore().

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-bom</artifactId>
-                <version>1.13.21</version>
+                <version>1.13.24-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
@@ -137,7 +137,7 @@ public class MappedBytes extends AbstractBytes<Void> implements Closeable {
         super.writeCheckOffset(offset, adding);
     }
 
-    private void acquireNextByteStore(long offset) {
+    private synchronized void acquireNextByteStore(long offset) {
         BytesStore oldBS = bytesStore;
         try {
             bytesStore = (BytesStore) mappedFile.acquireByteStore(offset);


### PR DESCRIPTION
This fixes the major race condition with multiple appenders. Please review for performance.