### PR TITLE
assertion in toString

### DIFF
--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
@@ -96,6 +96,7 @@ public class MappedFileTest {
         Bytes bytes = bs.bytesForRead();
 
         assertNotNull(bytes.toString()); // show it doesn't blow up.
+        assertNotNull(bs.toString()); // show it doesn't blow up.
         assertEquals(chunkSize, bytes.start());
         assertEquals(0L, bs.readLong(chunkSize + (1 << 10)));
         assertEquals(0L, bytes.readLong(chunkSize + (1 << 10)));


### PR DESCRIPTION
following line asserts when doing toString on a MappedBytesStore object
assert bytes.start() <= bytes.readPosition();

java.lang.AssertionError
	at net.openhft.chronicle.bytes.BytesInternal.toString(BytesInternal.java:1067)
	at net.openhft.chronicle.bytes.BytesInternal.toString(BytesInternal.java:1021)
	at net.openhft.chronicle.bytes.NativeBytesStore.toString(NativeBytesStore.java:538)

Does MappedBytesStore need readPosition() override that returns its start instead of 0?