### PR TITLE
Fix parse8bit_SB1 method for JDK9+ and UTF16 encoder

### DIFF
--- a/src/test/java/net/openhft/chronicle/bytes/BytesInternalTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesInternalTest.java
@@ -21,6 +21,8 @@ import net.openhft.chronicle.core.threads.ThreadDump;
 import org.jetbrains.annotations.NotNull;
 import org.junit.*;
 
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -138,6 +140,21 @@ public class BytesInternalTest {
         assertEquals(new String(bytes2, 0), sb.toString());
 
         bytes.release();
+    }
+
+    @Test
+    public void testParse8bitAndStringBuilderWithUtf16Coder() throws BufferUnderflowException, IOException {
+        @NotNull NativeBytesStore<Void> bs = NativeBytesStore.nativeStore(32);
+        bs.write(0, new byte[] {0x76, 0x61, 0x6c, 0x75, 0x65}); // "value" string
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("你好");
+
+        BytesInternal.parse8bit(0, bs, sb, 5);
+        String actual = sb.toString();
+
+        assertEquals("value", actual);
+        assertEquals(5, actual.length());
     }
 
     @Test


### PR DESCRIPTION
Hi,

this should fix https://github.com/OpenHFT/Chronicle-Queue/issues/553 issue.  The thing is that StringBuilder may internally change its coder from LATIN to UTF16 and any following reading of 8bit string is broken as it is not correct to simply copy bytes.

Notes:

* Using two StringBuilders with coder 1 and coder 2 would be more performant I guess. However, it's harder to make this invariant hold every time.
* Another way to fix the issue would be to change coder for given StringBuilder instance. This would require to implement new code to Chronicle-Core so I went with simpler solution. In absence of performance tests, it's hard for me to tell what solution is better.

I will send another PR to Chronicle Wire repo that verifies that the output is as below:

```java
    @Test
    public void testUnicodeReadAndWrite() {

        @NotNull Wire wire = createWire();
        wire.writeDocument(false, w -> w.write("data")
                .typePrefix("!UpdateEvent")
                .marshallable(
                        v -> {
                            v.write("mm").text("你好")
                                    .write("value").float64(15.0);
                        }));

        assertEquals("--- !!data #binary\n" +
                "data: !!UpdateEvent {\n" +
                "  mm: \"\\u4F60\\u597D\",\n" +
                "  value: 15\n" +
                "}\n", Wires.fromSizePrefixedBlobs(wire.bytes()));

        wire.bytes().release();
    }
```

Regards,
Martin