### PR TITLE
Polish: suppress 'rawtypes', 'checked', and 'restriction' warnings

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -29,6 +29,7 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
+@SuppressWarnings("rawtypes")
 public abstract class AbstractBytes<Underlying> implements Bytes<Underlying> {
     // used for debugging
     @UsedViaReflection

--- a/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
@@ -30,6 +30,7 @@ import java.nio.BufferUnderflowException;
 /*
  * Created by Peter Lawrey on 30/08/15.
  */
+@SuppressWarnings("rawtypes")
 public enum AppendableUtil {
     ;
 

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
@@ -12,9 +12,11 @@ import java.util.function.Function;
 
 public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocationHandler implements BytesMethodWriterInvocationHandler {
     private final Function<Method, MethodEncoder> methodToId;
+    @SuppressWarnings("rawtypes")
     private final BytesOut out;
     private final Map<Method, MethodEncoder> methodToIdMap = new LinkedHashMap<>();
 
+    @SuppressWarnings("rawtypes")
     public BinaryBytesMethodWriterInvocationHandler(Function<Method, MethodEncoder> methodToId, BytesOut out) {
         super(HashMap::new);
         this.methodToId = methodToId;

--- a/src/main/java/net/openhft/chronicle/bytes/ByteStringAppender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ByteStringAppender.java
@@ -28,6 +28,7 @@ import java.nio.BufferUnderflowException;
 /**
  * Methods to append text to a Bytes. This extends the Appendable interface.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface ByteStringAppender<B extends ByteStringAppender<B>> extends StreamingDataOutput<B>, Appendable {
 
     /**

--- a/src/main/java/net/openhft/chronicle/bytes/ByteStringParser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ByteStringParser.java
@@ -119,6 +119,7 @@ interface ByteStringParser<B extends ByteStringParser<B>> extends StreamingDataI
      * @param buffer         to populate
      * @param stopCharTester to check if the end has been reached.
      */
+    @SuppressWarnings("rawtypes")
     @ForceInline
     default void parse8bit(Appendable buffer, @NotNull StopCharTester stopCharTester)
             throws BufferUnderflowException {
@@ -144,6 +145,7 @@ interface ByteStringParser<B extends ByteStringParser<B>> extends StreamingDataI
      * @param buffer          to populate
      * @param stopCharsTester to check if the end has been reached.
      */
+    @SuppressWarnings("rawtypes")
     @ForceInline
     default void parse8bit(Appendable buffer, @NotNull StopCharsTester stopCharsTester)
             throws BufferUnderflowException {
@@ -153,6 +155,7 @@ interface ByteStringParser<B extends ByteStringParser<B>> extends StreamingDataI
             BytesInternal.parse8bit(this, (Bytes) buffer, stopCharsTester);
     }
 
+    @SuppressWarnings("rawtypes")
     default void parse8bit(Bytes buffer, @NotNull StopCharsTester stopCharsTester)
             throws BufferUnderflowException {
         BytesInternal.parse8bit(this, buffer, stopCharsTester);

--- a/src/main/java/net/openhft/chronicle/bytes/ByteStringReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ByteStringReader.java
@@ -23,6 +23,7 @@ import java.nio.BufferUnderflowException;
 /**
  * A Reader wrapper for Bytes.  This Reader moves the readPosition() of the underlying Bytes up to the readLimit()
  */
+@SuppressWarnings("rawtypes")
 public class ByteStringReader extends Reader {
     private final ByteStringParser in;
 

--- a/src/main/java/net/openhft/chronicle/bytes/ByteStringWriter.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ByteStringWriter.java
@@ -25,6 +25,7 @@ import java.nio.BufferOverflowException;
 /**
  * A Writer for an underlying Bytes.  This moves the writePosition() up to the writeLimit();
  */
+@SuppressWarnings("rawtypes")
 class ByteStringWriter extends Writer {
     private final ByteStringAppender out;
 

--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -42,6 +42,7 @@ import java.nio.charset.StandardCharsets;
  * writeLimit() &lt;= capacity() <p></p> Also readLimit() == writePosition() and readPosition()
  * &lt;= safeLimit(); <p></p>
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface Bytes<Underlying> extends
         BytesStore<Bytes<Underlying>, Underlying>,
         BytesIn<Underlying>,

--- a/src/main/java/net/openhft/chronicle/bytes/BytesComment.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesComment.java
@@ -16,6 +16,7 @@ public interface BytesComment<B extends BytesComment<B>> {
      * @param comment to add (or ignore)
      * @return this
      */
+    @SuppressWarnings("unchecked")
     default B comment(CharSequence comment) {
         return (B) this;
     }
@@ -26,6 +27,7 @@ public interface BytesComment<B extends BytesComment<B>> {
      * @param n +1 indent in, -1 reduce indenting
      * @return this.
      */
+    @SuppressWarnings("unchecked")
     default B indent(int n) {
         return (B) this;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesConsumer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesConsumer.java
@@ -28,6 +28,7 @@ public interface BytesConsumer {
      * @param bytes to read into
      * @return false if this queue is empty
      */
+    @SuppressWarnings("rawtypes")
     boolean read(BytesOut bytes) throws BufferOverflowException;
 
 }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesContext.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesContext.java
@@ -10,6 +10,7 @@ public interface BytesContext extends Closeable {
     /**
      * @return a bytes to write to
      */
+    @SuppressWarnings("rawtypes")
     Bytes bytes();
 
     /**

--- a/src/main/java/net/openhft/chronicle/bytes/BytesIn.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesIn.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 /*
  * Created by Peter Lawrey on 20/04/2016.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface BytesIn<Underlying> extends
         StreamingDataInput<Bytes<Underlying>>,
         RandomDataInput,

--- a/src/main/java/net/openhft/chronicle/bytes/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesInternal.java
@@ -52,6 +52,7 @@ import static net.openhft.chronicle.core.util.StringUtils.*;
  * Utility methods to support common functionality in this package. This is not intended to be
  * accessed directly.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 enum BytesInternal {
     ;
     static final char[] HEXADECIMAL = "0123456789abcdef".toCharArray();

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMarshallable.java
@@ -23,10 +23,12 @@ import net.openhft.chronicle.core.io.IORuntimeException;
  */
 public interface BytesMarshallable extends ReadBytesMarshallable, WriteBytesMarshallable {
     @Override
+    @SuppressWarnings("rawtypes")
     default void readMarshallable(BytesIn bytes) throws IORuntimeException {
         BytesUtil.readMarshallable(this, bytes);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     default void writeMarshallable(BytesOut bytes) {
         BytesUtil.writeMarshallable(this, bytes);

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 /*
  * Created by Peter Lawrey on 19/04/2016.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class BytesMarshaller<T> {
     public static final ClassLocal<BytesMarshaller> BYTES_MARSHALLER_CL
             = ClassLocal.withInitial(BytesMarshaller::new);

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMethodReader.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Consumer;
 
+@SuppressWarnings("rawtypes")
 public class BytesMethodReader implements MethodReader {
     private final BytesIn in;
     private final BytesParselet defaultParselet;

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMethodReaderBuilder.java
@@ -2,6 +2,7 @@ package net.openhft.chronicle.bytes;
 
 import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings("rawtypes")
 public class BytesMethodReaderBuilder implements MethodReaderBuilder {
     private final BytesIn in;
     private BytesParselet defaultParselet = createDefaultParselet();

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMethodWriterBuilder.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 @Deprecated(/*is it used?*/)
 public class BytesMethodWriterBuilder<T> implements MethodWriterBuilder<T> {
 

--- a/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 /*
  * Created by Peter Lawrey on 20/04/2016.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface BytesOut<Underlying> extends
         StreamingDataOutput<Bytes<Underlying>>,
         ByteStringAppender<Bytes<Underlying>>,

--- a/src/main/java/net/openhft/chronicle/bytes/BytesParselet.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesParselet.java
@@ -2,5 +2,6 @@ package net.openhft.chronicle.bytes;
 
 @FunctionalInterface
 public interface BytesParselet {
+    @SuppressWarnings("rawtypes")
     void accept(long messageType, BytesIn in);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesPrepender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesPrepender.java
@@ -46,6 +46,7 @@ public interface BytesPrepender<B extends BytesPrepender<B>> {
      * @throws BufferUnderflowException if the capacity of the underlying buffer was exceeded
      * @throws IORuntimeException       if an error occurred while attempting to resize the underlying buffer
      */
+    @SuppressWarnings("unchecked")
     @NotNull
     default B prepend(long value) throws BufferOverflowException {
         BytesInternal.prepend(this, value);
@@ -67,6 +68,7 @@ public interface BytesPrepender<B extends BytesPrepender<B>> {
      *
      * @param bytes to prepend to.
      */
+    @SuppressWarnings("rawtypes")
     @NotNull
     B prewrite(BytesStore bytes) throws BufferOverflowException;
 

--- a/src/main/java/net/openhft/chronicle/bytes/BytesRingBuffer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesRingBuffer.java
@@ -29,6 +29,7 @@ import java.nio.BufferOverflowException;
 /**
  * @author Rob Austin.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface BytesRingBuffer extends BytesRingBufferStats, BytesConsumer, Closeable {
 
     Logger LOG = LoggerFactory.getLogger(BytesRingBuffer.class);

--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -36,6 +36,7 @@ import static java.lang.Math.min;
  * provided the data referenced is accessed in a thread safe manner. Only offset access within the
  * capacity is possible.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
         extends RandomDataInput, RandomDataOutput<B>, ReferenceCounted, CharSequence {
 

--- a/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
@@ -40,6 +40,7 @@ import static net.openhft.chronicle.core.io.IOTools.*;
 /*
  * Created by Peter Lawrey on 30/08/15..
  */
+@SuppressWarnings("rawtypes")
 public enum BytesUtil {
     ;
 

--- a/src/main/java/net/openhft/chronicle/bytes/HeapBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/HeapBytesStore.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 /**
  * Wrapper for Heap ByteBuffers and arrays.
  */
-@SuppressWarnings("sunapi")
+@SuppressWarnings("restriction")
 public class HeapBytesStore<Underlying>
         extends AbstractBytesStore<HeapBytesStore<Underlying>, Underlying> {
     @Nullable
@@ -80,6 +80,7 @@ public class HeapBytesStore<Underlying>
         return false;
     }
 
+    @SuppressWarnings("unchecked")
     public void init(@NotNull ByteBuffer byteBuffer) {
         //noinspection unchecked
         this.underlyingObject = (Underlying) byteBuffer;
@@ -88,6 +89,7 @@ public class HeapBytesStore<Underlying>
         this.capacity = byteBuffer.capacity();
     }
 
+    @SuppressWarnings("unchecked")
     public void init(@NotNull byte[] byteArray) {
         //noinspection unchecked
         this.underlyingObject = (Underlying) byteArray;
@@ -410,6 +412,7 @@ public class HeapBytesStore<Underlying>
         throw new UnsupportedOperationException("todo");
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public boolean equals(Object obj) {
         return obj instanceof BytesStore && BytesInternal.contentEqual(this, (BytesStore) obj);

--- a/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class HexDumpBytes implements Bytes<Void> {
 
     private static final char[] HEXADECIMAL = "0123456789abcdef".toCharArray();

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
@@ -41,6 +41,7 @@ import static net.openhft.chronicle.core.util.StringUtils.*;
  * <p>
  * NOTE These Bytes are single Threaded as are all Bytes.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class MappedBytes extends AbstractBytes<Void> implements Closeable {
     private static final Logger LOGGER = LoggerFactory.getLogger(MappedBytes.class);
     private static final boolean ENFORCE_SINGLE_THREADED_ACCESS =
@@ -696,6 +697,7 @@ public class MappedBytes extends AbstractBytes<Void> implements Closeable {
         return bytesStore.readVolatileLong(offset);
     }
 
+    @SuppressWarnings("restriction")
     @Override
     public int peekVolatileInt() {
         if (!bytesStore.inside(readPosition, 4)) {

--- a/src/main/java/net/openhft/chronicle/bytes/MappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedFile.java
@@ -48,6 +48,7 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
  * A memory mapped files which can be randomly accessed in chunks. It has overlapping regions to
  * avoid wasting bytes at the end of chunks.
  */
+@SuppressWarnings({"rawtypes", "unchecked", "restriction"})
 public class MappedFile implements ReferenceCounted {
     private static final long DEFAULT_CAPACITY = 128L << 40;
     // A single JVM cannot lock a file more than once.

--- a/src/main/java/net/openhft/chronicle/bytes/MappedUniqueMicroTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedUniqueMicroTimeProvider.java
@@ -16,6 +16,7 @@ public enum MappedUniqueMicroTimeProvider implements TimeProvider {
     private static final int LAST_TIME = 128;
 
     private final MappedFile file;
+    @SuppressWarnings("rawtypes")
     private final Bytes bytes;
     private TimeProvider provider = SystemTimeProvider.INSTANCE;
 

--- a/src/main/java/net/openhft/chronicle/bytes/MethodEncoder.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodEncoder.java
@@ -3,7 +3,9 @@ package net.openhft.chronicle.bytes;
 public interface MethodEncoder {
     long messageId();
 
+    @SuppressWarnings("rawtypes")
     void encode(Object[] objects, BytesOut out);
 
+    @SuppressWarnings("rawtypes")
     Object[] decode(Object[] lastObjects, BytesIn in);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/MethodEncoderLookup.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodEncoderLookup.java
@@ -19,6 +19,7 @@ public enum MethodEncoderLookup implements Function<Method, MethodEncoder> {
                 return messageId;
             }
 
+            @SuppressWarnings("rawtypes")
             @Override
             public void encode(Object[] objects, BytesOut out) {
                 for (Object object : objects) {
@@ -30,6 +31,7 @@ public enum MethodEncoderLookup implements Function<Method, MethodEncoder> {
                 }
             }
 
+            @SuppressWarnings("rawtypes")
             @Override
             public Object[] decode(Object[] lastObjects, BytesIn in) {
                 for (Object lastObject : lastObjects)

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
@@ -34,6 +34,7 @@ import static net.openhft.chronicle.bytes.NoBytesStore.noBytesStore;
  * <p>
  * <p>This class can wrap <i>heap</i> ByteBuffers, called <i>Native</i>Bytes for historical reasons.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class NativeBytes<Underlying> extends VanillaBytes<Underlying> {
 
     private final long capacity;

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytesStore.java
@@ -35,7 +35,7 @@ import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
-@SuppressWarnings("sunapi")
+@SuppressWarnings({"restriction", "rawtypes", "unchecked"})
 public class NativeBytesStore<Underlying>
         extends AbstractBytesStore<NativeBytesStore<Underlying>, Underlying> {
     private static final long MEMORY_MAPPED_SIZE = 128 << 10;

--- a/src/main/java/net/openhft/chronicle/bytes/NoBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NoBytesStore.java
@@ -23,6 +23,7 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public enum NoBytesStore implements BytesStore {
     NO_BYTES_STORE;
 

--- a/src/main/java/net/openhft/chronicle/bytes/OffsetFormat.java
+++ b/src/main/java/net/openhft/chronicle/bytes/OffsetFormat.java
@@ -2,5 +2,6 @@ package net.openhft.chronicle.bytes;
 
 @FunctionalInterface
 public interface OffsetFormat {
+    @SuppressWarnings("rawtypes")
     void append(long offset, Bytes bytes);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/RandomCommon.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomCommon.java
@@ -125,12 +125,14 @@ interface RandomCommon extends ReferenceCounted {
     /**
      * @return the streaming bytes for reading.
      */
+    @SuppressWarnings("rawtypes")
     @NotNull
     Bytes bytesForRead() throws IllegalStateException;
 
     /**
      * @return the streaming bytes for writing.
      */
+    @SuppressWarnings("rawtypes")
     @NotNull
     Bytes bytesForWrite() throws IllegalStateException;
 

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
@@ -376,6 +376,7 @@ public interface RandomDataInput extends RandomCommon {
      * @param length of bytes
      * @return ByteStore copy.
      */
+    @SuppressWarnings("rawtypes")
     @NotNull
     default BytesStore subBytes(long start, long length) throws BufferUnderflowException {
         return BytesInternal.subBytes(this, start, length);

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataOutput.java
@@ -24,6 +24,7 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomCommon {
     /**
      * Write a byte at an offset.

--- a/src/main/java/net/openhft/chronicle/bytes/ReadBytesMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ReadBytesMarshallable.java
@@ -28,5 +28,6 @@ public interface ReadBytesMarshallable {
      *
      * @param bytes to read.
      */
+    @SuppressWarnings("rawtypes")
     void readMarshallable(BytesIn bytes) throws IORuntimeException;
 }

--- a/src/main/java/net/openhft/chronicle/bytes/RingBufferReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RingBufferReader.java
@@ -15,6 +15,7 @@ public interface RingBufferReader extends RingBufferReaderStats {
      * @param bytes who's byteStore must be the ring buffer,
      * @return nextReadPosition which should be passed to {@link RingBufferReader#afterRead(long)}
      */
+    @SuppressWarnings("rawtypes")
     long beforeRead(Bytes bytes);
 
     void afterRead(long next);
@@ -22,5 +23,6 @@ public interface RingBufferReader extends RingBufferReaderStats {
     /**
      * @return the byteStore which backs the ring buffer
      */
+    @SuppressWarnings("rawtypes")
     BytesStore byteStore();
 }

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataInput.java
@@ -34,6 +34,7 @@ import java.nio.ByteBuffer;
 /**
  * This data input has a a position() and a limit()
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface StreamingDataInput<S extends StreamingDataInput<S>> extends StreamingCommon<S> {
     @NotNull
     S readPosition(long position) throws BufferUnderflowException;

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
@@ -35,6 +35,7 @@ import java.nio.ByteBuffer;
  * Position based access.  Once data has been read, the position() moves.
  * <p>The use of this instance is single threaded, though the use of the data
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends StreamingCommon<S> {
     int JAVA9_STRING_CODER_LATIN = 0;
     int JAVA9_STRING_CODER_UTF16 = 1;

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingInputStream.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingInputStream.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 /*
  * Created by Peter Lawrey on 17/08/15.
  */
+@SuppressWarnings("rawtypes")
 public class StreamingInputStream extends InputStream {
 
     private StreamingDataInput in;

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingOutputStream.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingOutputStream.java
@@ -25,6 +25,7 @@ import java.nio.BufferOverflowException;
 /*
  * Created by Peter Lawrey on 17/08/15.
  */
+@SuppressWarnings("rawtypes")
 public class StreamingOutputStream extends OutputStream {
     private StreamingDataOutput sdo;
 

--- a/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
@@ -18,6 +18,7 @@ package net.openhft.chronicle.bytes;
 
 import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class SubBytes<Underlying> extends VanillaBytes<Underlying> {
     private final long start;
     private final long capacity;

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
@@ -30,6 +30,7 @@ import static net.openhft.chronicle.core.util.StringUtils.extractChars;
 /**
  * Fast unchecked version of AbstractBytes
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class UncheckedBytes<Underlying> extends AbstractBytes<Underlying> {
     Bytes underlyingBytes;
 

--- a/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
@@ -35,6 +35,7 @@ import static net.openhft.chronicle.bytes.NoBytesStore.noBytesStore;
 /**
  * Simple Bytes implementation which is not Elastic.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class VanillaBytes<Underlying> extends AbstractBytes<Underlying>
         implements Byteable<Bytes<Underlying>, Underlying>, Comparable<CharSequence> {
 

--- a/src/main/java/net/openhft/chronicle/bytes/WriteBytesMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/WriteBytesMarshallable.java
@@ -19,6 +19,7 @@ package net.openhft.chronicle.bytes;
 /**
  * Write data directly as Bytes.
  */
+@SuppressWarnings("rawtypes")
 @FunctionalInterface
 public interface WriteBytesMarshallable {
     /**

--- a/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
@@ -25,6 +25,7 @@ import java.util.function.ToLongFunction;
 /**
  * Simple function to derive a long hash from a BytesStore
  */
+@SuppressWarnings("rawtypes")
 public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> {
     static long hash(@NotNull BytesStore b) {
         return b.isDirectMemory() && b.bytesStore() instanceof NativeBytesStore

--- a/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
@@ -31,6 +31,7 @@ import static net.openhft.chronicle.bytes.algo.VanillaBytesStoreHash.*;
 /*
  * Created by Peter Lawrey on 28/06/15.
  */
+@SuppressWarnings("rawtypes")
 public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
     INSTANCE;
 

--- a/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
@@ -25,6 +25,7 @@ import java.nio.ByteOrder;
 /*
  * Created by Peter Lawrey on 28/06/15.
  */
+@SuppressWarnings("rawtypes")
 public enum VanillaBytesStoreHash implements BytesStoreHash<BytesStore> {
     INSTANCE;
 

--- a/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
@@ -3,6 +3,7 @@ package net.openhft.chronicle.bytes.algo;
 import net.openhft.chronicle.bytes.BytesStore;
 
 // Migration of XxHash from Zero-Allocation-Hashing
+@SuppressWarnings("rawtypes")
 public class XxHash implements BytesStoreHash<BytesStore> {
     // Primes if treated as unsigned
     private static final long P1 = -7046029288634856825L;

--- a/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
+++ b/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 /*
  * Created by Peter Lawrey on 20/12/16.
  */
+@SuppressWarnings("rawtypes")
 public class BytesPool {
     final ThreadLocal<Bytes> bytesTL = new ThreadLocal<>();
 

--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -12,6 +12,7 @@ import java.nio.BufferUnderflowException;
 /**
  * Created by Jerry Shea on 26/02/18.
  */
+@SuppressWarnings("rawtypes")
 public abstract class AbstractReference implements Byteable, Closeable {
 
     @Nullable

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
@@ -15,6 +15,7 @@ public class BinaryBooleanReference extends AbstractReference implements Boolean
     private static final byte FALSE = (byte) 0xB0;
     private static final byte TRUE = (byte) 0xB1;
 
+    @SuppressWarnings("rawtypes")
     @Override
     public void bytesStore(@NotNull final BytesStore bytes, final long offset, final long length) throws IllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException {
         if (length != maxSize())

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -27,6 +27,7 @@ import java.nio.BufferUnderflowException;
  */
 public class BinaryIntReference extends AbstractReference implements IntValue {
 
+    @SuppressWarnings("rawtypes")
     @Override
     public void bytesStore(@NotNull final BytesStore bytes, final long offset, final long length) throws IllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException {
         if (length != maxSize())

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
@@ -33,6 +33,7 @@ import static net.openhft.chronicle.bytes.ref.BinaryLongReference.LONG_NOT_COMPL
 /**
  * This class acts a Binary array of 64-bit values. c.f. TextLongArrayReference
  */
+@SuppressWarnings("rawtypes")
 public class BinaryLongArrayReference extends AbstractReference implements ByteableLongArrayValues, BytesMarshallable {
     private static final long CAPACITY = 0;
     private static final long USED = CAPACITY + Long.BYTES;

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -50,6 +50,7 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
         binaryLongReferences = null;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public void bytesStore(@NotNull final BytesStore bytes, final long offset, final long length) throws IllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException {
         if (length != maxSize())

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
@@ -20,6 +20,7 @@ import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.DynamicallySized;
 import net.openhft.chronicle.core.values.LongArrayValues;
 
+@SuppressWarnings("rawtypes")
 public interface ByteableLongArrayValues extends LongArrayValues, Byteable, DynamicallySized {
     @Override
     long sizeInBytes(long sizeInBytes);

--- a/src/main/java/net/openhft/chronicle/bytes/ref/LongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/LongReference.java
@@ -22,5 +22,6 @@ import net.openhft.chronicle.core.values.LongValue;
 /*
  * Created by Peter Lawrey on 20/01/16.
  */
+@SuppressWarnings("rawtypes")
 public interface LongReference extends LongValue, Byteable {
 }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
@@ -27,6 +27,7 @@ public class TextBooleanReference extends AbstractReference implements BooleanVa
     private static final int FALSE = 'f' | ('a' << 8) | ('l' << 16) | ('s' << 24);
     private static final int TRUE = ' ' | ('t' << 8) | ('r' << 16) | ('u' << 24);
 
+    @SuppressWarnings("rawtypes")
     public static void write(final boolean value, final BytesStore bytes, long offset) {
         bytes.writeVolatileInt(offset, value ? TRUE : FALSE);
         bytes.writeByte(offset + 4, (byte) 'e');

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
@@ -41,6 +41,7 @@ public class TextIntReference extends AbstractReference implements IntValue {
     private static final int VALUE = 34;
     private static final int DIGITS = 10;
 
+    @SuppressWarnings("rawtypes")
     public static void write(@NotNull Bytes bytes, int value) throws BufferOverflowException {
         long position = bytes.writePosition();
         bytes.write(template);
@@ -118,6 +119,7 @@ public class TextIntReference extends AbstractReference implements IntValue {
         }) == INT_TRUE;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public void bytesStore(@NotNull final BytesStore bytes, long offset, long length) {
         if (length != template.length)

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -27,7 +27,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 The format for a long array in text is
 { capacity: 12345678901234567890, values: [ 12345678901234567890, ... ] }
  */
-
+@SuppressWarnings("rawtypes")
 public class TextLongArrayReference extends AbstractReference implements ByteableLongArrayValues {
     private static final byte[] SECTION1 = "{ locked: false, capacity: ".getBytes(ISO_8859_1);
     private static final byte[] SECTION2 = ", used: ".getBytes(ISO_8859_1);

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
@@ -41,6 +41,7 @@ public class TextLongReference extends AbstractReference implements LongReferenc
     private static final int LOCKED = 20;
     private static final int DIGITS = 20;
 
+    @SuppressWarnings("rawtypes")
     public static void write(@NotNull Bytes bytes, long value) throws BufferOverflowException, IllegalArgumentException {
         long position = bytes.writePosition();
         bytes.write(template);
@@ -65,6 +66,7 @@ public class TextLongReference extends AbstractReference implements LongReferenc
         }
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public void bytesStore(@NotNull final BytesStore bytes, long offset, long length) {
         if (length != template.length)

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
@@ -22,5 +22,6 @@ import net.openhft.chronicle.core.values.TwoLongValue;
 /*
  * Created by Peter Lawrey on 20/01/16.
  */
+@SuppressWarnings("rawtypes")
 public interface TwoLongReference extends TwoLongValue, Byteable {
 }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
@@ -21,6 +21,7 @@ import net.openhft.chronicle.core.UnsafeMemory;
 import org.jetbrains.annotations.NotNull;
 import sun.misc.Unsafe;
 
+@SuppressWarnings({"rawtypes", "unchecked", "restriction"})
 public class UncheckedLongReference implements LongReference {
     private long address;
     private Unsafe unsafe;

--- a/src/main/java/net/openhft/chronicle/bytes/util/AbstractInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/AbstractInterner.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 /**
  * @author peter.lawrey
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class AbstractInterner<T> {
     @NotNull
     protected final InternerEntry<T>[] entries;

--- a/src/main/java/net/openhft/chronicle/bytes/util/Bit8StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Bit8StringInterner.java
@@ -31,6 +31,7 @@ public class Bit8StringInterner extends AbstractInterner<String> {
         super(capacity);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     @NotNull
     protected String getValue(@NotNull BytesStore cs, int length) {

--- a/src/main/java/net/openhft/chronicle/bytes/util/Compression.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Compression.java
@@ -30,6 +30,7 @@ import java.io.*;
 /*
  * Created by peter.lawrey on 09/12/2015.
  */
+@SuppressWarnings("rawtypes")
 public interface Compression {
 
     static <T> void compress(@NotNull CharSequence cs, @NotNull Bytes uncompressed, @NotNull Bytes compressed) {

--- a/src/main/java/net/openhft/chronicle/bytes/util/Compressions.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Compressions.java
@@ -30,6 +30,7 @@ import java.util.zip.*;
 /*
  * Created by peter.lawrey on 09/12/2015.
  */
+@SuppressWarnings("rawtypes")
 public enum Compressions implements Compression {
     Binary {
         @NotNull

--- a/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
@@ -35,6 +35,7 @@ public class StringInternerBytes extends StringInterner {
         super(capacity);
     }
 
+    @SuppressWarnings("rawtypes")
     public String intern(@NotNull final Bytes bytes) {
         return intern(bytes, Maths.toUInt31(bytes.readRemaining()));
     }
@@ -49,6 +50,7 @@ public class StringInternerBytes extends StringInterner {
      * @param length parse the string up to the length
      * @return the string made from bytes only ( rather than chars )
      */
+    @SuppressWarnings("rawtypes")
     public String intern(@NotNull final Bytes bytes, int length) {
         try {
             int hash32 = BytesStoreHash.hash32(bytes, length);

--- a/src/main/java/net/openhft/chronicle/bytes/util/UTF8StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/UTF8StringInterner.java
@@ -33,6 +33,7 @@ public class UTF8StringInterner extends AbstractInterner<String> {
         super(capacity);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     @NotNull
     protected String getValue(@NotNull BytesStore cs, int length) throws UTFDataFormatRuntimeException {

--- a/src/test/java/net/openhft/chronicle/bytes/AllocationRatesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/AllocationRatesTest.java
@@ -83,6 +83,7 @@ public class AllocationRatesTest {
         return System.nanoTime() - start;
     }
 
+    @SuppressWarnings("rawtypes")
     private long timeDirectStoreAllocations() {
         long start = System.nanoTime();
         for (int i = 0; i < ALLOCATIONS; i += BATCH) {

--- a/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
@@ -16,6 +16,7 @@ public class AppendableUtilTest {
         BytesUtil.checkRegisteredBytes();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void setLength() {
         StringBuilder sb = new StringBuilder("hello world");
@@ -36,6 +37,7 @@ public class AppendableUtilTest {
         b.release();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void setCharAt() {
         StringBuilder sb = new StringBuilder("hello world");

--- a/src/test/java/net/openhft/chronicle/bytes/ByteCheckSumTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteCheckSumTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("rawtypes")
 public class ByteCheckSumTest {
     @Test
     public void test() {

--- a/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
@@ -42,6 +42,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class ByteStoreTest {
 
     private static final int SIZE = 128;

--- a/src/test/java/net/openhft/chronicle/bytes/ByteStringAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStringAppenderTest.java
@@ -38,6 +38,7 @@ public class ByteStringAppenderTest {
 
     @NotNull
     private ThreadDump threadDump;
+    @SuppressWarnings("rawtypes")
     private Bytes bytes;
 
     public ByteStringAppenderTest(String name, boolean direct) {

--- a/src/test/java/net/openhft/chronicle/bytes/ByteStringParserTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStringParserTest.java
@@ -33,6 +33,7 @@ import static net.openhft.chronicle.bytes.StopCharTesters.SPACE_STOP;
 import static org.junit.Assert.assertEquals;
 
 public class ByteStringParserTest {
+    @SuppressWarnings("rawtypes")
     @NotNull
     Bytes bytes = Bytes.elasticByteBuffer();
     private ThreadDump threadDump;
@@ -53,6 +54,7 @@ public class ByteStringParserTest {
         threadDump.assertNoNewThreads();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testParseLong() {
         long expected = 123456789012345678L;

--- a/src/test/java/net/openhft/chronicle/bytes/Bytes2Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Bytes2Test.java
@@ -32,6 +32,7 @@ import static net.openhft.chronicle.bytes.Allocator.NATIVE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("rawtypes")
 @RunWith(Parameterized.class)
 public class Bytes2Test {
 

--- a/src/test/java/net/openhft/chronicle/bytes/BytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesMarshallableTest.java
@@ -87,6 +87,7 @@ public class BytesMarshallableTest {
         bytes.release();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void serializeScalars() throws IORuntimeException {
         Bytes<?> bytes = new HexDumpBytes();
@@ -233,6 +234,7 @@ public class BytesMarshallableTest {
         bytes.release();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void serializeBytes() throws IOException {
         Bytes<?> bytes = new HexDumpBytes();

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTextMethodTesterTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTextMethodTesterTest.java
@@ -12,6 +12,7 @@ public class BytesTextMethodTesterTest {
         btmttTest("btmtt/prim-input.txt", "btmtt/prim-output.txt");
     }
 
+    @SuppressWarnings("rawtypes")
     protected void btmttTest(String input, String output) throws IOException {
         BytesTextMethodTester tester = new BytesTextMethodTester<>(
                 input,

--- a/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 /*
  * Created by Peter Lawrey on 17/05/2017.
  */
+@SuppressWarnings("rawtypes")
 public class BytesUtilTest {
     @Test
     public void fromFileInJar() throws IOException {

--- a/src/test/java/net/openhft/chronicle/bytes/HeapByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/HeapByteStoreTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotEquals;
  * Created by Peter Lawrey on 20/12/16.
  */
 public class HeapByteStoreTest {
+    @SuppressWarnings("rawtypes")
     @Test
     public void testEquals() {
         @NotNull HeapBytesStore hbs = HeapBytesStore.wrap("Hello".getBytes());

--- a/src/test/java/net/openhft/chronicle/bytes/Issue85Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Issue85Test.java
@@ -25,6 +25,7 @@ public class Issue85Test {
                 DecimalFormatSymbols.getInstance(Locale.ENGLISH));
     }
 
+    @SuppressWarnings("rawtypes")
     static double parseDouble(Bytes bytes) {
         long value = 0;
         int deci = Integer.MIN_VALUE;

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
@@ -78,6 +78,7 @@ public class MappedFileTest {
         assertThat(third.refCount(), is(1L));
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testReferenceCounts() throws IOException {
         new File(OS.TARGET).mkdir();

--- a/src/test/java/net/openhft/chronicle/bytes/MappedMemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedMemoryTest.java
@@ -32,6 +32,7 @@ import static net.openhft.chronicle.bytes.MappedBytes.mappedBytes;
 import static net.openhft.chronicle.bytes.MappedFile.mappedFile;
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("rawtypes")
 public class MappedMemoryTest {
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(MappedMemoryTest.class);
     private static final long SHIFT = 27L;

--- a/src/test/java/net/openhft/chronicle/bytes/MyBytes.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MyBytes.java
@@ -3,6 +3,7 @@ package net.openhft.chronicle.bytes;
 import java.io.Closeable;
 import java.io.IOException;
 
+@SuppressWarnings("rawtypes")
 class MyBytes implements BytesMarshallable, Closeable {
     Bytes bytes1;
     Bytes bytes2;

--- a/src/test/java/net/openhft/chronicle/bytes/NativeByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NativeByteStoreTest.java
@@ -33,6 +33,7 @@ public class NativeByteStoreTest {
         BytesUtil.checkRegisteredBytes();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testEquals() {
         @NotNull NativeBytesStore hbs = NativeBytesStore.from("Hello".getBytes());

--- a/src/test/java/net/openhft/chronicle/bytes/NativeBytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NativeBytesStoreTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.*;
 /*
  * Created by peter.lawrey on 27/02/15.
  */
+@SuppressWarnings("rawtypes")
 public class NativeBytesStoreTest {
     volatile int bcs;
     private ThreadDump threadDump;

--- a/src/test/java/net/openhft/chronicle/bytes/NativeBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NativeBytesTest.java
@@ -73,6 +73,7 @@ public class NativeBytesTest {
         threadDump.assertNoNewThreads();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testWriteBytesWhereResizeNeeded0() throws IORuntimeException, BufferUnderflowException, BufferOverflowException {
         Bytes b = alloc.elasticBytes(1);
@@ -87,6 +88,7 @@ public class NativeBytesTest {
         b.release();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testWriteBytesWhereResizeNeeded() throws IllegalArgumentException, IORuntimeException, BufferUnderflowException, BufferOverflowException {
         Bytes b = alloc.elasticBytes(1);
@@ -101,6 +103,7 @@ public class NativeBytesTest {
         b.release();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testAppendCharArrayNonAscii() {
         Bytes b = alloc.elasticBytes(1);

--- a/src/test/java/net/openhft/chronicle/bytes/PrewriteTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/PrewriteTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
  * Created by Peter Lawrey on 20/12/16.
  */
 public class PrewriteTest {
+    @SuppressWarnings("rawtypes")
     @Test
     public void test() {
         Bytes bytes = Bytes.allocateDirect(64);

--- a/src/test/java/net/openhft/chronicle/bytes/ReadLenientTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ReadLenientTest.java
@@ -16,6 +16,7 @@ public class ReadLenientTest {
         doTest(Bytes.from(""));
     }
 
+    @SuppressWarnings("rawtypes")
     private void doTest(Bytes bytes) {
         bytes.lenient(true);
         ByteBuffer bb = ByteBuffer.allocateDirect(32);

--- a/src/test/java/net/openhft/chronicle/bytes/ReadWriteMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ReadWriteMarshallableTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("rawtypes")
 public class ReadWriteMarshallableTest {
     @Test
     public void test() {

--- a/src/test/java/net/openhft/chronicle/bytes/StreamingInputStreamTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StreamingInputStreamTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("rawtypes")
 public class StreamingInputStreamTest {
     private ThreadDump threadDump;
 

--- a/src/test/java/net/openhft/chronicle/bytes/VanillaBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/VanillaBytesTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 /*
  * Created by Peter Lawrey on 17/06/2016.
  */
+@SuppressWarnings("rawtypes")
 public class VanillaBytesTest {
     @Test
     public void testBytesForRead() {

--- a/src/test/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHashTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHashTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 /*
  * Created by Peter Lawrey on 28/06/15.
  */
+@SuppressWarnings("rawtypes")
 public class OptimisedBytesStoreHashTest {
 
     private ThreadDump threadDump;

--- a/src/test/java/net/openhft/chronicle/bytes/jitter/MemoryMessager.java
+++ b/src/test/java/net/openhft/chronicle/bytes/jitter/MemoryMessager.java
@@ -51,6 +51,7 @@ public class MemoryMessager {
         if (!works2) throw new AssertionError();
     }
 
+    @SuppressWarnings("restriction")
     public int length() {
         int length = UnsafeMemory.UNSAFE.getIntVolatile(null, address);
         Jvm.safepoint();

--- a/src/test/java/net/openhft/chronicle/bytes/ref/ByteableReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/ByteableReferenceTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 @RunWith(Parameterized.class)
 public class ByteableReferenceTest {
     private final Byteable byteable;

--- a/src/test/java/net/openhft/chronicle/bytes/util/StringInternerBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/StringInternerBytesTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class StringInternerBytesTest {
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testIntern() {
         @NotNull StringInternerBytes si = new StringInternerBytes(128);


### PR DESCRIPTION
Suppress 'rawtypes', 'checked', and 'restriction' compiler warnings.