### PR TITLE
Polish: remove managed version duplicates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
             </plugin>
 
             <plugin>
@@ -132,7 +131,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.2</version>
                 <configuration>
                     <compilerArgument>-Xlint:deprecation</compilerArgument>
                     <source>1.8</source>
@@ -163,7 +161,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.3.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
Remove version duplicates of managed dependencies. The `maven-bundle-plugin` is also a downgrade from `3.3.0` to the managed `3.0.0` version; all tests pass.