### PR TITLE
Feature/mapped file multi thread resize

### DIFF
--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
@@ -28,7 +28,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,6 +43,7 @@ import static org.junit.Assert.assertNotNull;
 public class MappedFileMultiThreadTest extends BytesTestCommon {
     private static final int CORES = Integer.getInteger("cores", Runtime.getRuntime().availableProcessors());
     private static final int RUNTIME_MS = Integer.getInteger("runtimems", 2_000);
+    private static final String TMP_FILE = System.getProperty("file", IOTools.createTempFile("testMultiThreadLock").getAbsolutePath());
 
     private ThreadDump threadDump;
 
@@ -65,9 +65,8 @@ public class MappedFileMultiThreadTest extends BytesTestCommon {
     @Test
     public void testMultiThreadLock() throws Exception {
         final List<String> garbage = Collections.synchronizedList(new ArrayList<>());
-        final File tmp = IOTools.createTempFile("testMultiThreadLock");
         final long chunkSize = OS.isWindows() ? 64 << 10 : 4 << 10;
-        try (MappedFile mf = MappedFile.mappedFile(tmp, chunkSize, 0)) {
+        try (MappedFile mf = MappedFile.mappedFile(TMP_FILE, chunkSize, 0)) {
             assertEquals("refCount: 1", mf.referenceCounts());
 
             final List<Future<?>> futures = new ArrayList<>();
@@ -106,6 +105,6 @@ public class MappedFileMultiThreadTest extends BytesTestCommon {
             for (Future<?> f : futures)
                 f.get(1, TimeUnit.SECONDS);
         }
-        IOTools.deleteDirWithFiles(tmp);
+        IOTools.deleteDirWithFiles(TMP_FILE);
     }
 }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016-2020 chronicle.software
+ *
+ * https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.chronicle.bytes;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.AbstractReferenceCounted;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.core.io.ReferenceOwner;
+import net.openhft.chronicle.core.threads.ThreadDump;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class MappedFileMultiThreadTest extends BytesTestCommon {
+    private static final int CORES = Integer.getInteger("cores", Runtime.getRuntime().availableProcessors());
+    private static final int RUNTIME_MS = Integer.getInteger("runtimems", 60_000);
+
+    private ThreadDump threadDump;
+
+    @After
+    public void checkRegisteredBytes() {
+        AbstractReferenceCounted.assertReferencesReleased();
+    }
+
+    @Before
+    public void threadDump() {
+        threadDump = new ThreadDump();
+    }
+
+    @After
+    public void checkThreadDump() {
+        threadDump.assertNoNewThreads();
+    }
+
+    @Test
+    public void testMultiThreadLock() throws Exception {
+        final List<String> garbage = Collections.synchronizedList(new ArrayList<>());
+        final File tmp = IOTools.createTempFile("testMultiThreadLock");
+        final long chunkSize = OS.isWindows() ? 64 << 10 : 4 << 10;
+        try (MappedFile mf = MappedFile.mappedFile(tmp, chunkSize, 0)) {
+            assertEquals("refCount: 1", mf.referenceCounts());
+
+            final List<Future<?>> futures = new ArrayList<>();
+            final ExecutorService es = Executors.newFixedThreadPool(CORES);
+            for (int i = 0; i < CORES; i++) {
+                int finalI = i;
+                futures.add(es.submit(() -> {
+                    long offset = 1;
+                    final ReferenceOwner test = ReferenceOwner.temporary("test" + finalI);
+                    while (!Thread.currentThread().isInterrupted()) {
+                        garbage.add(test.referenceName() + offset);
+                        MappedBytesStore bs = null;
+                        Bytes<?> bytes = null;
+                        try {
+                            bs = mf.acquireByteStore(test, chunkSize * offset);
+                            bytes = bs.bytesForRead();
+                            assertNotNull(bytes.toString()); // show it doesn't blow up.
+                            assertNotNull(bs.toString()); // show it doesn't blow up.
+                            ++offset;
+                        } catch (IOException e) {
+                            throw Jvm.rethrow(e);
+                        } finally {
+                            if (bytes != null) bytes.releaseLast();
+                            if (bs != null) bs.release(test);
+                        }
+                        if (finalI == 0 && offset % 1_000 == 0) {
+                            garbage.clear();
+                            System.gc();
+                        }
+                    }
+                }));
+            }
+
+            Jvm.pause(RUNTIME_MS);
+            es.shutdownNow();
+            for (Future<?> f : futures)
+                f.get(1, TimeUnit.SECONDS);
+        }
+        IOTools.deleteDirWithFiles(tmp);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
@@ -106,6 +106,8 @@ public class MappedFileMultiThreadTest extends BytesTestCommon {
             running.set(false);
             for (Future<?> f : futures)
                 f.get(5, TimeUnit.SECONDS);
+            es.shutdownNow();
+            es.awaitTermination(1, TimeUnit.SECONDS);
         }
         IOTools.deleteDirWithFiles(TMP_FILE);
     }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class MappedFileMultiThreadTest extends BytesTestCommon {
     private static final int CORES = Integer.getInteger("cores", Runtime.getRuntime().availableProcessors());
-    private static final int RUNTIME_MS = Integer.getInteger("runtimems", 60_000);
+    private static final int RUNTIME_MS = Integer.getInteger("runtimems", 2_000);
 
     private ThreadDump threadDump;
 


### PR DESCRIPTION
Client reported issue https://github.com/ChronicleEnterprise/Chronicle-Queue-Enterprise/issues/156

I don't think we need the complexity of WeakReferences when dealing with synchronizing over FileLocks, as we can use the interned canonical path instead, and this makes the code easier to reason about.

And makes it classloader-safe - if MappedFile were loaded in >1 classloaders then the static FILE_LOCKS can not be relied upon. String#intern is JVM-wide.
