### PR TITLE
Removed SonarQube warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,8 @@
                         <configuration>
                             <referenceVersion>2.22ea3</referenceVersion>
                             <artifactsURI>https://teamcity.chronicle.software/repository/download</artifactsURI>
-                            <binaryCompatibilityPercentageRequired>83.6</binaryCompatibilityPercentageRequired>
+                            <!--Abstract classes got protected constructors-->
+                            <binaryCompatibilityPercentageRequired>99.9</binaryCompatibilityPercentageRequired>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                         <configuration>
                             <referenceVersion>2.22ea3</referenceVersion>
                             <artifactsURI>https://teamcity.chronicle.software/repository/download</artifactsURI>
-                            <!--                            <binaryCompatibilityPercentageRequired>92</binaryCompatibilityPercentageRequired>-->
+                            <binaryCompatibilityPercentageRequired>83.6</binaryCompatibilityPercentageRequired>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -38,18 +38,18 @@ import java.nio.ByteBuffer;
 /**
  * Abstract representation of Bytes.
  *
- * @param <U> Underlying type
+ * @param <Underlying> Underlying type
  */
 @SuppressWarnings("rawtypes")
-public abstract class AbstractBytes<U>
+public abstract class AbstractBytes<Underlying>
         extends AbstractReferenceCounted
-        implements Bytes<U> {
+        implements Bytes<Underlying> {
     private static final boolean BYTES_BOUNDS_UNCHECKED = Jvm.getBoolean("bytes.bounds.unchecked", false);
     // used for debugging
     @UsedViaReflection
     private final String name;
     @NotNull
-    protected BytesStore<Bytes<U>, U> bytesStore;
+    protected BytesStore<Bytes<Underlying>, Underlying> bytesStore;
     protected long readPosition;
     protected long writePosition;
     protected long writeLimit;
@@ -58,12 +58,12 @@ public abstract class AbstractBytes<U>
     private boolean lenient = false;
     private boolean lastNumberHadDigits = false;
 
-    AbstractBytes(@NotNull BytesStore<Bytes<U>, U> bytesStore, long writePosition, long writeLimit)
+    AbstractBytes(@NotNull BytesStore<Bytes<Underlying>, Underlying> bytesStore, long writePosition, long writeLimit)
             throws IllegalStateException {
         this(bytesStore, writePosition, writeLimit, "");
     }
 
-    AbstractBytes(@NotNull BytesStore<Bytes<U>, U> bytesStore, long writePosition, long writeLimit, String name)
+    AbstractBytes(@NotNull BytesStore<Bytes<Underlying>, Underlying> bytesStore, long writePosition, long writeLimit, String name)
             throws IllegalStateException {
         super(bytesStore.isDirectMemory());
         this.bytesStore(bytesStore);
@@ -95,7 +95,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> compact()
+    public Bytes<Underlying> compact()
             throws IllegalStateException {
         long start = start();
         long readRemaining = readRemaining();
@@ -113,7 +113,7 @@ public abstract class AbstractBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> clear()
+    public Bytes<Underlying> clear()
             throws IllegalStateException {
         long start = start();
         readPosition = start;
@@ -124,7 +124,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> clearAndPad(long length)
+    public Bytes<Underlying> clearAndPad(long length)
             throws BufferOverflowException {
         if ((start() + length) > capacity()) {
             throw newBOERange(start(), length, "clearAndPad failed. Start: %d + length: %d > capacity: %d", capacity());
@@ -165,7 +165,7 @@ public abstract class AbstractBytes<U>
 
     @Nullable
     @Override
-    public U underlyingObject() {
+    public Underlying underlyingObject() {
         return bytesStore.underlyingObject();
     }
 
@@ -229,7 +229,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> readPosition(long position)
+    public Bytes<Underlying> readPosition(long position)
             throws BufferUnderflowException, IllegalStateException {
         if (position < start()) {
             throw new DecoratedBufferUnderflowException(String.format("readPosition failed. Position: %d < start: %d", position, start()));
@@ -244,7 +244,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> readLimit(long limit)
+    public Bytes<Underlying> readLimit(long limit)
             throws BufferUnderflowException {
         if (limit < start())
             throw limitLessThanStart(limit);
@@ -266,7 +266,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writePosition(long position)
+    public Bytes<Underlying> writePosition(long position)
             throws BufferOverflowException {
         if (position > writeLimit())
             throw writePositionTooLarge(position);
@@ -293,7 +293,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> readSkip(long bytesToSkip)
+    public Bytes<Underlying> readSkip(long bytesToSkip)
             throws BufferUnderflowException, IllegalStateException {
         if (lenient) {
             bytesToSkip = Math.min(bytesToSkip, readRemaining());
@@ -314,7 +314,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeSkip(long bytesToSkip)
+    public Bytes<Underlying> writeSkip(long bytesToSkip)
             throws BufferOverflowException, IllegalStateException {
         final long writePos = writePosition();
         writeCheckOffset(writePos, bytesToSkip);
@@ -324,7 +324,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLimit(long limit)
+    public Bytes<Underlying> writeLimit(long limit)
             throws BufferOverflowException {
         if (limit < start()) {
             throw writeLimitTooSmall(limit);
@@ -544,7 +544,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(long offset, byte i)
+    public Bytes<Underlying> writeByte(long offset, byte i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeByte(offset, i);
@@ -553,7 +553,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeShort(long offset, short i)
+    public Bytes<Underlying> writeShort(long offset, short i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeShort(offset, i);
@@ -562,7 +562,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeInt(long offset, int i)
+    public Bytes<Underlying> writeInt(long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeInt(offset, i);
@@ -571,7 +571,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedInt(long offset, int i)
+    public Bytes<Underlying> writeOrderedInt(long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeOrderedInt(offset, i);
@@ -580,7 +580,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLong(long offset, long i)
+    public Bytes<Underlying> writeLong(long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeLong(offset, i);
@@ -589,7 +589,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedLong(long offset, long i)
+    public Bytes<Underlying> writeOrderedLong(long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeOrderedLong(offset, i);
@@ -598,7 +598,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeFloat(long offset, float d)
+    public Bytes<Underlying> writeFloat(long offset, float d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeFloat(offset, d);
@@ -607,7 +607,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeDouble(long offset, double d)
+    public Bytes<Underlying> writeDouble(long offset, double d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeDouble(offset, d);
@@ -616,7 +616,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileByte(long offset, byte i8)
+    public Bytes<Underlying> writeVolatileByte(long offset, byte i8)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeVolatileByte(offset, i8);
@@ -625,7 +625,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileShort(long offset, short i16)
+    public Bytes<Underlying> writeVolatileShort(long offset, short i16)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeVolatileShort(offset, i16);
@@ -634,7 +634,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileInt(long offset, int i32)
+    public Bytes<Underlying> writeVolatileInt(long offset, int i32)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeVolatileInt(offset, i32);
@@ -643,7 +643,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileLong(long offset, long i64)
+    public Bytes<Underlying> writeVolatileLong(long offset, long i64)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeVolatileLong(offset, i64);
@@ -652,7 +652,7 @@ public abstract class AbstractBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> write(@NotNull RandomDataInput bytes)
+    public Bytes<Underlying> write(@NotNull RandomDataInput bytes)
             throws IllegalStateException, BufferOverflowException {
         assert bytes != this : "you should not write to yourself !";
 
@@ -665,7 +665,7 @@ public abstract class AbstractBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> write(long offsetInRDO, byte[] bytes, int offset, int length)
+    public Bytes<Underlying> write(long offsetInRDO, byte[] bytes, int offset, int length)
             throws BufferOverflowException, IllegalStateException {
         long remaining = length;
         while (remaining > 0) {
@@ -688,7 +688,7 @@ public abstract class AbstractBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> write(long writeOffset, RandomDataInput bytes, long readOffset, long length)
+    public Bytes<Underlying> write(long writeOffset, RandomDataInput bytes, long readOffset, long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
 
         long remaining = length;
@@ -704,7 +704,7 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public @NotNull Bytes<U> write8bit(@NotNull String s, int start, int length) throws BufferOverflowException, IndexOutOfBoundsException, ArithmeticException, IllegalStateException, BufferUnderflowException {
+    public @NotNull Bytes<Underlying> write8bit(@NotNull String s, int start, int length) throws BufferOverflowException, IndexOutOfBoundsException, ArithmeticException, IllegalStateException, BufferUnderflowException {
         final long toWriteLength = UnsafeMemory.INSTANCE.stopBitLength(length) + (long) length;
         final long position = writeOffsetPositionMoved(toWriteLength, 0);
         bytesStore.write8bit(position, s, start, length);
@@ -712,7 +712,7 @@ public abstract class AbstractBytes<U>
         return this;
     }
 
-    public @NotNull Bytes<U> write8bit(@Nullable BytesStore bs) throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
+    public @NotNull Bytes<Underlying> write8bit(@Nullable BytesStore bs) throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
         if (bs == null) {
             BytesInternal.writeStopBitNeg1(this);
             return this;
@@ -862,7 +862,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(byte i8)
+    public Bytes<Underlying> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(1, 1);
         bytesStore.writeByte(offset, i8);
@@ -871,7 +871,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewrite(@NotNull byte[] bytes)
+    public Bytes<Underlying> prewrite(@NotNull byte[] bytes)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(bytes.length);
         bytesStore.write(offset, bytes);
@@ -880,7 +880,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewrite(@NotNull BytesStore bytes)
+    public Bytes<Underlying> prewrite(@NotNull BytesStore bytes)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(bytes.readRemaining());
         bytesStore.write(offset, bytes);
@@ -889,7 +889,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewriteByte(byte i8)
+    public Bytes<Underlying> prewriteByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
@@ -898,7 +898,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewriteInt(int i)
+    public Bytes<Underlying> prewriteInt(int i)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(4);
         bytesStore.writeInt(offset, i);
@@ -907,7 +907,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewriteShort(short i)
+    public Bytes<Underlying> prewriteShort(short i)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(2);
         bytesStore.writeShort(offset, i);
@@ -916,7 +916,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewriteLong(long l)
+    public Bytes<Underlying> prewriteLong(long l)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(8);
         bytesStore.writeLong(offset, l);
@@ -949,7 +949,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeShort(short i16)
+    public Bytes<Underlying> writeShort(short i16)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(2);
         bytesStore.writeShort(offset, i16);
@@ -958,7 +958,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeInt(int i)
+    public Bytes<Underlying> writeInt(int i)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeInt(offset, i);
@@ -967,7 +967,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeIntAdv(int i, int advance)
+    public Bytes<Underlying> writeIntAdv(int i, int advance)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4, advance);
         bytesStore.writeInt(offset, i);
@@ -976,7 +976,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLong(long i64)
+    public Bytes<Underlying> writeLong(long i64)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeLong(offset, i64);
@@ -985,7 +985,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLongAdv(long i64, int advance)
+    public Bytes<Underlying> writeLongAdv(long i64, int advance)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8, advance);
         bytesStore.writeLong(offset, i64);
@@ -994,7 +994,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeFloat(float f)
+    public Bytes<Underlying> writeFloat(float f)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeFloat(offset, f);
@@ -1003,7 +1003,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeDouble(double d)
+    public Bytes<Underlying> writeDouble(double d)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeDouble(offset, d);
@@ -1012,7 +1012,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeDoubleAndInt(double d, int i)
+    public Bytes<Underlying> writeDoubleAndInt(double d, int i)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(12);
         bytesStore.writeDouble(offset, d);
@@ -1022,7 +1022,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull byte[] bytes, int offset, int length)
+    public Bytes<Underlying> write(@NotNull byte[] bytes, int offset, int length)
             throws BufferOverflowException, IllegalStateException, IllegalArgumentException {
 
         if ((length + offset) > bytes.length) {
@@ -1050,7 +1050,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeSome(@NotNull ByteBuffer buffer)
+    public Bytes<Underlying> writeSome(@NotNull ByteBuffer buffer)
             throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
         int length = (int) Math.min(buffer.remaining(), writeRemaining());
         try {
@@ -1066,7 +1066,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedInt(int i)
+    public Bytes<Underlying> writeOrderedInt(int i)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeOrderedInt(offset, i);
@@ -1075,7 +1075,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedLong(long i)
+    public Bytes<Underlying> writeOrderedLong(long i)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeOrderedLong(offset, i);
@@ -1148,7 +1148,7 @@ public abstract class AbstractBytes<U>
         return bytesStore;
     }
 
-    protected void bytesStore(BytesStore<Bytes<U>, U> bytesStore) {
+    protected void bytesStore(BytesStore<Bytes<Underlying>, Underlying> bytesStore) {
         this.bytesStore = bytesStore;
     }
 
@@ -1173,7 +1173,7 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public BytesStore<Bytes<U>, U> copy() throws IllegalStateException {
+    public BytesStore<Bytes<Underlying>, Underlying> copy() throws IllegalStateException {
         return null;
     }
 

--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -35,16 +35,21 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
+/**
+ * Abstract representation of Bytes.
+ *
+ * @param <U> Underlying type
+ */
 @SuppressWarnings("rawtypes")
-public abstract class AbstractBytes<Underlying>
+public abstract class AbstractBytes<U>
         extends AbstractReferenceCounted
-        implements Bytes<Underlying> {
+        implements Bytes<U> {
     private static final boolean BYTES_BOUNDS_UNCHECKED = Jvm.getBoolean("bytes.bounds.unchecked", false);
     // used for debugging
     @UsedViaReflection
     private final String name;
     @NotNull
-    protected BytesStore<Bytes<Underlying>, Underlying> bytesStore;
+    protected BytesStore<Bytes<U>, U> bytesStore;
     protected long readPosition;
     protected long writePosition;
     protected long writeLimit;
@@ -53,12 +58,12 @@ public abstract class AbstractBytes<Underlying>
     private boolean lenient = false;
     private boolean lastNumberHadDigits = false;
 
-    AbstractBytes(@NotNull BytesStore<Bytes<Underlying>, Underlying> bytesStore, long writePosition, long writeLimit)
+    AbstractBytes(@NotNull BytesStore<Bytes<U>, U> bytesStore, long writePosition, long writeLimit)
             throws IllegalStateException {
         this(bytesStore, writePosition, writeLimit, "");
     }
 
-    AbstractBytes(@NotNull BytesStore<Bytes<Underlying>, Underlying> bytesStore, long writePosition, long writeLimit, String name)
+    AbstractBytes(@NotNull BytesStore<Bytes<U>, U> bytesStore, long writePosition, long writeLimit, String name)
             throws IllegalStateException {
         super(bytesStore.isDirectMemory());
         this.bytesStore(bytesStore);
@@ -90,7 +95,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> compact()
+    public Bytes<U> compact()
             throws IllegalStateException {
         long start = start();
         long readRemaining = readRemaining();
@@ -108,7 +113,7 @@ public abstract class AbstractBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> clear()
+    public Bytes<U> clear()
             throws IllegalStateException {
         long start = start();
         readPosition = start;
@@ -119,7 +124,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> clearAndPad(long length)
+    public Bytes<U> clearAndPad(long length)
             throws BufferOverflowException {
         if ((start() + length) > capacity()) {
             throw newBOERange(start(), length, "clearAndPad failed. Start: %d + length: %d > capacity: %d", capacity());
@@ -160,7 +165,7 @@ public abstract class AbstractBytes<Underlying>
 
     @Nullable
     @Override
-    public Underlying underlyingObject() {
+    public U underlyingObject() {
         return bytesStore.underlyingObject();
     }
 
@@ -200,6 +205,7 @@ public abstract class AbstractBytes<Underlying>
         return bytesStore.compareAndSwapLong(offset, expected, value);
     }
 
+    @Override
     public @NotNull AbstractBytes append(double d)
             throws BufferOverflowException, IllegalStateException {
         boolean fits = canWriteDirect(380);
@@ -223,7 +229,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> readPosition(long position)
+    public Bytes<U> readPosition(long position)
             throws BufferUnderflowException, IllegalStateException {
         if (position < start()) {
             throw new DecoratedBufferUnderflowException(String.format("readPosition failed. Position: %d < start: %d", position, start()));
@@ -238,7 +244,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> readLimit(long limit)
+    public Bytes<U> readLimit(long limit)
             throws BufferUnderflowException {
         if (limit < start())
             throw limitLessThanStart(limit);
@@ -260,7 +266,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writePosition(long position)
+    public Bytes<U> writePosition(long position)
             throws BufferOverflowException {
         if (position > writeLimit())
             throw writePositionTooLarge(position);
@@ -287,7 +293,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> readSkip(long bytesToSkip)
+    public Bytes<U> readSkip(long bytesToSkip)
             throws BufferUnderflowException, IllegalStateException {
         if (lenient) {
             bytesToSkip = Math.min(bytesToSkip, readRemaining());
@@ -308,17 +314,17 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeSkip(long bytesToSkip)
+    public Bytes<U> writeSkip(long bytesToSkip)
             throws BufferOverflowException, IllegalStateException {
-        final long writePosition = writePosition();
-        writeCheckOffset(writePosition, bytesToSkip);
-        uncheckedWritePosition(writePosition + bytesToSkip);
+        final long writePos = writePosition();
+        writeCheckOffset(writePos, bytesToSkip);
+        uncheckedWritePosition(writePos + bytesToSkip);
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLimit(long limit)
+    public Bytes<U> writeLimit(long limit)
             throws BufferOverflowException {
         if (limit < start()) {
             throw writeLimitTooSmall(limit);
@@ -362,6 +368,7 @@ public abstract class AbstractBytes<Underlying>
         }
     }
 
+    @Override
     public int readUnsignedByte(long offset)
             throws BufferUnderflowException, IllegalStateException {
         return readByte(offset) & 0xFF;
@@ -537,7 +544,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeByte(long offset, byte i)
+    public Bytes<U> writeByte(long offset, byte i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeByte(offset, i);
@@ -546,7 +553,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeShort(long offset, short i)
+    public Bytes<U> writeShort(long offset, short i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeShort(offset, i);
@@ -555,7 +562,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeInt(long offset, int i)
+    public Bytes<U> writeInt(long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeInt(offset, i);
@@ -564,7 +571,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeOrderedInt(long offset, int i)
+    public Bytes<U> writeOrderedInt(long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeOrderedInt(offset, i);
@@ -573,7 +580,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLong(long offset, long i)
+    public Bytes<U> writeLong(long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeLong(offset, i);
@@ -582,7 +589,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeOrderedLong(long offset, long i)
+    public Bytes<U> writeOrderedLong(long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeOrderedLong(offset, i);
@@ -591,7 +598,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeFloat(long offset, float d)
+    public Bytes<U> writeFloat(long offset, float d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeFloat(offset, d);
@@ -600,7 +607,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeDouble(long offset, double d)
+    public Bytes<U> writeDouble(long offset, double d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeDouble(offset, d);
@@ -609,7 +616,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeVolatileByte(long offset, byte i8)
+    public Bytes<U> writeVolatileByte(long offset, byte i8)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeVolatileByte(offset, i8);
@@ -618,7 +625,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeVolatileShort(long offset, short i16)
+    public Bytes<U> writeVolatileShort(long offset, short i16)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeVolatileShort(offset, i16);
@@ -627,7 +634,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeVolatileInt(long offset, int i32)
+    public Bytes<U> writeVolatileInt(long offset, int i32)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeVolatileInt(offset, i32);
@@ -636,7 +643,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeVolatileLong(long offset, long i64)
+    public Bytes<U> writeVolatileLong(long offset, long i64)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeVolatileLong(offset, i64);
@@ -645,7 +652,7 @@ public abstract class AbstractBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> write(@NotNull RandomDataInput bytes)
+    public Bytes<U> write(@NotNull RandomDataInput bytes)
             throws IllegalStateException, BufferOverflowException {
         assert bytes != this : "you should not write to yourself !";
 
@@ -658,7 +665,7 @@ public abstract class AbstractBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> write(long offsetInRDO, byte[] bytes, int offset, int length)
+    public Bytes<U> write(long offsetInRDO, byte[] bytes, int offset, int length)
             throws BufferOverflowException, IllegalStateException {
         long remaining = length;
         while (remaining > 0) {
@@ -681,7 +688,7 @@ public abstract class AbstractBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> write(long writeOffset, RandomDataInput bytes, long readOffset, long length)
+    public Bytes<U> write(long writeOffset, RandomDataInput bytes, long readOffset, long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
 
         long remaining = length;
@@ -697,7 +704,7 @@ public abstract class AbstractBytes<Underlying>
     }
 
     @Override
-    public @NotNull Bytes<Underlying> write8bit(@NotNull String s, int start, int length) throws BufferOverflowException, IndexOutOfBoundsException, ArithmeticException, IllegalStateException, BufferUnderflowException {
+    public @NotNull Bytes<U> write8bit(@NotNull String s, int start, int length) throws BufferOverflowException, IndexOutOfBoundsException, ArithmeticException, IllegalStateException, BufferUnderflowException {
         final long toWriteLength = UnsafeMemory.INSTANCE.stopBitLength(length) + (long) length;
         final long position = writeOffsetPositionMoved(toWriteLength, 0);
         bytesStore.write8bit(position, s, start, length);
@@ -705,7 +712,7 @@ public abstract class AbstractBytes<Underlying>
         return this;
     }
 
-    public @NotNull Bytes<Underlying> write8bit(@Nullable BytesStore bs) throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
+    public @NotNull Bytes<U> write8bit(@Nullable BytesStore bs) throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
         if (bs == null) {
             BytesInternal.writeStopBitNeg1(this);
             return this;
@@ -848,9 +855,6 @@ public abstract class AbstractBytes<Underlying>
         }
         long limit0 = readLimit();
         if (offset > limit0) {
-            // assert false : "can't read bytes past the limit : limit=" + limit0 + ",offset=" +
-            // offset +
-            // ",adding=" + adding;
             throw new DecoratedBufferOverflowException(
                     String.format("prewriteCheckOffset0 failed. Offset: %d > readLimit: %d", offset, limit0));
         }
@@ -858,7 +862,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeByte(byte i8)
+    public Bytes<U> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(1, 1);
         bytesStore.writeByte(offset, i8);
@@ -867,7 +871,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewrite(@NotNull byte[] bytes)
+    public Bytes<U> prewrite(@NotNull byte[] bytes)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(bytes.length);
         bytesStore.write(offset, bytes);
@@ -876,7 +880,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewrite(@NotNull BytesStore bytes)
+    public Bytes<U> prewrite(@NotNull BytesStore bytes)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(bytes.readRemaining());
         bytesStore.write(offset, bytes);
@@ -885,7 +889,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewriteByte(byte i8)
+    public Bytes<U> prewriteByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
@@ -894,7 +898,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewriteInt(int i)
+    public Bytes<U> prewriteInt(int i)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(4);
         bytesStore.writeInt(offset, i);
@@ -903,7 +907,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewriteShort(short i)
+    public Bytes<U> prewriteShort(short i)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(2);
         bytesStore.writeShort(offset, i);
@@ -912,7 +916,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewriteLong(long l)
+    public Bytes<U> prewriteLong(long l)
             throws BufferOverflowException, IllegalStateException {
         long offset = prewriteOffsetPositionMoved(8);
         bytesStore.writeLong(offset, l);
@@ -939,12 +943,13 @@ public abstract class AbstractBytes<Underlying>
     protected long prewriteOffsetPositionMoved(long subtracting)
             throws BufferOverflowException, IllegalStateException {
         prewriteCheckOffset(readPosition, subtracting);
-        return readPosition -= subtracting;
+        readPosition -= subtracting;
+        return readPosition;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeShort(short i16)
+    public Bytes<U> writeShort(short i16)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(2);
         bytesStore.writeShort(offset, i16);
@@ -953,7 +958,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeInt(int i)
+    public Bytes<U> writeInt(int i)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeInt(offset, i);
@@ -962,7 +967,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeIntAdv(int i, int advance)
+    public Bytes<U> writeIntAdv(int i, int advance)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4, advance);
         bytesStore.writeInt(offset, i);
@@ -971,7 +976,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLong(long i64)
+    public Bytes<U> writeLong(long i64)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeLong(offset, i64);
@@ -980,7 +985,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLongAdv(long i64, int advance)
+    public Bytes<U> writeLongAdv(long i64, int advance)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8, advance);
         bytesStore.writeLong(offset, i64);
@@ -989,7 +994,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeFloat(float f)
+    public Bytes<U> writeFloat(float f)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeFloat(offset, f);
@@ -998,7 +1003,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeDouble(double d)
+    public Bytes<U> writeDouble(double d)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeDouble(offset, d);
@@ -1007,7 +1012,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeDoubleAndInt(double d, int i)
+    public Bytes<U> writeDoubleAndInt(double d, int i)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(12);
         bytesStore.writeDouble(offset, d);
@@ -1017,7 +1022,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> write(@NotNull byte[] bytes, int offset, int length)
+    public Bytes<U> write(@NotNull byte[] bytes, int offset, int length)
             throws BufferOverflowException, IllegalStateException, IllegalArgumentException {
 
         if ((length + offset) > bytes.length) {
@@ -1045,7 +1050,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeSome(@NotNull ByteBuffer buffer)
+    public Bytes<U> writeSome(@NotNull ByteBuffer buffer)
             throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
         int length = (int) Math.min(buffer.remaining(), writeRemaining());
         try {
@@ -1061,7 +1066,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeOrderedInt(int i)
+    public Bytes<U> writeOrderedInt(int i)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeOrderedInt(offset, i);
@@ -1070,7 +1075,7 @@ public abstract class AbstractBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeOrderedLong(long i)
+    public Bytes<U> writeOrderedLong(long i)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeOrderedLong(offset, i);
@@ -1143,7 +1148,7 @@ public abstract class AbstractBytes<Underlying>
         return bytesStore;
     }
 
-    protected void bytesStore(BytesStore<Bytes<Underlying>, Underlying> bytesStore) {
+    protected void bytesStore(BytesStore<Bytes<U>, U> bytesStore) {
         this.bytesStore = bytesStore;
     }
 
@@ -1168,7 +1173,7 @@ public abstract class AbstractBytes<Underlying>
     }
 
     @Override
-    public BytesStore<Bytes<Underlying>, Underlying> copy() throws IllegalStateException {
+    public BytesStore<Bytes<U>, U> copy() throws IllegalStateException {
         return null;
     }
 
@@ -1210,9 +1215,12 @@ public abstract class AbstractBytes<Underlying>
         return sum & 0xFF;
     }
 
-    static class ReportUnoptimised {
+    static final class ReportUnoptimised {
         static {
             Jvm.reportUnoptimised();
+        }
+
+        private ReportUnoptimised() {
         }
 
         static void reportOnce() {

--- a/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
@@ -85,7 +85,7 @@ public enum AppendableUtil {
             throw new IllegalArgumentException("" + sb.getClass());
     }
 
-    public static <ACS extends Appendable & CharSequence> void append(@NotNull ACS sb, String str) {
+    public static <C extends Appendable & CharSequence> void append(@NotNull C sb, String str) {
         try {
             sb.append(str);
         } catch (IOException e) {
@@ -227,7 +227,7 @@ public enum AppendableUtil {
         }
     }
 
-    public static <ACS extends Appendable & CharSequence> void append(ACS a, CharSequence cs, long start, long len)
+    public static <C extends Appendable & CharSequence> void append(C a, CharSequence cs, long start, long len)
             throws ArithmeticException, BufferUnderflowException, IllegalStateException, BufferOverflowException {
         if (a instanceof StringBuilder) {
             if (cs instanceof Bytes)

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
@@ -47,11 +47,11 @@ public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocation
         MethodEncoder info = methodToIdMap.computeIfAbsent(method, methodToId);
         if (info == null) {
             Jvm.warn().on(getClass(), "Unknown method " + method + " ignored");
-            return null;
+        } else {
+            out.comment(method.getName());
+            out.writeStopBit(info.messageId());
+            info.encode(args, out);
         }
-        out.comment(method.getName());
-        out.writeStopBit(info.messageId());
-        info.encode(args, out);
         return null;
     }
 }

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryWireCode.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryWireCode.java
@@ -98,7 +98,7 @@ public interface BinaryWireCode {
 
     String[] STRING_FOR_CODE = _stringForCode(BinaryWireCode.class);
 
-    static String[] _stringForCode(Class clazz) {
+    static String[] _stringForCode(Class<?> clazz) {
         String[] stringForCode = new String[256];
         try {
             for (@NotNull Field field : clazz.getDeclaredFields()) {
@@ -113,10 +113,11 @@ public interface BinaryWireCode {
                 stringForCode[i] = "STRING_" + i;
             for (int i = 0; i < stringForCode.length; i++) {
                 if (stringForCode[i] == null)
-                    if (i <= ' ' || i >= 127)
+                    if (i <= ' ' || i >= 127) {
                         stringForCode[i] = "Unknown_0x" + Integer.toHexString(i).toUpperCase();
-                    else
+                    } else {
                         stringForCode[i] = "Unknown_" + (char) i;
+                    }
             }
         } catch (IllegalAccessException | IllegalArgumentException e) {
             throw new AssertionError(e);

--- a/src/main/java/net/openhft/chronicle/bytes/Byteable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Byteable.java
@@ -29,8 +29,11 @@ import java.nio.channels.FileLock;
  * This Interface allows a reference to off heap memory to be reassigned.
  * <p></p>
  * A reference to off heap memory is a proxy for some memory which sits outside the heap.
+ *
+ * @param <B> Bytes type
+ * @param <U> Underlying type
  */
-public interface Byteable<B extends BytesStore<B, Underlying>, Underlying> {
+public interface Byteable<B extends BytesStore<B, U>, U> {
     /**
      * This setter for a data type which points to an underlying ByteStore.
      *
@@ -38,11 +41,11 @@ public interface Byteable<B extends BytesStore<B, Underlying>, Underlying> {
      * @param offset     the offset within the ByteStore
      * @param length     the length in the ByteStore
      */
-    void bytesStore(BytesStore<B, Underlying> bytesStore, long offset, long length)
+    void bytesStore(BytesStore<B, U> bytesStore, long offset, long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException;
 
     @Nullable
-    BytesStore<B, Underlying> bytesStore();
+    BytesStore<B, U> bytesStore();
 
     /**
      * @return The offset within the BytesStore (not the address)

--- a/src/main/java/net/openhft/chronicle/bytes/Byteable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Byteable.java
@@ -31,9 +31,9 @@ import java.nio.channels.FileLock;
  * A reference to off heap memory is a proxy for some memory which sits outside the heap.
  *
  * @param <B> Bytes type
- * @param <U> Underlying type
+ * @param <Underlying> Underlying type
  */
-public interface Byteable<B extends BytesStore<B, U>, U> {
+public interface Byteable<B extends BytesStore<B, Underlying>, Underlying> {
     /**
      * This setter for a data type which points to an underlying ByteStore.
      *
@@ -41,11 +41,11 @@ public interface Byteable<B extends BytesStore<B, U>, U> {
      * @param offset     the offset within the ByteStore
      * @param length     the length in the ByteStore
      */
-    void bytesStore(BytesStore<B, U> bytesStore, long offset, long length)
+    void bytesStore(BytesStore<B, Underlying> bytesStore, long offset, long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException;
 
     @Nullable
-    BytesStore<B, U> bytesStore();
+    BytesStore<B, Underlying> bytesStore();
 
     /**
      * @return The offset within the BytesStore (not the address)

--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -47,14 +47,14 @@ import java.nio.charset.StandardCharsets;
  * <p></p> Also {@code readLimit() == writePosition() && readPosition() <= safeLimit()}
  * <p></p>
  *
- * @param <U> Underlying type
+ * @param <Underlying> Underlying type
  *
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public interface Bytes<U> extends
-        BytesStore<Bytes<U>, U>,
-        BytesIn<U>,
-        BytesOut<U> {
+public interface Bytes<Underlying> extends
+        BytesStore<Bytes<Underlying>, Underlying>,
+        BytesIn<Underlying>,
+        BytesOut<Underlying> {
 
     long MAX_CAPACITY = Long.MAX_VALUE & ~0xF; // 8 EiB - 16
     int MAX_HEAP_CAPACITY = Integer.MAX_VALUE & ~0xF;  // 2 GiB - 16
@@ -739,12 +739,12 @@ public interface Bytes<U> extends
      * @throws IllegalStateException if the underlying BytesStore has been released
      */
     @NotNull
-    default Bytes<U> unchecked(boolean unchecked)
+    default Bytes<Underlying> unchecked(boolean unchecked)
             throws IllegalStateException {
         if (unchecked) {
             if (isElastic())
                 BytesUtil.WarnUncheckedElasticBytes.warn();
-            Bytes<U> underlyingBytes = start() == 0 && bytesStore().isDirectMemory() ?
+            Bytes<Underlying> underlyingBytes = start() == 0 && bytesStore().isDirectMemory() ?
                     new UncheckedNativeBytes<>(this) :
                     new UncheckedBytes<>(this);
             release(INIT);
@@ -786,7 +786,7 @@ public interface Bytes<U> extends
      * @return a copy of this Bytes from position() to limit().
      */
     @Override
-    BytesStore<Bytes<U>, U> copy()
+    BytesStore<Bytes<Underlying>, Underlying> copy()
             throws IllegalStateException;
 
     @NotNull
@@ -856,7 +856,7 @@ public interface Bytes<U> extends
      */
     @NotNull
     @Override
-    default Bytes<U> bytesForRead()
+    default Bytes<Underlying> bytesForRead()
             throws IllegalStateException {
         try {
             return isClear() ? BytesStore.super.bytesForRead() : new SubBytes<>(this, readPosition(), readLimit() + start());
@@ -883,7 +883,7 @@ public interface Bytes<U> extends
      * @return this
      */
     @NotNull
-    Bytes<U> compact()
+    Bytes<Underlying> compact()
             throws IllegalStateException;
 
     /**
@@ -997,7 +997,7 @@ public interface Bytes<U> extends
 
     @Override
     @NotNull
-    Bytes<U> clear()
+    Bytes<Underlying> clear()
             throws IllegalStateException;
 
     @Override
@@ -1005,7 +1005,7 @@ public interface Bytes<U> extends
         return bytesStore().readWrite();
     }
 
-    default void readWithLength(long length, @NotNull BytesOut<U> bytesOut)
+    default void readWithLength(long length, @NotNull BytesOut<Underlying> bytesOut)
             throws BufferUnderflowException, IORuntimeException, BufferOverflowException, IllegalStateException {
         if (length > readRemaining())
             throw new BufferUnderflowException();

--- a/src/main/java/net/openhft/chronicle/bytes/BytesIn.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesIn.java
@@ -26,10 +26,10 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public interface BytesIn<Underlying> extends
+public interface BytesIn<U> extends
         RandomDataInput,
-        StreamingDataInput<Bytes<Underlying>>,
-        ByteStringParser<Bytes<Underlying>> {
+        StreamingDataInput<Bytes<U>>,
+        ByteStringParser<Bytes<U>> {
     /**
      * Reads messages from this tails as methods.  It returns a BooleanSupplier which returns
      *

--- a/src/main/java/net/openhft/chronicle/bytes/BytesIn.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesIn.java
@@ -26,10 +26,10 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public interface BytesIn<U> extends
+public interface BytesIn<Underlying> extends
         RandomDataInput,
-        StreamingDataInput<Bytes<U>>,
-        ByteStringParser<Bytes<U>> {
+        StreamingDataInput<Bytes<Underlying>>,
+        ByteStringParser<Bytes<Underlying>> {
     /**
      * Reads messages from this tails as methods.  It returns a BooleanSupplier which returns
      *

--- a/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
@@ -27,11 +27,11 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public interface BytesOut<U> extends
-        StreamingDataOutput<Bytes<U>>,
-        ByteStringAppender<Bytes<U>>,
-        BytesPrepender<Bytes<U>>,
-        BytesComment<BytesOut<U>> {
+public interface BytesOut<Underlying> extends
+        StreamingDataOutput<Bytes<Underlying>>,
+        ByteStringAppender<Bytes<Underlying>>,
+        BytesPrepender<Bytes<Underlying>>,
+        BytesComment<BytesOut<Underlying>> {
 
     /**
      * Proxy an interface so each message called is written to a file for replay.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
@@ -27,11 +27,11 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public interface BytesOut<Underlying> extends
-        StreamingDataOutput<Bytes<Underlying>>,
-        ByteStringAppender<Bytes<Underlying>>,
-        BytesPrepender<Bytes<Underlying>>,
-        BytesComment<BytesOut<Underlying>> {
+public interface BytesOut<U> extends
+        StreamingDataOutput<Bytes<U>>,
+        ByteStringAppender<Bytes<U>>,
+        BytesPrepender<Bytes<U>>,
+        BytesComment<BytesOut<U>> {
 
     /**
      * Proxy an interface so each message called is written to a file for replay.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -45,10 +45,10 @@ import static java.lang.Math.min;
  * provided the data referenced is accessed in a thread safe manner. Only offset access within the
  * capacity is possible.
  * @param <B> BytesStore type
- * @param <U> Underlying type
+ * @param <Underlying> Underlying type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public interface BytesStore<B extends BytesStore<B, U>, U>
+public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
         extends RandomDataInput, RandomDataOutput<B>, ReferenceCounted, CharSequence {
 
     /**
@@ -188,7 +188,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
     /**
      * @return a copy of this BytesStore.
      */
-    BytesStore<B, U> copy()
+    BytesStore<B, Underlying> copy()
             throws IllegalStateException;
 
     /**
@@ -201,10 +201,10 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      */
     @Override
     @NotNull
-    default Bytes<U> bytesForRead()
+    default Bytes<Underlying> bytesForRead()
             throws IllegalStateException {
         try {
-            Bytes<U> ret = bytesForWrite();
+            Bytes<Underlying> ret = bytesForWrite();
             ret.readLimit(writeLimit());
             ret.writeLimit(realCapacity());
             ret.readPosition(start());
@@ -224,7 +224,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      */
     @Override
     @NotNull
-    default Bytes<U> bytesForWrite()
+    default Bytes<Underlying> bytesForWrite()
             throws IllegalStateException {
         try {
             return new VanillaBytes<>(this, writePosition(), writeLimit());
@@ -264,7 +264,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @return the underlying object being wrapped, if there is one, or null if not.
      */
     @Nullable
-    U underlyingObject();
+    Underlying underlyingObject();
 
     /**
      * Returns if a specified offset is inside this BytesStore limits.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -44,9 +44,11 @@ import static java.lang.Math.min;
  * An immutable reference to some bytes with fixed extents. This can be shared safely across thread
  * provided the data referenced is accessed in a thread safe manner. Only offset access within the
  * capacity is possible.
+ * @param <B> BytesStore type
+ * @param <U> Underlying type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
+public interface BytesStore<B extends BytesStore<B, U>, U>
         extends RandomDataInput, RandomDataOutput<B>, ReferenceCounted, CharSequence {
 
     /**
@@ -96,7 +98,7 @@ public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
      * @param bytes to wrap
      * @return BytesStore
      */
-    static BytesStore<?, byte[]> wrap(@NotNull byte[] bytes) {
+    static BytesStore<?, byte[]> wrap(byte[] bytes) {
         return HeapBytesStore.wrap(bytes);
     }
 
@@ -186,7 +188,7 @@ public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
     /**
      * @return a copy of this BytesStore.
      */
-    BytesStore<B, Underlying> copy()
+    BytesStore<B, U> copy()
             throws IllegalStateException;
 
     /**
@@ -199,10 +201,10 @@ public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
      */
     @Override
     @NotNull
-    default Bytes<Underlying> bytesForRead()
+    default Bytes<U> bytesForRead()
             throws IllegalStateException {
         try {
-            Bytes<Underlying> ret = bytesForWrite();
+            Bytes<U> ret = bytesForWrite();
             ret.readLimit(writeLimit());
             ret.writeLimit(realCapacity());
             ret.readPosition(start());
@@ -222,7 +224,7 @@ public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
      */
     @Override
     @NotNull
-    default Bytes<Underlying> bytesForWrite()
+    default Bytes<U> bytesForWrite()
             throws IllegalStateException {
         try {
             return new VanillaBytes<>(this, writePosition(), writeLimit());
@@ -262,7 +264,7 @@ public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
      * @return the underlying object being wrapped, if there is one, or null if not.
      */
     @Nullable
-    Underlying underlyingObject();
+    U underlyingObject();
 
     /**
      * Returns if a specified offset is inside this BytesStore limits.
@@ -517,7 +519,7 @@ public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
      */
     default boolean contentEquals(@Nullable BytesStore bytesStore)
             throws IllegalStateException {
-        return BytesInternal.contentEqual(this, bytesStore);
+        return bytesStore != null && BytesInternal.contentEqual(this, bytesStore);
     }
 
     /**
@@ -529,7 +531,7 @@ public interface BytesStore<B extends BytesStore<B, Underlying>, Underlying>
      */
     default boolean startsWith(@Nullable BytesStore bytesStore)
             throws IllegalStateException {
-        return BytesInternal.startsWith(this, bytesStore);
+        return bytesStore != null && BytesInternal.startsWith(this, bytesStore);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
@@ -140,9 +140,7 @@ public enum BytesUtil {
             url = urlFor(Thread.currentThread().getContextClassLoader(), name);
             file = new File(url.getFile());
         }
-        return // name.endsWith(".gz") || !file.exists() || OS.isWindows() ?
-                Bytes.wrapForRead(readAsBytes(url == null ? new FileInputStream(file) : open(url)));
-        //: MappedFile.readOnly(file).acquireBytesForRead(0);
+        return Bytes.wrapForRead(readAsBytes(url == null ? new FileInputStream(file) : open(url)));
 
     }
 
@@ -346,9 +344,12 @@ public enum BytesUtil {
         BytesInternal.copy8bit(bs, addressForWrite, length);
     }
 
-    static class WarnUncheckedElasticBytes {
+    static final class WarnUncheckedElasticBytes {
         static {
             Jvm.debug().on(WarnUncheckedElasticBytes.class, "Wrapping elastic bytes with unchecked() will require calling ensureCapacity() as needed!");
+        }
+
+        private WarnUncheckedElasticBytes() {
         }
 
         static void warn() {

--- a/src/main/java/net/openhft/chronicle/bytes/GuardedNativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/GuardedNativeBytes.java
@@ -25,7 +25,7 @@ import java.nio.BufferUnderflowException;
 
 import static net.openhft.chronicle.bytes.BinaryWireCode.*;
 
-public class GuardedNativeBytes<U> extends NativeBytes<U> {
+public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
     static final byte BYTE_T = (byte) INT8;
     static final byte SHORT_T = (byte) INT16;
     static final byte INT_T = (byte) INT32;
@@ -43,20 +43,20 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(byte i8)
+    public Bytes<Underlying> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(BYTE_T);
         return super.writeByte(i8);
     }
 
     @Override
-    public Bytes<U> rawWriteByte(byte i8)
+    public Bytes<Underlying> rawWriteByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         return super.writeByte(i8);
     }
 
     @Override
-    public Bytes<U> rawWriteInt(int i)
+    public Bytes<Underlying> rawWriteInt(int i)
             throws BufferOverflowException, IllegalStateException {
         return super.writeInt(i);
     }
@@ -85,7 +85,7 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
 
     @NotNull
     @Override
-    public Bytes<U> writeShort(short i16)
+    public Bytes<Underlying> writeShort(short i16)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(SHORT_T);
         return super.writeShort(i16);
@@ -100,7 +100,7 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
 
     @NotNull
     @Override
-    public Bytes<U> writeStopBit(char x)
+    public Bytes<Underlying> writeStopBit(char x)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(STOP_T);
         return super.writeStopBit(x);
@@ -108,7 +108,7 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
 
     @NotNull
     @Override
-    public Bytes<U> writeStopBit(long x)
+    public Bytes<Underlying> writeStopBit(long x)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(STOP_T);
         return super.writeStopBit(x);
@@ -130,7 +130,7 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
 
     @NotNull
     @Override
-    public Bytes<U> writeInt(int i)
+    public Bytes<Underlying> writeInt(int i)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(INT_T);
         return super.writeInt(i);
@@ -160,7 +160,7 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
 
     @NotNull
     @Override
-    public Bytes<U> writeFloat(float f)
+    public Bytes<Underlying> writeFloat(float f)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(FLOAT_T);
         return super.writeFloat(f);
@@ -175,7 +175,7 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
 
     @NotNull
     @Override
-    public Bytes<U> writeDouble(double d)
+    public Bytes<Underlying> writeDouble(double d)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(DOUBLE_T);
         return super.writeDouble(d);

--- a/src/main/java/net/openhft/chronicle/bytes/GuardedNativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/GuardedNativeBytes.java
@@ -25,7 +25,7 @@ import java.nio.BufferUnderflowException;
 
 import static net.openhft.chronicle.bytes.BinaryWireCode.*;
 
-public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
+public class GuardedNativeBytes<U> extends NativeBytes<U> {
     static final byte BYTE_T = (byte) INT8;
     static final byte SHORT_T = (byte) INT16;
     static final byte INT_T = (byte) INT32;
@@ -36,27 +36,27 @@ public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
 
     private static final String[] STRING_FOR_CODE = _stringForCode(GuardedNativeBytes.class);
 
-    public GuardedNativeBytes(@NotNull BytesStore store, long capacity)
+    public GuardedNativeBytes(@NotNull BytesStore<?, ?> store, long capacity)
             throws IllegalStateException, IllegalArgumentException {
         super(store, capacity);
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeByte(byte i8)
+    public Bytes<U> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(BYTE_T);
         return super.writeByte(i8);
     }
 
     @Override
-    public Bytes<Underlying> rawWriteByte(byte i8)
+    public Bytes<U> rawWriteByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         return super.writeByte(i8);
     }
 
     @Override
-    public Bytes<Underlying> rawWriteInt(int i)
+    public Bytes<U> rawWriteInt(int i)
             throws BufferOverflowException, IllegalStateException {
         return super.writeInt(i);
     }
@@ -85,7 +85,7 @@ public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeShort(short i16)
+    public Bytes<U> writeShort(short i16)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(SHORT_T);
         return super.writeShort(i16);
@@ -100,7 +100,7 @@ public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeStopBit(char x)
+    public Bytes<U> writeStopBit(char x)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(STOP_T);
         return super.writeStopBit(x);
@@ -108,7 +108,7 @@ public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeStopBit(long x)
+    public Bytes<U> writeStopBit(long x)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(STOP_T);
         return super.writeStopBit(x);
@@ -130,7 +130,7 @@ public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeInt(int i)
+    public Bytes<U> writeInt(int i)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(INT_T);
         return super.writeInt(i);
@@ -160,7 +160,7 @@ public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeFloat(float f)
+    public Bytes<U> writeFloat(float f)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(FLOAT_T);
         return super.writeFloat(f);
@@ -175,7 +175,7 @@ public class GuardedNativeBytes<Underlying> extends NativeBytes<Underlying> {
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeDouble(double d)
+    public Bytes<U> writeDouble(double d)
             throws BufferOverflowException, IllegalStateException {
         super.writeByte(DOUBLE_T);
         return super.writeDouble(d);

--- a/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
@@ -760,19 +760,19 @@ base.lastNumberHadDigits(lastNumberHadDigits);
     }
 
     @Override
-    public <ACS extends Appendable & CharSequence> boolean readUtf8(@NotNull ACS sb)
+    public <C extends Appendable & CharSequence> boolean readUtf8(@NotNull C sb)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, IllegalStateException, ArithmeticException {
         return base.readUtf8(sb);
     }
 
     @Override
-    public <ACS extends Appendable & CharSequence> long readUtf8(long offset, @NotNull ACS sb)
+    public <C extends Appendable & CharSequence> long readUtf8(long offset, @NotNull C sb)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, ArithmeticException, IllegalStateException {
         return base.readUtf8(offset, sb);
     }
 
     @Override
-    public <ACS extends Appendable & CharSequence> long readUtf8Limited(long offset, @NotNull ACS sb, int maxUtf8Len)
+    public <C extends Appendable & CharSequence> long readUtf8Limited(long offset, @NotNull C sb, int maxUtf8Len)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, IllegalStateException {
         return base.readUtf8Limited(offset, sb, maxUtf8Len);
     }
@@ -783,7 +783,7 @@ base.lastNumberHadDigits(lastNumberHadDigits);
         return base.readUtf8Limited(offset, maxUtf8Len);
     }
 
-    public <ACS extends Appendable & CharSequence> boolean readUTFΔ(@NotNull ACS sb)
+    public <C extends Appendable & CharSequence> boolean readUTFΔ(@NotNull C sb)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, IllegalStateException, ArithmeticException {
         return base.readUtf8(sb);
 
@@ -797,7 +797,7 @@ base.lastNumberHadDigits(lastNumberHadDigits);
     }
 
     @Override
-    public <ACS extends Appendable & CharSequence> boolean read8bit(@NotNull ACS sb)
+    public <C extends Appendable & CharSequence> boolean read8bit(@NotNull C sb)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, IllegalStateException, ArithmeticException {
         return base.read8bit(sb);
 

--- a/src/main/java/net/openhft/chronicle/bytes/MappedUniqueTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedUniqueTimeProvider.java
@@ -36,7 +36,6 @@ public enum MappedUniqueTimeProvider implements TimeProvider {
 
     private static final int LAST_TIME = 128;
 
-    private final MappedFile file;
     @SuppressWarnings("rawtypes")
     private final Bytes bytes;
     private TimeProvider provider = SystemTimeProvider.INSTANCE;
@@ -44,7 +43,7 @@ public enum MappedUniqueTimeProvider implements TimeProvider {
     MappedUniqueTimeProvider() {
         try {
             String user = System.getProperty("user.name", "unknown");
-            file = MappedFile.mappedFile(OS.TMP + "/.time-stamp." + user + ".dat", OS.pageSize(), 0);
+            MappedFile file = MappedFile.mappedFile(OS.TMP + "/.time-stamp." + user + ".dat", OS.pageSize(), 0);
             IOTools.unmonitor(file);
             ReferenceOwner mumtp = ReferenceOwner.temporary("mumtp");
             bytes = file.acquireBytesForWrite(mumtp, 0);
@@ -97,9 +96,8 @@ public enum MappedUniqueTimeProvider implements TimeProvider {
             long time0 = bytes.readVolatileLong(LAST_TIME);
             long timeNanos5 = time0 >>> 5;
 
-            if (time5 > timeNanos5)
-                if (bytes.compareAndSwapLong(LAST_TIME, time0, time))
-                    return time;
+            if (time5 > timeNanos5 && bytes.compareAndSwapLong(LAST_TIME, time0, time))
+                return time;
 
             while (true) {
                 time0 = bytes.readVolatileLong(LAST_TIME);

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
@@ -36,12 +36,14 @@ import static net.openhft.chronicle.bytes.NoBytesStore.noBytesStore;
  * Elastic memory accessor which can wrap either a ByteBuffer or malloc'ed memory.
  * <p>
  * <p>This class can wrap <i>heap</i> ByteBuffers, called <i>Native</i>Bytes for historical reasons.
+ *
+ * @param <U> Underlying type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class NativeBytes<Underlying>
-        extends VanillaBytes<Underlying> {
+public class NativeBytes<U>
+        extends VanillaBytes<U> {
     private static final boolean BYTES_GUARDED = Jvm.getBoolean("bytes.guarded");
-    private static boolean s_newGuarded = BYTES_GUARDED;
+    private static boolean newGuarded = BYTES_GUARDED;
     private long capacity;
 
     public NativeBytes(@NotNull final BytesStore store, final long capacity)
@@ -62,7 +64,7 @@ public class NativeBytes<Underlying>
      * @return will new NativeBytes be guarded.
      */
     public static boolean areNewGuarded() {
-        return s_newGuarded;
+        return newGuarded;
     }
 
     /**
@@ -74,7 +76,7 @@ public class NativeBytes<Underlying>
      * @param guarded turn on if true
      */
     public static boolean setNewGuarded(final boolean guarded) {
-        s_newGuarded = guarded;
+        newGuarded = guarded;
         return true;
     }
 
@@ -82,7 +84,7 @@ public class NativeBytes<Underlying>
      * For testing
      */
     public static void resetNewGuarded() {
-        s_newGuarded = BYTES_GUARDED;
+        newGuarded = BYTES_GUARDED;
     }
 
     @NotNull
@@ -130,7 +132,7 @@ public class NativeBytes<Underlying>
     @NotNull
     public static <T> NativeBytes<T> wrapWithNativeBytes(@NotNull final BytesStore<?, T> bs, long capacity)
             throws IllegalStateException, IllegalArgumentException {
-        return s_newGuarded
+        return newGuarded
                 ? new GuardedNativeBytes(bs, capacity)
                 : new NativeBytes<>(bs, capacity);
     }
@@ -220,7 +222,7 @@ public class NativeBytes<Underlying>
             throw new DecoratedBufferOverflowException(endOfBuffer + ">" + capacity());
         final long realCapacity = realCapacity();
         if (endOfBuffer <= realCapacity) {
-//            System.out.println("no resize " + endOfBuffer + " < " + realCapacity);
+            //  No resize
             return;
         }
 
@@ -248,7 +250,6 @@ public class NativeBytes<Underlying>
                     "this bytes' underlyingObject() is ByteBuffer, NullPointerException is likely to be thrown. " +
                     stack);
         }
-//        System.out.println("resize " + endOfBuffer + " to " + size);
         // native block of 128 KiB or more have an individual memory mapping so are more expensive.
         if (endOfBuffer >= 128 << 10)
             Jvm.perf().on(getClass(), "Resizing buffer was " + realCapacity / 1024 + " KB, " +
@@ -277,7 +278,7 @@ public class NativeBytes<Underlying>
         }
 
         throwExceptionIfReleased();
-        @Nullable final BytesStore<Bytes<Underlying>, Underlying> tempStore = this.bytesStore;
+        @Nullable final BytesStore<Bytes<U>, U> tempStore = this.bytesStore;
         this.bytesStore.copyTo(store);
         this.bytesStore(store);
         try {
@@ -295,14 +296,14 @@ public class NativeBytes<Underlying>
     }
 
     @Override
-    protected void bytesStore(BytesStore<Bytes<Underlying>, Underlying> bytesStore) {
+    protected void bytesStore(BytesStore<Bytes<U>, U> bytesStore) {
         if (capacity < bytesStore.capacity())
             capacity = bytesStore.capacity();
         super.bytesStore(bytesStore);
     }
 
     @Override
-    public void bytesStore(@NotNull BytesStore<Bytes<Underlying>, Underlying> byteStore, long offset, long length) throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
+    public void bytesStore(@NotNull BytesStore<Bytes<U>, U> byteStore, long offset, long length) throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
         if (capacity < offset + length)
             capacity = offset + length;
         super.bytesStore(byteStore, offset, length);
@@ -364,7 +365,7 @@ public class NativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeByte(final byte i8)
+    public Bytes<U> writeByte(final byte i8)
             throws BufferOverflowException, IllegalStateException {
         final long offset = writeOffsetPositionMoved(1, 1);
         bytesStore.writeByte(offset, i8);
@@ -373,7 +374,7 @@ public class NativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLong(final long i64)
+    public Bytes<U> writeLong(final long i64)
             throws BufferOverflowException, IllegalStateException {
         final long offset = writeOffsetPositionMoved(8L, 8L);
         bytesStore.writeLong(offset, i64);

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
@@ -37,11 +37,11 @@ import static net.openhft.chronicle.bytes.NoBytesStore.noBytesStore;
  * <p>
  * <p>This class can wrap <i>heap</i> ByteBuffers, called <i>Native</i>Bytes for historical reasons.
  *
- * @param <U> Underlying type
+ * @param <Underlying> Underlying type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class NativeBytes<U>
-        extends VanillaBytes<U> {
+public class NativeBytes<Underlying>
+        extends VanillaBytes<Underlying> {
     private static final boolean BYTES_GUARDED = Jvm.getBoolean("bytes.guarded");
     private static boolean newGuarded = BYTES_GUARDED;
     private long capacity;
@@ -278,7 +278,7 @@ public class NativeBytes<U>
         }
 
         throwExceptionIfReleased();
-        @Nullable final BytesStore<Bytes<U>, U> tempStore = this.bytesStore;
+        @Nullable final BytesStore<Bytes<Underlying>, Underlying> tempStore = this.bytesStore;
         this.bytesStore.copyTo(store);
         this.bytesStore(store);
         try {
@@ -296,14 +296,14 @@ public class NativeBytes<U>
     }
 
     @Override
-    protected void bytesStore(BytesStore<Bytes<U>, U> bytesStore) {
+    protected void bytesStore(BytesStore<Bytes<Underlying>, Underlying> bytesStore) {
         if (capacity < bytesStore.capacity())
             capacity = bytesStore.capacity();
         super.bytesStore(bytesStore);
     }
 
     @Override
-    public void bytesStore(@NotNull BytesStore<Bytes<U>, U> byteStore, long offset, long length) throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
+    public void bytesStore(@NotNull BytesStore<Bytes<Underlying>, Underlying> byteStore, long offset, long length) throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
         if (capacity < offset + length)
             capacity = offset + length;
         super.bytesStore(byteStore, offset, length);
@@ -365,7 +365,7 @@ public class NativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(final byte i8)
+    public Bytes<Underlying> writeByte(final byte i8)
             throws BufferOverflowException, IllegalStateException {
         final long offset = writeOffsetPositionMoved(1, 1);
         bytesStore.writeByte(offset, i8);
@@ -374,7 +374,7 @@ public class NativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLong(final long i64)
+    public Bytes<Underlying> writeLong(final long i64)
             throws BufferOverflowException, IllegalStateException {
         final long offset = writeOffsetPositionMoved(8L, 8L);
         bytesStore.writeLong(offset, i64);

--- a/src/main/java/net/openhft/chronicle/bytes/OnHeapBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/OnHeapBytes.java
@@ -22,7 +22,7 @@ public class OnHeapBytes extends VanillaBytes<byte[]> {
      * @throws IllegalStateException if bytesStore has been released
      * @throws IllegalArgumentException
      */
-    public OnHeapBytes(@NotNull BytesStore bytesStore, boolean elastic)
+    public OnHeapBytes(@NotNull BytesStore<?, ?> bytesStore, boolean elastic)
             throws IllegalStateException, IllegalArgumentException {
         super(bytesStore);
         this.elastic = elastic;
@@ -92,7 +92,7 @@ public class OnHeapBytes extends VanillaBytes<byte[]> {
             throw new BufferOverflowException();
         final long realCapacity = realCapacity();
         if (endOfBuffer <= realCapacity) {
-//            System.out.println("no resize " + endOfBuffer + " < " + realCapacity);
+            // No resize
             return;
         }
 
@@ -101,7 +101,6 @@ public class OnHeapBytes extends VanillaBytes<byte[]> {
         // Size must not be more than capacity(), it may break some assumptions in BytesStore or elsewhere
         int size = (int) Math.min(size0, capacity());
 
-        //        System.out.println("resize " + endOfBuffer + " to " + size);
         // native block of 128 KiB or more have an individual memory mapping so are more expensive.
         if (endOfBuffer >= 128 << 10)
             Jvm.perf().on(getClass(), "Resizing buffer was " + realCapacity / 1024 + " KB, " +

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
@@ -363,6 +363,7 @@ public interface RandomDataInput extends RandomCommon {
      *
      * @return the actual capacity that can be potentially read.
      */
+    @Override
     long realCapacity();
 
     /**
@@ -449,13 +450,13 @@ public interface RandomDataInput extends RandomCommon {
      *
      * @param offset the offset in this {@code RandomDataInput} to read char sequence from
      * @param sb     the buffer to read char sequence into (truncated first)
-     * @param <ACS>  buffer type, must be {@code StringBuilder} or {@code Bytes}
+     * @param <C>  buffer type, must be {@code StringBuilder} or {@code Bytes}
      * @return offset after the normal read char sequence, or -1 - offset, if char sequence is
      * {@code null}
      * @see RandomDataOutput#writeUtf8(long, CharSequence)
      * @throws IllegalStateException    if released
      */
-    default <ACS extends Appendable & CharSequence> long readUtf8(long offset, @NotNull ACS sb)
+    default <C extends Appendable & CharSequence> long readUtf8(long offset, @NotNull C sb)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, ArithmeticException, IllegalStateException {
         AppendableUtil.setLength(sb, 0);
         // TODO insert some bounds check here
@@ -500,14 +501,15 @@ public interface RandomDataInput extends RandomCommon {
      * @param offset     the offset in this {@code RandomDataInput} to read char sequence from
      * @param sb         the buffer to read char sequence into (truncated first)
      * @param maxUtf8Len the maximum allowed length of the char sequence in Utf8 encoding
-     * @param <ACS>      buffer type, must be {@code StringBuilder} or {@code Bytes}
+     * @param <C>      buffer type, must be {@code StringBuilder} or {@code Bytes}
      * @return offset after the normal read char sequence, or -1 - offset, if char sequence is
      * {@code null}
      * @throws IllegalStateException    if released
      * @see RandomDataOutput#writeUtf8Limited(long, CharSequence, int)
      */
-    default <ACS extends Appendable & CharSequence> long readUtf8Limited(
-            long offset, @NotNull ACS sb, int maxUtf8Len)
+    default <C extends Appendable & CharSequence> long readUtf8Limited(long offset,
+                                                                       final @NotNull C sb,
+                                                                       final int maxUtf8Len)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException,
             IllegalStateException {
         AppendableUtil.setLength(sb, 0);

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
@@ -450,13 +450,13 @@ public interface RandomDataInput extends RandomCommon {
      *
      * @param offset the offset in this {@code RandomDataInput} to read char sequence from
      * @param sb     the buffer to read char sequence into (truncated first)
-     * @param <C>  buffer type, must be {@code StringBuilder} or {@code Bytes}
+     * @param <ACS>  buffer type, must be {@code StringBuilder} or {@code Bytes}
      * @return offset after the normal read char sequence, or -1 - offset, if char sequence is
      * {@code null}
      * @see RandomDataOutput#writeUtf8(long, CharSequence)
      * @throws IllegalStateException    if released
      */
-    default <C extends Appendable & CharSequence> long readUtf8(long offset, @NotNull C sb)
+    default <ACS extends Appendable & CharSequence> long readUtf8(long offset, @NotNull ACS sb)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, ArithmeticException, IllegalStateException {
         AppendableUtil.setLength(sb, 0);
         // TODO insert some bounds check here
@@ -501,15 +501,15 @@ public interface RandomDataInput extends RandomCommon {
      * @param offset     the offset in this {@code RandomDataInput} to read char sequence from
      * @param sb         the buffer to read char sequence into (truncated first)
      * @param maxUtf8Len the maximum allowed length of the char sequence in Utf8 encoding
-     * @param <C>      buffer type, must be {@code StringBuilder} or {@code Bytes}
+     * @param <ACS>      buffer type, must be {@code StringBuilder} or {@code Bytes}
      * @return offset after the normal read char sequence, or -1 - offset, if char sequence is
      * {@code null}
      * @throws IllegalStateException    if released
      * @see RandomDataOutput#writeUtf8Limited(long, CharSequence, int)
      */
-    default <C extends Appendable & CharSequence> long readUtf8Limited(long offset,
-                                                                       final @NotNull C sb,
-                                                                       final int maxUtf8Len)
+    default <ACS extends Appendable & CharSequence> long readUtf8Limited(long offset,
+                                                                         final @NotNull ACS sb,
+                                                                         final int maxUtf8Len)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException,
             IllegalStateException {
         AppendableUtil.setLength(sb, 0);

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataInput.java
@@ -288,7 +288,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
      * @param sb to copy chars to
      * @return <code>true</code> if there was a String, or <code>false</code> if it was <code>null</code>
      */
-    default <ACS extends Appendable & CharSequence> boolean readUtf8(@NotNull ACS sb)
+    default <C extends Appendable & CharSequence> boolean readUtf8(@NotNull C sb)
             throws IORuntimeException, BufferUnderflowException, ArithmeticException, IllegalStateException, IllegalArgumentException {
         try {
             AppendableUtil.setLength(sb, 0);
@@ -360,7 +360,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
     }
 
     @Deprecated(/* remove in x.23 */)
-    default <ACS extends Appendable & CharSequence> boolean read8bit(@NotNull ACS sb)
+    default <C extends Appendable & CharSequence> boolean read8bit(@NotNull C sb)
             throws IORuntimeException, BufferUnderflowException, ArithmeticException, IllegalArgumentException, IllegalStateException {
         AppendableUtil.setLength(sb, 0);
         if (readRemaining() <= 0)
@@ -482,7 +482,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
         if (isDirectMemory()) {
             long src = addressForRead(readPosition());
             readSkip(length);
-            MEMORY.copyMemory(src, address, length);
+            UnsafeMemory.copyMemory(src, address, length);
         } else {
             int i = 0;
             for (; i < length - 7; i += 8)

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
@@ -209,7 +209,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
         writeStopBit(length);
         for (int i = 0; i < length; i++) {
             char c = s.charAt(i + start);
-            rawWriteByte((byte) Maths.toUInt8((int) c));
+            rawWriteByte((byte) Maths.toUInt8(c));
         }
         return (S) this;
     }
@@ -386,6 +386,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     /**
      * @return capacity without resize or -1 if closed
      */
+    @Override
     long realCapacity();
 
     default boolean canWriteDirect(long count) {
@@ -477,7 +478,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
         if (isDirectMemory()) {
             long destAddress = addressForWrite(writePosition());
             writeSkip(length); // blow up if there isn't that much space left
-            MEMORY.copyMemory(address, destAddress, length);
+            UnsafeMemory.copyMemory(address, destAddress, length);
         } else {
             int i = 0;
             for (; i < length - 7; i += 8)

--- a/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.BufferUnderflowException;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class SubBytes<U> extends VanillaBytes<U> {
+public class SubBytes<Underlying> extends VanillaBytes<Underlying> {
     private final long start;
     private final long capacity;
 

--- a/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.BufferUnderflowException;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class SubBytes<Underlying> extends VanillaBytes<Underlying> {
+public class SubBytes<U> extends VanillaBytes<U> {
     private final long start;
     private final long capacity;
 

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
@@ -36,8 +36,8 @@ import static net.openhft.chronicle.core.util.StringUtils.extractChars;
  * Fast unchecked version of AbstractBytes
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class UncheckedBytes<Underlying>
-        extends AbstractBytes<Underlying> {
+public class UncheckedBytes<U>
+        extends AbstractBytes<U> {
     Bytes underlyingBytes;
 
     public UncheckedBytes(@NotNull Bytes underlyingBytes)
@@ -51,10 +51,10 @@ public class UncheckedBytes<Underlying>
 
     public void setBytes(@NotNull Bytes bytes)
             throws IllegalStateException {
-        BytesStore underlyingBytes = bytes.bytesStore();
-        if (bytesStore != underlyingBytes) {
+        BytesStore underlying = bytes.bytesStore();
+        if (bytesStore != underlying) {
             bytesStore.release(this);
-            this.bytesStore(underlyingBytes);
+            this.bytesStore(underlying);
             bytesStore.reserve(this);
         }
         readPosition(bytes.readPosition());
@@ -75,7 +75,7 @@ public class UncheckedBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> unchecked(boolean unchecked) {
+    public Bytes<U> unchecked(boolean unchecked) {
         return this;
     }
 
@@ -101,49 +101,49 @@ public class UncheckedBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> readPosition(long position) {
+    public Bytes<U> readPosition(long position) {
         readPosition = position;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> readLimit(long limit) {
+    public Bytes<U> readLimit(long limit) {
         uncheckedWritePosition(limit);
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> writePosition(long position) {
+    public Bytes<U> writePosition(long position) {
         uncheckedWritePosition(position);
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> readSkip(long bytesToSkip) {
+    public Bytes<U> readSkip(long bytesToSkip) {
         readPosition += bytesToSkip;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeSkip(long bytesToSkip) {
+    public Bytes<U> writeSkip(long bytesToSkip) {
         uncheckedWritePosition(writePosition() + bytesToSkip);
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLimit(long limit) {
+    public Bytes<U> writeLimit(long limit) {
         writeLimit = limit;
         return this;
     }
 
     @NotNull
     @Override
-    public BytesStore<Bytes<Underlying>, Underlying> copy() {
+    public BytesStore<Bytes<U>, U> copy() {
         throw new UnsupportedOperationException("todo");
     }
 
@@ -169,12 +169,13 @@ public class UncheckedBytes<Underlying>
     @Override
     protected long prewriteOffsetPositionMoved(long subtracting)
             throws BufferOverflowException {
-        return readPosition -= subtracting;
+        readPosition -= subtracting;
+        return readPosition;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> write(@NotNull RandomDataInput bytes, long offset, long length)
+    public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException, BufferUnderflowException {
         if (length == 8) {
             writeLong(bytes.readLong(offset));
@@ -186,7 +187,8 @@ public class UncheckedBytes<Underlying>
     }
 
     @NotNull
-    public Bytes<Underlying> write(@NotNull BytesStore bytes, long offset, long length)
+    @Override
+    public Bytes<U> write(@NotNull BytesStore bytes, long offset, long length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException, BufferUnderflowException {
         if (length == 8) {
             writeLong(bytes.readLong(offset));
@@ -204,7 +206,7 @@ public class UncheckedBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> append8bit(@NotNull CharSequence cs)
+    public Bytes<U> append8bit(@NotNull CharSequence cs)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         if (cs instanceof RandomDataInput) {
             return write((RandomDataInput) cs);
@@ -234,7 +236,7 @@ public class UncheckedBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeByte(byte i8)
+    public Bytes<U> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(1, 1);
         bytesStore.writeByte(offset, i8);
@@ -243,7 +245,7 @@ public class UncheckedBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeUtf8(String s)
+    public Bytes<U> writeUtf8(String s)
             throws BufferOverflowException, IllegalStateException {
         if (s == null) {
             BytesInternal.writeStopBitNeg1(this);
@@ -284,7 +286,7 @@ public class UncheckedBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> appendUtf8(char[] chars, int offset, int length)
+    public Bytes<U> appendUtf8(char[] chars, int offset, int length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         long wp = writePosition();
         int i;

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
@@ -36,8 +36,8 @@ import static net.openhft.chronicle.core.util.StringUtils.extractChars;
  * Fast unchecked version of AbstractBytes
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class UncheckedBytes<U>
-        extends AbstractBytes<U> {
+public class UncheckedBytes<Underlying>
+        extends AbstractBytes<Underlying> {
     Bytes underlyingBytes;
 
     public UncheckedBytes(@NotNull Bytes underlyingBytes)
@@ -75,7 +75,7 @@ public class UncheckedBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> unchecked(boolean unchecked) {
+    public Bytes<Underlying> unchecked(boolean unchecked) {
         return this;
     }
 
@@ -101,49 +101,49 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> readPosition(long position) {
+    public Bytes<Underlying> readPosition(long position) {
         readPosition = position;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> readLimit(long limit) {
+    public Bytes<Underlying> readLimit(long limit) {
         uncheckedWritePosition(limit);
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> writePosition(long position) {
+    public Bytes<Underlying> writePosition(long position) {
         uncheckedWritePosition(position);
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> readSkip(long bytesToSkip) {
+    public Bytes<Underlying> readSkip(long bytesToSkip) {
         readPosition += bytesToSkip;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> writeSkip(long bytesToSkip) {
+    public Bytes<Underlying> writeSkip(long bytesToSkip) {
         uncheckedWritePosition(writePosition() + bytesToSkip);
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> writeLimit(long limit) {
+    public Bytes<Underlying> writeLimit(long limit) {
         writeLimit = limit;
         return this;
     }
 
     @NotNull
     @Override
-    public BytesStore<Bytes<U>, U> copy() {
+    public BytesStore<Bytes<Underlying>, Underlying> copy() {
         throw new UnsupportedOperationException("todo");
     }
 
@@ -175,7 +175,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
+    public Bytes<Underlying> write(@NotNull RandomDataInput bytes, long offset, long length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException, BufferUnderflowException {
         if (length == 8) {
             writeLong(bytes.readLong(offset));
@@ -188,7 +188,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull BytesStore bytes, long offset, long length)
+    public Bytes<Underlying> write(@NotNull BytesStore bytes, long offset, long length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException, BufferUnderflowException {
         if (length == 8) {
             writeLong(bytes.readLong(offset));
@@ -206,7 +206,7 @@ public class UncheckedBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> append8bit(@NotNull CharSequence cs)
+    public Bytes<Underlying> append8bit(@NotNull CharSequence cs)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         if (cs instanceof RandomDataInput) {
             return write((RandomDataInput) cs);
@@ -236,7 +236,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(byte i8)
+    public Bytes<Underlying> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(1, 1);
         bytesStore.writeByte(offset, i8);
@@ -245,7 +245,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeUtf8(String s)
+    public Bytes<Underlying> writeUtf8(String s)
             throws BufferOverflowException, IllegalStateException {
         if (s == null) {
             BytesInternal.writeStopBitNeg1(this);
@@ -286,7 +286,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> appendUtf8(char[] chars, int offset, int length)
+    public Bytes<Underlying> appendUtf8(char[] chars, int offset, int length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         long wp = writePosition();
         int i;

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedNativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedNativeBytes.java
@@ -37,23 +37,26 @@ import java.nio.ByteBuffer;
 
 /**
  * Fast unchecked version of AbstractBytes
+ *
+ * @param <U> Underlying type
+ *
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class UncheckedNativeBytes<Underlying>
+public class UncheckedNativeBytes<U>
         extends AbstractReferenceCounted
-        implements Bytes<Underlying> {
+        implements Bytes<U> {
     protected final long capacity;
     @NotNull
-    private final Bytes<Underlying> underlyingBytes;
+    private final Bytes<U> underlyingBytes;
     @NotNull
-    protected BytesStore<?, Underlying> bytesStore;
+    protected BytesStore<?, U> bytesStore;
     protected long readPosition;
     protected long writePosition;
     protected long writeLimit;
     private int lastDecimalPlaces = 0;
     private boolean lastNumberHadDigits = false;
 
-    public UncheckedNativeBytes(@NotNull Bytes<Underlying> underlyingBytes)
+    public UncheckedNativeBytes(@NotNull Bytes<U> underlyingBytes)
             throws IllegalStateException {
         this.underlyingBytes = underlyingBytes;
         underlyingBytes.reserve(this);
@@ -86,7 +89,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> unchecked(boolean unchecked) {
+    public Bytes<U> unchecked(boolean unchecked) {
         return this;
     }
 
@@ -98,7 +101,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> compact() {
+    public Bytes<U> compact() {
         try {
             long start = start();
             long readRemaining = readRemaining();
@@ -117,28 +120,28 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> readPosition(long position) {
+    public Bytes<U> readPosition(long position) {
         readPosition = position;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> readLimit(long limit) {
+    public Bytes<U> readLimit(long limit) {
         writePosition = limit;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> writePosition(long position) {
+    public Bytes<U> writePosition(long position) {
         writePosition = position;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> readSkip(long bytesToSkip) {
+    public Bytes<U> readSkip(long bytesToSkip) {
         readPosition += bytesToSkip;
         return this;
     }
@@ -179,21 +182,21 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeSkip(long bytesToSkip) {
+    public Bytes<U> writeSkip(long bytesToSkip) {
         writePosition += bytesToSkip;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLimit(long limit) {
+    public Bytes<U> writeLimit(long limit) {
         writeLimit = limit;
         return this;
     }
 
     @NotNull
     @Override
-    public BytesStore<Bytes<Underlying>, Underlying> copy() {
+    public BytesStore<Bytes<U>, U> copy() {
         throw new UnsupportedOperationException("todo");
     }
 
@@ -221,12 +224,13 @@ public class UncheckedNativeBytes<Underlying>
     }
 
     protected long prewriteOffsetPositionMoved(long substracting) {
-        return readPosition -= substracting;
+        readPosition -= substracting;
+        return readPosition;
     }
 
     @NotNull
     @Override
-    public Bytes<Underlying> write(@NotNull RandomDataInput bytes, long offset, long length)
+    public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         if (length == 8) {
             writeLong(bytes.readLong(offset));
@@ -254,7 +258,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> clear() {
+    public Bytes<U> clear() {
         readPosition = writePosition = start();
         writeLimit = capacity();
         return this;
@@ -262,7 +266,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> clearAndPad(long length)
+    public Bytes<U> clearAndPad(long length)
             throws BufferOverflowException {
         if (start() + length > capacity())
             throw new BufferOverflowException();
@@ -298,7 +302,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @Nullable
     @Override
-    public Underlying underlyingObject() {
+    public U underlyingObject() {
         return bytesStore.underlyingObject();
     }
 
@@ -412,7 +416,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeByte(long offset, byte i)
+    public Bytes<U> writeByte(long offset, byte i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeByte(offset, i);
@@ -421,7 +425,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeShort(long offset, short i)
+    public Bytes<U> writeShort(long offset, short i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeShort(offset, i);
@@ -430,7 +434,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeInt(long offset, int i)
+    public Bytes<U> writeInt(long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeInt(offset, i);
@@ -439,7 +443,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeOrderedInt(long offset, int i)
+    public Bytes<U> writeOrderedInt(long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeOrderedInt(offset, i);
@@ -448,7 +452,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLong(long offset, long i)
+    public Bytes<U> writeLong(long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeLong(offset, i);
@@ -457,7 +461,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeOrderedLong(long offset, long i)
+    public Bytes<U> writeOrderedLong(long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeOrderedLong(offset, i);
@@ -466,7 +470,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeFloat(long offset, float d)
+    public Bytes<U> writeFloat(long offset, float d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeFloat(offset, d);
@@ -475,7 +479,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeDouble(long offset, double d)
+    public Bytes<U> writeDouble(long offset, double d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeDouble(offset, d);
@@ -484,7 +488,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeVolatileByte(long offset, byte i8)
+    public Bytes<U> writeVolatileByte(long offset, byte i8)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeVolatileByte(offset, i8);
@@ -493,7 +497,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeVolatileShort(long offset, short i16)
+    public Bytes<U> writeVolatileShort(long offset, short i16)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeVolatileShort(offset, i16);
@@ -502,7 +506,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeVolatileInt(long offset, int i32)
+    public Bytes<U> writeVolatileInt(long offset, int i32)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeVolatileInt(offset, i32);
@@ -511,7 +515,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeVolatileLong(long offset, long i64)
+    public Bytes<U> writeVolatileLong(long offset, long i64)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeVolatileLong(offset, i64);
@@ -520,7 +524,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> write(long offsetInRDO, byte[] bytes, int offset, int length)
+    public Bytes<U> write(long offsetInRDO, byte[] bytes, int offset, int length)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offsetInRDO, length);
         bytesStore.write(offsetInRDO, bytes, offset, length);
@@ -536,8 +540,8 @@ public class UncheckedNativeBytes<Underlying>
 
     @Override
     @NotNull
-    public Bytes<Underlying> write(long writeOffset,
-                                   @NotNull RandomDataInput bytes, long readOffset, long length)
+    public Bytes<U> write(long writeOffset,
+                          @NotNull RandomDataInput bytes, long readOffset, long length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         writeCheckOffset(writeOffset, length);
         bytesStore.write(writeOffset, bytes, readOffset, length);
@@ -546,7 +550,7 @@ public class UncheckedNativeBytes<Underlying>
 
     void writeCheckOffset(long offset, long adding)
             throws BufferOverflowException {
-//        assert writeCheckOffset0(offset, adding);
+
     }
 
     @Override
@@ -591,7 +595,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeByte(byte i8) {
+    public Bytes<U> writeByte(byte i8) {
         long offset = writeOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
         return this;
@@ -599,7 +603,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewriteByte(byte i8) {
+    public Bytes<U> prewriteByte(byte i8) {
         long offset = prewriteOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
         return this;
@@ -607,7 +611,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeShort(short i16)
+    public Bytes<U> writeShort(short i16)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(2);
         bytesStore.writeShort(offset, i16);
@@ -616,7 +620,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewriteShort(short i16)
+    public Bytes<U> prewriteShort(short i16)
             throws IllegalStateException {
         long offset = prewriteOffsetPositionMoved(2);
         bytesStore.writeShort(offset, i16);
@@ -625,7 +629,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeInt(int i)
+    public Bytes<U> writeInt(int i)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeInt(offset, i);
@@ -634,7 +638,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeIntAdv(int i, int advance)
+    public Bytes<U> writeIntAdv(int i, int advance)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4, advance);
         bytesStore.writeInt(offset, i);
@@ -643,7 +647,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewriteInt(int i)
+    public Bytes<U> prewriteInt(int i)
             throws IllegalStateException {
         long offset = prewriteOffsetPositionMoved(4);
         bytesStore.writeInt(offset, i);
@@ -652,7 +656,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLong(long i64)
+    public Bytes<U> writeLong(long i64)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeLong(offset, i64);
@@ -661,7 +665,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeLongAdv(long i64, int advance)
+    public Bytes<U> writeLongAdv(long i64, int advance)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8, advance);
         bytesStore.writeLong(offset, i64);
@@ -670,7 +674,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewriteLong(long i64)
+    public Bytes<U> prewriteLong(long i64)
             throws IllegalStateException {
         long offset = prewriteOffsetPositionMoved(8);
         bytesStore.writeLong(offset, i64);
@@ -679,7 +683,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeFloat(float f)
+    public Bytes<U> writeFloat(float f)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeFloat(offset, f);
@@ -688,7 +692,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeDouble(double d)
+    public Bytes<U> writeDouble(double d)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeDouble(offset, d);
@@ -697,7 +701,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeDoubleAndInt(double d, int i)
+    public Bytes<U> writeDoubleAndInt(double d, int i)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(12);
         bytesStore.writeDouble(offset, d);
@@ -707,7 +711,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> write(@NotNull byte[] bytes, int offset, int length)
+    public Bytes<U> write(@NotNull byte[] bytes, int offset, int length)
             throws BufferOverflowException, IllegalStateException, ArrayIndexOutOfBoundsException {
         if (length + offset > bytes.length)
             throw new ArrayIndexOutOfBoundsException("bytes.length=" + bytes.length + ", " +
@@ -721,7 +725,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewrite(@NotNull byte[] bytes)
+    public Bytes<U> prewrite(@NotNull byte[] bytes)
             throws IllegalStateException, BufferOverflowException {
         long offsetInRDO = prewriteOffsetPositionMoved(bytes.length);
         bytesStore.write(offsetInRDO, bytes);
@@ -730,7 +734,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> prewrite(@NotNull BytesStore bytes)
+    public Bytes<U> prewrite(@NotNull BytesStore bytes)
             throws IllegalStateException, BufferOverflowException {
         long offsetInRDO = prewriteOffsetPositionMoved(bytes.length());
         bytesStore.write(offsetInRDO, bytes);
@@ -739,7 +743,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeSome(@NotNull ByteBuffer buffer)
+    public Bytes<U> writeSome(@NotNull ByteBuffer buffer)
             throws IllegalStateException {
         bytesStore.write(writePosition, buffer, buffer.position(), buffer.limit());
         writePosition += buffer.remaining();
@@ -749,7 +753,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeOrderedInt(int i)
+    public Bytes<U> writeOrderedInt(int i)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeOrderedInt(offset, i);
@@ -758,7 +762,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> writeOrderedLong(long i)
+    public Bytes<U> writeOrderedLong(long i)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeOrderedLong(offset, i);
@@ -854,13 +858,13 @@ public class UncheckedNativeBytes<Underlying>
     @Override
     public int byteCheckSum()
             throws IORuntimeException {
-        @Nullable NativeBytesStore bytesStore = (NativeBytesStore) bytesStore();
-        return bytesStore.byteCheckSum(readPosition(), readLimit());
+        @Nullable NativeBytesStore nativeBytesStore = (NativeBytesStore) bytesStore();
+        return nativeBytesStore.byteCheckSum(readPosition(), readLimit());
     }
 
     @Override
     @NotNull
-    public Bytes<Underlying> append8bit(@NotNull CharSequence cs)
+    public Bytes<U> append8bit(@NotNull CharSequence cs)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         if (cs instanceof BytesStore) {
             return write((BytesStore) cs);
@@ -887,7 +891,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> appendUtf8(char[] chars, int offset, int length)
+    public Bytes<U> appendUtf8(char[] chars, int offset, int length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         long actualUTF8Length = AppendableUtil.findUtf8Length(chars, offset, length);
         ensureCapacity(writePosition + actualUTF8Length);
@@ -919,7 +923,7 @@ public class UncheckedNativeBytes<Underlying>
 
     @NotNull
     @Override
-    public Bytes<Underlying> write(@NotNull RandomDataInput bytes)
+    public Bytes<U> write(@NotNull RandomDataInput bytes)
             throws IllegalStateException {
         assert bytes != this : "you should not write to yourself !";
 
@@ -940,7 +944,7 @@ public class UncheckedNativeBytes<Underlying>
         return bytesStore.write8bit(position, s, start, length);
     }
 
-    public Bytes<Underlying> write8bit(@Nullable BytesStore bs) throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
+    public Bytes<U> write8bit(@Nullable BytesStore bs) throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
         if (bs == null) {
             BytesInternal.writeStopBitNeg1(this);
 
@@ -958,7 +962,7 @@ public class UncheckedNativeBytes<Underlying>
     }
 
     @Override
-    public @NotNull Bytes<Underlying> write8bit(final @NotNull String s, final int start, final int length) {
+    public @NotNull Bytes<U> write8bit(final @NotNull String s, final int start, final int length) {
         final long toWriteLength = UnsafeMemory.INSTANCE.stopBitLength(length) + (long) length;
         final long position = writeOffsetPositionMoved(toWriteLength, 0);
         bytesStore.write8bit(position, s, start, length);

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedNativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedNativeBytes.java
@@ -38,25 +38,25 @@ import java.nio.ByteBuffer;
 /**
  * Fast unchecked version of AbstractBytes
  *
- * @param <U> Underlying type
+ * @param <Underlying> Underlying type
  *
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class UncheckedNativeBytes<U>
+public class UncheckedNativeBytes<Underlying>
         extends AbstractReferenceCounted
-        implements Bytes<U> {
+        implements Bytes<Underlying> {
     protected final long capacity;
     @NotNull
-    private final Bytes<U> underlyingBytes;
+    private final Bytes<Underlying> underlyingBytes;
     @NotNull
-    protected BytesStore<?, U> bytesStore;
+    protected BytesStore<?, Underlying> bytesStore;
     protected long readPosition;
     protected long writePosition;
     protected long writeLimit;
     private int lastDecimalPlaces = 0;
     private boolean lastNumberHadDigits = false;
 
-    public UncheckedNativeBytes(@NotNull Bytes<U> underlyingBytes)
+    public UncheckedNativeBytes(@NotNull Bytes<Underlying> underlyingBytes)
             throws IllegalStateException {
         this.underlyingBytes = underlyingBytes;
         underlyingBytes.reserve(this);
@@ -89,7 +89,7 @@ public class UncheckedNativeBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> unchecked(boolean unchecked) {
+    public Bytes<Underlying> unchecked(boolean unchecked) {
         return this;
     }
 
@@ -101,7 +101,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> compact() {
+    public Bytes<Underlying> compact() {
         try {
             long start = start();
             long readRemaining = readRemaining();
@@ -120,28 +120,28 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> readPosition(long position) {
+    public Bytes<Underlying> readPosition(long position) {
         readPosition = position;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> readLimit(long limit) {
+    public Bytes<Underlying> readLimit(long limit) {
         writePosition = limit;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> writePosition(long position) {
+    public Bytes<Underlying> writePosition(long position) {
         writePosition = position;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> readSkip(long bytesToSkip) {
+    public Bytes<Underlying> readSkip(long bytesToSkip) {
         readPosition += bytesToSkip;
         return this;
     }
@@ -182,21 +182,21 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeSkip(long bytesToSkip) {
+    public Bytes<Underlying> writeSkip(long bytesToSkip) {
         writePosition += bytesToSkip;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> writeLimit(long limit) {
+    public Bytes<Underlying> writeLimit(long limit) {
         writeLimit = limit;
         return this;
     }
 
     @NotNull
     @Override
-    public BytesStore<Bytes<U>, U> copy() {
+    public BytesStore<Bytes<Underlying>, Underlying> copy() {
         throw new UnsupportedOperationException("todo");
     }
 
@@ -230,7 +230,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
+    public Bytes<Underlying> write(@NotNull RandomDataInput bytes, long offset, long length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         if (length == 8) {
             writeLong(bytes.readLong(offset));
@@ -258,7 +258,7 @@ public class UncheckedNativeBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> clear() {
+    public Bytes<Underlying> clear() {
         readPosition = writePosition = start();
         writeLimit = capacity();
         return this;
@@ -266,7 +266,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> clearAndPad(long length)
+    public Bytes<Underlying> clearAndPad(long length)
             throws BufferOverflowException {
         if (start() + length > capacity())
             throw new BufferOverflowException();
@@ -302,7 +302,7 @@ public class UncheckedNativeBytes<U>
 
     @Nullable
     @Override
-    public U underlyingObject() {
+    public Underlying underlyingObject() {
         return bytesStore.underlyingObject();
     }
 
@@ -416,7 +416,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(long offset, byte i)
+    public Bytes<Underlying> writeByte(long offset, byte i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeByte(offset, i);
@@ -425,7 +425,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeShort(long offset, short i)
+    public Bytes<Underlying> writeShort(long offset, short i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeShort(offset, i);
@@ -434,7 +434,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeInt(long offset, int i)
+    public Bytes<Underlying> writeInt(long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeInt(offset, i);
@@ -443,7 +443,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedInt(long offset, int i)
+    public Bytes<Underlying> writeOrderedInt(long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeOrderedInt(offset, i);
@@ -452,7 +452,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLong(long offset, long i)
+    public Bytes<Underlying> writeLong(long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeLong(offset, i);
@@ -461,7 +461,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedLong(long offset, long i)
+    public Bytes<Underlying> writeOrderedLong(long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeOrderedLong(offset, i);
@@ -470,7 +470,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeFloat(long offset, float d)
+    public Bytes<Underlying> writeFloat(long offset, float d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeFloat(offset, d);
@@ -479,7 +479,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeDouble(long offset, double d)
+    public Bytes<Underlying> writeDouble(long offset, double d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeDouble(offset, d);
@@ -488,7 +488,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileByte(long offset, byte i8)
+    public Bytes<Underlying> writeVolatileByte(long offset, byte i8)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeVolatileByte(offset, i8);
@@ -497,7 +497,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileShort(long offset, short i16)
+    public Bytes<Underlying> writeVolatileShort(long offset, short i16)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeVolatileShort(offset, i16);
@@ -506,7 +506,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileInt(long offset, int i32)
+    public Bytes<Underlying> writeVolatileInt(long offset, int i32)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeVolatileInt(offset, i32);
@@ -515,7 +515,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileLong(long offset, long i64)
+    public Bytes<Underlying> writeVolatileLong(long offset, long i64)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeVolatileLong(offset, i64);
@@ -524,7 +524,7 @@ public class UncheckedNativeBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> write(long offsetInRDO, byte[] bytes, int offset, int length)
+    public Bytes<Underlying> write(long offsetInRDO, byte[] bytes, int offset, int length)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offsetInRDO, length);
         bytesStore.write(offsetInRDO, bytes, offset, length);
@@ -540,8 +540,8 @@ public class UncheckedNativeBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> write(long writeOffset,
-                          @NotNull RandomDataInput bytes, long readOffset, long length)
+    public Bytes<Underlying> write(long writeOffset,
+                                   @NotNull RandomDataInput bytes, long readOffset, long length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         writeCheckOffset(writeOffset, length);
         bytesStore.write(writeOffset, bytes, readOffset, length);
@@ -595,7 +595,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(byte i8) {
+    public Bytes<Underlying> writeByte(byte i8) {
         long offset = writeOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
         return this;
@@ -603,7 +603,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewriteByte(byte i8) {
+    public Bytes<Underlying> prewriteByte(byte i8) {
         long offset = prewriteOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
         return this;
@@ -611,7 +611,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeShort(short i16)
+    public Bytes<Underlying> writeShort(short i16)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(2);
         bytesStore.writeShort(offset, i16);
@@ -620,7 +620,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewriteShort(short i16)
+    public Bytes<Underlying> prewriteShort(short i16)
             throws IllegalStateException {
         long offset = prewriteOffsetPositionMoved(2);
         bytesStore.writeShort(offset, i16);
@@ -629,7 +629,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeInt(int i)
+    public Bytes<Underlying> writeInt(int i)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeInt(offset, i);
@@ -638,7 +638,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeIntAdv(int i, int advance)
+    public Bytes<Underlying> writeIntAdv(int i, int advance)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4, advance);
         bytesStore.writeInt(offset, i);
@@ -647,7 +647,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewriteInt(int i)
+    public Bytes<Underlying> prewriteInt(int i)
             throws IllegalStateException {
         long offset = prewriteOffsetPositionMoved(4);
         bytesStore.writeInt(offset, i);
@@ -656,7 +656,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLong(long i64)
+    public Bytes<Underlying> writeLong(long i64)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeLong(offset, i64);
@@ -665,7 +665,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLongAdv(long i64, int advance)
+    public Bytes<Underlying> writeLongAdv(long i64, int advance)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8, advance);
         bytesStore.writeLong(offset, i64);
@@ -674,7 +674,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewriteLong(long i64)
+    public Bytes<Underlying> prewriteLong(long i64)
             throws IllegalStateException {
         long offset = prewriteOffsetPositionMoved(8);
         bytesStore.writeLong(offset, i64);
@@ -683,7 +683,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeFloat(float f)
+    public Bytes<Underlying> writeFloat(float f)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeFloat(offset, f);
@@ -692,7 +692,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeDouble(double d)
+    public Bytes<Underlying> writeDouble(double d)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeDouble(offset, d);
@@ -701,7 +701,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeDoubleAndInt(double d, int i)
+    public Bytes<Underlying> writeDoubleAndInt(double d, int i)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(12);
         bytesStore.writeDouble(offset, d);
@@ -711,7 +711,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull byte[] bytes, int offset, int length)
+    public Bytes<Underlying> write(@NotNull byte[] bytes, int offset, int length)
             throws BufferOverflowException, IllegalStateException, ArrayIndexOutOfBoundsException {
         if (length + offset > bytes.length)
             throw new ArrayIndexOutOfBoundsException("bytes.length=" + bytes.length + ", " +
@@ -725,7 +725,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewrite(@NotNull byte[] bytes)
+    public Bytes<Underlying> prewrite(@NotNull byte[] bytes)
             throws IllegalStateException, BufferOverflowException {
         long offsetInRDO = prewriteOffsetPositionMoved(bytes.length);
         bytesStore.write(offsetInRDO, bytes);
@@ -734,7 +734,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> prewrite(@NotNull BytesStore bytes)
+    public Bytes<Underlying> prewrite(@NotNull BytesStore bytes)
             throws IllegalStateException, BufferOverflowException {
         long offsetInRDO = prewriteOffsetPositionMoved(bytes.length());
         bytesStore.write(offsetInRDO, bytes);
@@ -743,7 +743,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeSome(@NotNull ByteBuffer buffer)
+    public Bytes<Underlying> writeSome(@NotNull ByteBuffer buffer)
             throws IllegalStateException {
         bytesStore.write(writePosition, buffer, buffer.position(), buffer.limit());
         writePosition += buffer.remaining();
@@ -753,7 +753,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedInt(int i)
+    public Bytes<Underlying> writeOrderedInt(int i)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4);
         bytesStore.writeOrderedInt(offset, i);
@@ -762,7 +762,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedLong(long i)
+    public Bytes<Underlying> writeOrderedLong(long i)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8);
         bytesStore.writeOrderedLong(offset, i);
@@ -864,7 +864,7 @@ public class UncheckedNativeBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> append8bit(@NotNull CharSequence cs)
+    public Bytes<Underlying> append8bit(@NotNull CharSequence cs)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         if (cs instanceof BytesStore) {
             return write((BytesStore) cs);
@@ -891,7 +891,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> appendUtf8(char[] chars, int offset, int length)
+    public Bytes<Underlying> appendUtf8(char[] chars, int offset, int length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         long actualUTF8Length = AppendableUtil.findUtf8Length(chars, offset, length);
         ensureCapacity(writePosition + actualUTF8Length);
@@ -923,7 +923,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull RandomDataInput bytes)
+    public Bytes<Underlying> write(@NotNull RandomDataInput bytes)
             throws IllegalStateException {
         assert bytes != this : "you should not write to yourself !";
 
@@ -944,7 +944,7 @@ public class UncheckedNativeBytes<U>
         return bytesStore.write8bit(position, s, start, length);
     }
 
-    public Bytes<U> write8bit(@Nullable BytesStore bs) throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
+    public Bytes<Underlying> write8bit(@Nullable BytesStore bs) throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
         if (bs == null) {
             BytesInternal.writeStopBitNeg1(this);
 
@@ -962,7 +962,7 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public @NotNull Bytes<U> write8bit(final @NotNull String s, final int start, final int length) {
+    public @NotNull Bytes<Underlying> write8bit(final @NotNull String s, final int start, final int length) {
         final long toWriteLength = UnsafeMemory.INSTANCE.stopBitLength(length) + (long) length;
         final long position = writeOffsetPositionMoved(toWriteLength, 0);
         bytesStore.write8bit(position, s, start, length);

--- a/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
@@ -36,12 +36,12 @@
     /**
      * Simple Bytes implementation which is not Elastic.
      *
-     * @param <U> Underlying type
+     * @param <Underlying> Underlying type
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public class VanillaBytes<U>
-            extends AbstractBytes<U>
-            implements Byteable<Bytes<U>, U>, Comparable<CharSequence> {
+    public class VanillaBytes<Underlying>
+            extends AbstractBytes<Underlying>
+            implements Byteable<Bytes<Underlying>, Underlying>, Comparable<CharSequence> {
 
         @Deprecated(/* make protected in x.23, used in Chronicle-Map */)
         public VanillaBytes(@NotNull BytesStore bytesStore)
@@ -158,7 +158,7 @@
         }
 
         @Override
-        public void bytesStore(@NotNull BytesStore<Bytes<U>, U> byteStore, long offset, long length)
+        public void bytesStore(@NotNull BytesStore<Bytes<Underlying>, Underlying> byteStore, long offset, long length)
                 throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
             setBytesStore(byteStore);
             // assume its read-only
@@ -171,7 +171,7 @@
             }
         }
 
-        private void setBytesStore(@NotNull BytesStore<Bytes<U>, U> bytesStore)
+        private void setBytesStore(@NotNull BytesStore<Bytes<Underlying>, Underlying> bytesStore)
                 throws IllegalStateException, IllegalArgumentException {
             if (this.bytesStore != bytesStore) {
                 @Nullable BytesStore oldBS = this.bytesStore;
@@ -199,7 +199,7 @@
 
         @NotNull
         @Override
-        public Bytes<U> bytesForRead()
+        public Bytes<Underlying> bytesForRead()
                 throws IllegalStateException {
             try {
                 return isClear()
@@ -252,7 +252,7 @@
 
         @NotNull
         @Override
-        public BytesStore<Bytes<U>, U> copy()
+        public BytesStore<Bytes<Underlying>, Underlying> copy()
                 throws IllegalStateException {
             ReportUnoptimised.reportOnce();
 
@@ -276,7 +276,7 @@
 
         @NotNull
         @Override
-        public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
+        public Bytes<Underlying> write(@NotNull RandomDataInput bytes, long offset, long length)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
             ensureCapacity(writePosition() + length);
             optimisedWrite(bytes, offset, length);
@@ -386,7 +386,7 @@
 
         @Override
         @NotNull
-        public Bytes<U> append8bit(@NotNull CharSequence cs)
+        public Bytes<Underlying> append8bit(@NotNull CharSequence cs)
                 throws BufferOverflowException, BufferUnderflowException, IndexOutOfBoundsException, IllegalStateException {
             if (cs instanceof RandomDataInput)
                 return write((RandomDataInput) cs);
@@ -398,7 +398,7 @@
 
         @Override
         @NotNull
-        public Bytes<U> append8bit(@NotNull BytesStore bs)
+        public Bytes<Underlying> append8bit(@NotNull BytesStore bs)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
             long remaining = bs.readLimit() - bs.readPosition();
             try {
@@ -410,7 +410,7 @@
 
         @NotNull
         @Override
-        public Bytes<U> write(@NotNull BytesStore bytes, long offset, long length)
+        public Bytes<Underlying> write(@NotNull BytesStore bytes, long offset, long length)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
             ensureCapacity(writePosition() + length);
             if (length == (int) length) {
@@ -434,7 +434,7 @@
 
         @Override
         @NotNull
-        public Bytes<U> append8bit(@NotNull String cs)
+        public Bytes<Underlying> append8bit(@NotNull String cs)
                 throws BufferOverflowException, IllegalStateException {
             if (isDirectMemory())
                 return append8bitNBS_S(cs);
@@ -442,7 +442,7 @@
         }
 
         @NotNull
-        private Bytes<U> append8bitNBS_S(@NotNull String s)
+        private Bytes<Underlying> append8bitNBS_S(@NotNull String s)
                 throws BufferOverflowException, IllegalStateException {
             int length = s.length();
             long offset = writeOffsetPositionMoved(length); // can re-assign the byteStore if not large enough.
@@ -521,7 +521,7 @@
         }
 
         @NotNull
-        protected Bytes<U> append8bit0(@NotNull CharSequence cs)
+        protected Bytes<Underlying> append8bit0(@NotNull CharSequence cs)
                 throws BufferOverflowException, IllegalStateException {
             int length = cs.length();
             long offset = writeOffsetPositionMoved(length);
@@ -608,7 +608,7 @@
 
         @NotNull
         @Override
-        public Bytes<U> appendUtf8(char[] chars, int offset, int length)
+        public Bytes<Underlying> appendUtf8(char[] chars, int offset, int length)
                 throws BufferOverflowException, IllegalStateException, BufferUnderflowException, IllegalArgumentException {
             long actualUTF8Length = AppendableUtil.findUtf8Length(chars, offset, length);
             ensureCapacity(writePosition() + actualUTF8Length);

--- a/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
@@ -35,11 +35,13 @@
 
     /**
      * Simple Bytes implementation which is not Elastic.
+     *
+     * @param <U> Underlying type
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public class VanillaBytes<Underlying>
-            extends AbstractBytes<Underlying>
-            implements Byteable<Bytes<Underlying>, Underlying>, Comparable<CharSequence> {
+    public class VanillaBytes<U>
+            extends AbstractBytes<U>
+            implements Byteable<Bytes<U>, U>, Comparable<CharSequence> {
 
         @Deprecated(/* make protected in x.23, used in Chronicle-Map */)
         public VanillaBytes(@NotNull BytesStore bytesStore)
@@ -156,7 +158,7 @@
         }
 
         @Override
-        public void bytesStore(@NotNull BytesStore<Bytes<Underlying>, Underlying> byteStore, long offset, long length)
+        public void bytesStore(@NotNull BytesStore<Bytes<U>, U> byteStore, long offset, long length)
                 throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
             setBytesStore(byteStore);
             // assume its read-only
@@ -169,7 +171,7 @@
             }
         }
 
-        private void setBytesStore(@NotNull BytesStore<Bytes<Underlying>, Underlying> bytesStore)
+        private void setBytesStore(@NotNull BytesStore<Bytes<U>, U> bytesStore)
                 throws IllegalStateException, IllegalArgumentException {
             if (this.bytesStore != bytesStore) {
                 @Nullable BytesStore oldBS = this.bytesStore;
@@ -197,7 +199,7 @@
 
         @NotNull
         @Override
-        public Bytes<Underlying> bytesForRead()
+        public Bytes<U> bytesForRead()
                 throws IllegalStateException {
             try {
                 return isClear()
@@ -250,7 +252,7 @@
 
         @NotNull
         @Override
-        public BytesStore<Bytes<Underlying>, Underlying> copy()
+        public BytesStore<Bytes<U>, U> copy()
                 throws IllegalStateException {
             ReportUnoptimised.reportOnce();
 
@@ -274,7 +276,7 @@
 
         @NotNull
         @Override
-        public Bytes<Underlying> write(@NotNull RandomDataInput bytes, long offset, long length)
+        public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
             ensureCapacity(writePosition() + length);
             optimisedWrite(bytes, offset, length);
@@ -384,7 +386,7 @@
 
         @Override
         @NotNull
-        public Bytes<Underlying> append8bit(@NotNull CharSequence cs)
+        public Bytes<U> append8bit(@NotNull CharSequence cs)
                 throws BufferOverflowException, BufferUnderflowException, IndexOutOfBoundsException, IllegalStateException {
             if (cs instanceof RandomDataInput)
                 return write((RandomDataInput) cs);
@@ -396,7 +398,7 @@
 
         @Override
         @NotNull
-        public Bytes<Underlying> append8bit(@NotNull BytesStore bs)
+        public Bytes<U> append8bit(@NotNull BytesStore bs)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
             long remaining = bs.readLimit() - bs.readPosition();
             try {
@@ -408,7 +410,7 @@
 
         @NotNull
         @Override
-        public Bytes<Underlying> write(@NotNull BytesStore bytes, long offset, long length)
+        public Bytes<U> write(@NotNull BytesStore bytes, long offset, long length)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
             ensureCapacity(writePosition() + length);
             if (length == (int) length) {
@@ -432,7 +434,7 @@
 
         @Override
         @NotNull
-        public Bytes<Underlying> append8bit(@NotNull String cs)
+        public Bytes<U> append8bit(@NotNull String cs)
                 throws BufferOverflowException, IllegalStateException {
             if (isDirectMemory())
                 return append8bitNBS_S(cs);
@@ -440,7 +442,7 @@
         }
 
         @NotNull
-        private Bytes<Underlying> append8bitNBS_S(@NotNull String s)
+        private Bytes<U> append8bitNBS_S(@NotNull String s)
                 throws BufferOverflowException, IllegalStateException {
             int length = s.length();
             long offset = writeOffsetPositionMoved(length); // can re-assign the byteStore if not large enough.
@@ -449,8 +451,10 @@
             final long address = bytesStore.address + bytesStore.translate(offset);
             @Nullable final Memory memory = bytesStore.memory;
 
-            if (memory == null)
+            if (memory == null) {
                 bytesStore.throwExceptionIfReleased();
+                throw new NullPointerException("byteStore.memory is null.");
+            }
 
             if (Jvm.isJava9Plus()) {
                 final byte[] chars = StringUtils.extractBytes(s);
@@ -477,6 +481,7 @@
             return this;
         }
 
+        @Override
         @NotNull
         public String toString() {
             try {
@@ -516,7 +521,7 @@
         }
 
         @NotNull
-        protected Bytes<Underlying> append8bit0(@NotNull CharSequence cs)
+        protected Bytes<U> append8bit0(@NotNull CharSequence cs)
                 throws BufferOverflowException, IllegalStateException {
             int length = cs.length();
             long offset = writeOffsetPositionMoved(length);
@@ -603,7 +608,7 @@
 
         @NotNull
         @Override
-        public Bytes<Underlying> appendUtf8(char[] chars, int offset, int length)
+        public Bytes<U> appendUtf8(char[] chars, int offset, int length)
                 throws BufferOverflowException, IllegalStateException, BufferUnderflowException, IllegalArgumentException {
             long actualUTF8Length = AppendableUtil.findUtf8Length(chars, offset, length);
             ensureCapacity(writePosition() + actualUTF8Length);

--- a/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
@@ -30,13 +30,13 @@ import java.util.function.ToLongFunction;
 @SuppressWarnings("rawtypes")
 public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> {
     static long hash(@NotNull BytesStore b) {
-        return b.isDirectMemory() && b.isDirectMemory()
+        return b.isDirectMemory()
                 ? OptimisedBytesStoreHash.INSTANCE.applyAsLong(b)
                 : VanillaBytesStoreHash.INSTANCE.applyAsLong(b);
     }
 
     static long hash(@NotNull BytesStore b, long length) throws IllegalStateException, BufferUnderflowException {
-        return b.isDirectMemory() && b.isDirectMemory()
+        return b.isDirectMemory()
                 ? OptimisedBytesStoreHash.INSTANCE.applyAsLong(b, length)
                 : VanillaBytesStoreHash.INSTANCE.applyAsLong(b, length);
     }

--- a/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
@@ -23,7 +23,6 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Memory;
 import net.openhft.chronicle.core.OS;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.nio.BufferUnderflowException;
 import java.nio.ByteOrder;
@@ -34,7 +33,6 @@ import static net.openhft.chronicle.bytes.algo.VanillaBytesStoreHash.*;
 public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
     INSTANCE;
 
-    @Nullable
     public static final Memory MEMORY = OS.memory();
     public static final boolean IS_LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
     private static final int TOP_BYTES = IS_LITTLE_ENDIAN ? 4 : 0;

--- a/src/main/java/net/openhft/chronicle/bytes/internal/AbstractBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/AbstractBytesStore.java
@@ -28,12 +28,12 @@ import java.nio.BufferUnderflowException;
 /**
  * Abstract BytesStore
  * @param <B> ByteStore type
- * @param <U> Underlying type
+ * @param <Underlying> Underlying type
  */
 
-public abstract class AbstractBytesStore<B extends BytesStore<B, U>, U>
+public abstract class AbstractBytesStore<B extends BytesStore<B, Underlying>, Underlying>
         extends AbstractReferenceCounted
-        implements BytesStore<B, U> {
+        implements BytesStore<B, Underlying> {
 
     protected AbstractBytesStore() {
     }

--- a/src/main/java/net/openhft/chronicle/bytes/internal/AbstractBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/AbstractBytesStore.java
@@ -25,9 +25,15 @@ import net.openhft.chronicle.core.io.AbstractReferenceCounted;
 
 import java.nio.BufferUnderflowException;
 
-public abstract class AbstractBytesStore<B extends BytesStore<B, Underlying>, Underlying>
+/**
+ * Abstract BytesStore
+ * @param <B> ByteStore type
+ * @param <U> Underlying type
+ */
+
+public abstract class AbstractBytesStore<B extends BytesStore<B, U>, U>
         extends AbstractReferenceCounted
-        implements BytesStore<B, Underlying> {
+        implements BytesStore<B, U> {
 
     protected AbstractBytesStore() {
     }

--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesFieldInfo.java
@@ -33,7 +33,10 @@ public class BytesFieldInfo {
         List<Field> fields = fields(aClass);
         String prefix0 = "";
         BFIEntry entry = null;
-        int longs = 0, ints = 0, shorts = 0, bytes = 0;
+        int longs = 0;
+        int ints = 0;
+        int shorts = 0;
+        int bytes = 0;
         boolean nonHeader = false;
         boolean hasHeader = false;
         for (int i = 0; i <= fields.size(); i++) {
@@ -73,9 +76,12 @@ public class BytesFieldInfo {
                         assert !hasHeader || (ints == 0 && shorts == 0 && bytes == 0);
                         longs++;
                         break;
+                    default:
+                        throw new UnsupportedOperationException("Primitive types of size " + size + " not supported");
                 }
             }
             if (matches) {
+                assert entry != null;
                 entry.end = position + size;
 
             } else if (!prefix.isEmpty()) {
@@ -96,11 +102,11 @@ public class BytesFieldInfo {
         assert ints < 256;
         assert shorts < 128;
         assert bytes < 256;
-        int description = (longs << 24) | (ints << 16) | (shorts << 8) | bytes;
+        int newDescription = (longs << 24) | (ints << 16) | (shorts << 8) | bytes;
         // ensure the header has an odd parity as a validity check
-        if (Integer.bitCount(description) % 2 == 0)
-            description |= 0x8000;
-        this.description = description;
+        if (Integer.bitCount(newDescription) % 2 == 0)
+            newDescription |= 0x8000;
+        this.description = newDescription;
     }
 
     private static int sizeOf(Class<?> type) {
@@ -112,7 +118,8 @@ public class BytesFieldInfo {
     }
 
     static class BFIEntry {
-        long start, end;
+        long start;
+        long end;
     }
 
     private static BytesFieldInfo init(Class<?> aClass) {
@@ -150,7 +157,7 @@ public class BytesFieldInfo {
     }
 
     // internal only
-    public static List<Field> fields(Class clazz) {
+    public static List<Field> fields(Class<?> clazz) {
         List<Field> fields = new ArrayList<>();
         while (clazz != null && clazz != Object.class) {
             Collections.addAll(fields, clazz.getDeclaredFields());

--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -64,7 +64,14 @@ import static net.openhft.chronicle.core.util.StringUtils.*;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public
 enum BytesInternal {
+
     ; // none
+    private static final String INFINITY = "Infinity";
+    private static final String MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END = "malformed input: partial character at end";
+    private static final String MALFORMED_INPUT_AROUND_BYTE = "malformed input around byte ";
+    private static final String WAS = " was ";
+    private static final String CAN_T_PARSE_FLEXIBLE_LONG_WITHOUT_PRECISION_LOSS = "Can't parse flexible long without precision loss: ";
+
     static final char[] HEXADECIMAL = "0123456789abcdef".toCharArray();
     public static final ThreadLocal<ByteBuffer> BYTE_BUFFER_TL = ThreadLocal.withInitial(() -> ByteBuffer.allocateDirect(0));
     public static final ThreadLocal<ByteBuffer> BYTE_BUFFER2_TL = ThreadLocal.withInitial(() -> ByteBuffer.allocateDirect(0));
@@ -72,7 +79,7 @@ enum BytesInternal {
     private static final StringBuilderPool SBP = new StringBuilderPool();
     private static final BytesPool BP = new BytesPool();
     public static final StringInternerBytes SI;
-    private static final byte[] Infinity = "Infinity".getBytes(ISO_8859_1);
+    private static final byte[] Infinity = INFINITY.getBytes(ISO_8859_1);
     private static final byte[] NaN = "NaN".getBytes(ISO_8859_1);
     private static final long MAX_VALUE_DIVIDE_5 = Long.MAX_VALUE / 5;
     private static final ThreadLocal<byte[]> NUMBER_BUFFER = ThreadLocal.withInitial(() -> new byte[20]);
@@ -314,7 +321,7 @@ enum BytesInternal {
                     /* 110x xxxx 10xx xxxx */
                     if (offset == limit)
                         throw new UTFDataFormatRuntimeException(
-                                "malformed input: partial character at end");
+                                MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
                     int char2 = input.readUnsignedByte(offset++);
                     if ((char2 & 0xC0) != 0x80)
                         throw newUTFDataFormatRuntimeException((offset - limit + utfLen), "was " + char2);
@@ -329,14 +336,14 @@ enum BytesInternal {
                     /* 1110 xxxx 10xx xxxx 10xx xxxx */
                     if (offset + 2 > limit)
                         throw new UTFDataFormatRuntimeException(
-                                "malformed input: partial character at end");
+                                MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
                     int char2 = input.readUnsignedByte(offset++);
                     int char3 = input.readUnsignedByte(offset++);
 
                     if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80))
                         throw new UTFDataFormatRuntimeException(
-                                "malformed input around byte " + (offset - limit + utfLen - 1) +
-                                        " was " + char2 + " " + char3);
+                                MALFORMED_INPUT_AROUND_BYTE + (offset - limit + utfLen - 1) +
+                                        WAS + char2 + " " + char3);
                     int c3 = (char) (((c & 0x0F) << 12) |
                             ((char2 & 0x3F) << 6) |
                             (char3 & 0x3F));
@@ -602,11 +609,11 @@ enum BytesInternal {
                     count += utf ? 2 : 1;
                     if (count > length)
                         throw new UTFDataFormatRuntimeException(
-                                "malformed input: partial character at end");
+                                MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
                     int char2 = bytes.readUnsignedByte();
                     if ((char2 & 0xC0) != 0x80)
                         throw new UTFDataFormatRuntimeException(
-                                "malformed input around byte " + count + " was " + char2);
+                                MALFORMED_INPUT_AROUND_BYTE + count + WAS + char2);
                     int c2 = (char) (((c & 0x1F) << 6) |
                             (char2 & 0x3F));
                     appendable.append((char) c2);
@@ -618,12 +625,12 @@ enum BytesInternal {
                     count += utf ? 3 : 1;
                     if (count > length)
                         throw new UTFDataFormatRuntimeException(
-                                "malformed input: partial character at end");
+                                MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
                     int char2 = bytes.readUnsignedByte();
                     int char3 = bytes.readUnsignedByte();
 
                     if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80))
-                        throw newUTFDataFormatRuntimeException(count - 1, " was " + char2 + " " + char3);
+                        throw newUTFDataFormatRuntimeException(count - 1L, WAS + char2 + " " + char3);
                     int c3 = (char) (((c & 0x0F) << 12) |
                             ((char2 & 0x3F) << 6) |
                             (char3 & 0x3F));
@@ -661,7 +668,7 @@ enum BytesInternal {
                     /* 110x xxxx 10xx xxxx */
                     if (offset == limit)
                         throw new UTFDataFormatRuntimeException(
-                                "malformed input: partial character at end");
+                                MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
                     int char2 = input.readUnsignedByte(offset++);
                     if ((char2 & 0xC0) != 0x80)
                         throw newUTFDataFormatRuntimeException(offset - limit + utflen, "was " + char2);
@@ -675,12 +682,12 @@ enum BytesInternal {
                     /* 1110 xxxx 10xx xxxx 10xx xxxx */
                     if (offset + 2 > limit)
                         throw new UTFDataFormatRuntimeException(
-                                "malformed input: partial character at end");
+                                MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
                     int char2 = input.readUnsignedByte(offset++);
                     int char3 = input.readUnsignedByte(offset++);
 
                     if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80))
-                        throw newUTFDataFormatRuntimeException(offset - limit + utflen - 1, " was " + char2 + " " + char3);
+                        throw newUTFDataFormatRuntimeException(offset - limit + utflen - 1, WAS + char2 + " " + char3);
                     int c3 = (char) (((c & 0x0F) << 12) |
                             ((char2 & 0x3F) << 6) |
                             (char3 & 0x3F));
@@ -1478,7 +1485,7 @@ enum BytesInternal {
             out.writeUnsignedByte(offset++, '.');
             while (decimalPlaces-- > digits)
                 out.writeUnsignedByte(offset++, '0');
-            out.write(offset++, numberBuffer, endIndex, digits);
+            out.write(offset, numberBuffer, endIndex, digits);
             return;
         } else {
             int numDigitsRequired = digits + 1;
@@ -1494,30 +1501,12 @@ enum BytesInternal {
         out.write(offset, numberBuffer, endIndex, decimalLength);
         offset += decimalLength;
         out.writeUnsignedByte(offset++, '.');
-        out.write(offset++, numberBuffer, endIndex + decimalLength, digits - decimalLength);
+        out.write(offset, numberBuffer, endIndex + decimalLength, digits - decimalLength);
     }
 
     private static void numberTooLarge(int digits)
             throws IllegalArgumentException {
         throw new IllegalArgumentException("Number too large for " + digits + "digits");
-    }
-
-    private static void appendInt0(@NotNull StreamingDataOutput out, int num)
-            throws IllegalArgumentException, BufferOverflowException, IllegalStateException {
-        if (num < 10) {
-            out.rawWriteByte((byte) ('0' + num));
-
-        } else if (num < 100) {
-            out.writeShort((short) (num / 10 + (num % 10 << 8) + '0' * 0x101));
-
-        } else {
-            byte[] numberBuffer = NUMBER_BUFFER.get();
-            // Extract digits into the end of the numberBuffer
-            int endIndex = appendInt1(numberBuffer, num);
-
-            // Bulk copy the digits into the front of the buffer
-            out.write(numberBuffer, endIndex, numberBuffer.length - endIndex);
-        }
     }
 
     private static void appendLong0(@NotNull StreamingDataOutput out, long num)
@@ -1950,7 +1939,6 @@ enum BytesInternal {
                         return;
                     }
                     chars[i] = (char) c;
-//            appendable.appendDouble((char) c);
                 }
             }
             StringUtils.setCount(appendable, i);
@@ -2020,11 +2008,11 @@ enum BytesInternal {
     }
 
     private static UTFDataFormatException newUTFDataFormatException(final long offset, final String suffix) {
-        return new UTFDataFormatException("malformed input around byte " + offset + " " + suffix);
+        return new UTFDataFormatException(MALFORMED_INPUT_AROUND_BYTE + offset + " " + suffix);
     }
 
     private static UTFDataFormatRuntimeException newUTFDataFormatRuntimeException(final long offset, final String suffix) {
-        return new UTFDataFormatRuntimeException("malformed input around byte " + offset + " " + suffix);
+        return new UTFDataFormatRuntimeException(MALFORMED_INPUT_AROUND_BYTE + offset + " " + suffix);
     }
 
     private static void readUtf81(@NotNull StreamingDataInput bytes, @NotNull Appendable appendable, @NotNull StopCharTester tester)
@@ -2087,7 +2075,7 @@ enum BytesInternal {
 
                     if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80))
                         throw new UTFDataFormatException(
-                                "malformed input around byte ");
+                                MALFORMED_INPUT_AROUND_BYTE);
                     int c3 = (char) (((c & 0x0F) << 12) |
                             ((char2 & 0x3F) << 6) |
                             (char3 & 0x3F));
@@ -2100,7 +2088,7 @@ enum BytesInternal {
                 default:
                     /* 10xx xxxx, 1111 xxxx */
                     throw new UTFDataFormatException(
-                            "malformed input around byte ");
+                            MALFORMED_INPUT_AROUND_BYTE);
             }
         }
     }
@@ -2213,11 +2201,13 @@ enum BytesInternal {
                     in.readSkip(-1);
                     throw new IORuntimeException("Expected flexible long, but got: I");
                 case '-':
-                    if (compareRest(in, "Infinity"))
+                    if (compareRest(in, INFINITY))
                         throw new IORuntimeException("Expected flexible long, but got: -Infinity");
                     sign = -1;
                     ch = in.rawReadByte();
                     break;
+                default:
+                    // Do nothing
             }
 
             int tens = 0;
@@ -2229,7 +2219,7 @@ enum BytesInternal {
                         if (ch == '0')
                             tens++;
                         else if (parsingError == null) {
-                            parsingError = new IORuntimeException("Can't parse flexible long without precision loss: " +
+                            parsingError = new IORuntimeException(CAN_T_PARSE_FLEXIBLE_LONG_WITHOUT_PRECISION_LOSS +
                                     (sign * absValue) + " <- " + ((char) ch));
                         }
 
@@ -2237,7 +2227,7 @@ enum BytesInternal {
                         if (ch <= '7' || (sign < 0 && ch == '8'))
                             absValue = absValue * 10 + (ch - '0');
                         else if (parsingError == null) {
-                            parsingError = new IORuntimeException("Can't parse flexible long without precision loss: " +
+                            parsingError = new IORuntimeException(CAN_T_PARSE_FLEXIBLE_LONG_WITHOUT_PRECISION_LOSS +
                                     (sign * absValue) + " <- " + ((char) ch));
                         }
                     } else {
@@ -2279,7 +2269,7 @@ enum BytesInternal {
                     int truncatingDigit = (int) Math.abs(absValue % 10);
 
                     if (truncatingDigit != 0) {
-                        throw new IORuntimeException("Can't parse flexible long without precision loss: " +
+                        throw new IORuntimeException(CAN_T_PARSE_FLEXIBLE_LONG_WITHOUT_PRECISION_LOSS +
                                 "division of " + absValue + " by 10");
                     }
 
@@ -2333,11 +2323,13 @@ enum BytesInternal {
                     in.readSkip(-1);
                     return Double.NaN;
                 case '-':
-                    if (compareRest(in, "Infinity"))
+                    if (compareRest(in, INFINITY))
                         return Double.NEGATIVE_INFINITY;
                     negative = true;
                     ch = in.rawReadByte();
                     break;
+                default:
+                    // do nothing
             }
             int tens = 0;
             while (true) {
@@ -2421,7 +2413,6 @@ enum BytesInternal {
         }
         while (in.readRemaining() > 0) {
             b = in.rawReadByte();
-            // if (b >= '0' && b <= '9')
             if ((b - ('0' + Integer.MIN_VALUE)) <= 9 + Integer.MIN_VALUE) {
                 num = num * 10 + b - '0';
                 digits = true;
@@ -2448,13 +2439,10 @@ enum BytesInternal {
         long num = 0;
         while (in.readRemaining() > 0) {
             int b = in.readUnsignedByte();
-            // if (b >= '0' && b <= '9')
             if ((b - ('0' + Integer.MIN_VALUE)) <= 9 + Integer.MIN_VALUE) {
                 num = (num << 4) + b - '0';
-                // if (b >= 'A' && b <= 'F')
             } else if ((b - ('A' + Integer.MIN_VALUE)) < 6 + Integer.MIN_VALUE) {
                 num = (num << 4) + b - ('A' - 10);
-                // if (b >= 'a' && b <= 'f')
             } else if ((b - ('a' + Integer.MIN_VALUE)) < 6 + Integer.MIN_VALUE) {
                 num = (num << 4) + b - ('a' - 10);
             } else if (b == ']' || b == '}') {
@@ -2488,10 +2476,10 @@ enum BytesInternal {
         long num = 0;
         boolean negative = false;
         int decimalPlaces = Integer.MIN_VALUE;
-        boolean digits = false, first = true;
+        boolean digits = false;
+        boolean first = true;
         while (in.readRemaining() > 0) {
             int b = in.readUnsignedByte();
-            // if (b >= '0' && b <= '9')
             if ((b - ('0' + Integer.MIN_VALUE)) <= 9 + Integer.MIN_VALUE) {
                 num = num * 10 + b - '0';
                 decimalPlaces++;
@@ -2524,7 +2512,6 @@ enum BytesInternal {
         long num = 0;
         while (in.readRemaining() > 0) {
             int b = in.readUnsignedByte();
-            // if (b >= '0' && b <= '9')
             if ((b - ('0' + Integer.MIN_VALUE)) <= 9 + Integer.MIN_VALUE) {
                 num = num * 16 + b - '0';
             } else if ((b - ('A' + Integer.MIN_VALUE)) <= 6 + Integer.MIN_VALUE) {
@@ -2549,7 +2536,6 @@ enum BytesInternal {
         boolean negative = false;
         while (true) {
             int b = in.peekUnsignedByte(offset++);
-            // if (b >= '0' && b <= '9')
             if ((b - ('0' + Integer.MIN_VALUE)) <= 9 + Integer.MIN_VALUE)
                 num = num * 10 + b - '0';
             else if (b == '-')

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -52,6 +52,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         super(mappedFile, name);
     }
 
+    @Override
     public @NotNull ChunkedMappedBytes write(final long offsetInRDO,
                                              final byte[] bytes,
                                              int offset,
@@ -93,6 +94,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
     }
 
+    @Override
     public @NotNull ChunkedMappedBytes write(final long writeOffset,
                                              final RandomDataInput bytes,
                                              long readOffset,
@@ -253,15 +255,14 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
         throwExceptionIfClosed();
         if (offset < 0 || offset > mappedFile.capacity() - adding)
-            throw writeBufferOverflowException(offset);
+            throw writeBufferOverflowException0(offset);
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, checkSize(adding))) {
+        if (!bytesStore.inside(offset, checkSize0(adding))) {
             acquireNextByteStore0(offset, false);
         }
-//        super.writeCheckOffset(offset, adding);
     }
 
-    private long checkSize(long adding) {
+    private long checkSize0(long adding) {
         if (adding < 0 || adding > MAX_CAPACITY)
             throw new IllegalArgumentException("Invalid size " + adding);
         return adding;
@@ -273,7 +274,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(writePosition(), checkSize(desiredCapacity))) {
+        if (!bytesStore.inside(writePosition(), checkSize0(desiredCapacity))) {
             acquireNextByteStore0(writePosition(), false);
         }
     }
@@ -289,7 +290,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @NotNull
-    private BufferOverflowException writeBufferOverflowException(final long offset) {
+    private BufferOverflowException writeBufferOverflowException0(final long offset) {
         BufferOverflowException exception = new BufferOverflowException();
         exception.initCause(new IllegalArgumentException("Offset out of bound " + offset));
         return exception;
@@ -381,7 +382,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
         final long oldPosition = writePosition();
         if (writePosition() < 0 || writePosition() > capacity() - 1)
-            throw writeBufferOverflowException(writePosition());
+            throw writeBufferOverflowException0(writePosition());
         BytesStore bytesStore = this.bytesStore;
         if (!bytesStore.inside(writePosition(), 1)) {
             // already determined we need it
@@ -554,7 +555,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         if (writePosition() < 0 || writePosition() > capacity() - 1L + length)
-            throw writeBufferOverflowException(writePosition());
+            throw writeBufferOverflowException0(writePosition());
         int i;
         ascii:
         {
@@ -587,7 +588,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         if (offset < 0 || offset > mappedFile.capacity() - 8L)
-            throw writeBufferOverflowException(offset);
+            throw writeBufferOverflowException0(offset);
         // this is correct that it uses the maximumLimit, yes it is different from the method above.
         BytesStore bytesStore = this.bytesStore;
         if (bytesStore.start() > offset || offset + 8L > bytesStore.safeLimit()) {

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
@@ -50,7 +50,6 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 @SuppressWarnings({"rawtypes", "unchecked", "restriction"})
 public class ChunkedMappedFile extends MappedFile {
     static final boolean RETAIN = Jvm.getBoolean("mappedFile.retain");
-    private static final long DEFAULT_CAPACITY = 128L << 40;
 
     @NotNull
     private final RandomAccessFile raf;
@@ -299,10 +298,12 @@ public class ChunkedMappedFile extends MappedFile {
         return overlapSize;
     }
 
+    @Override
     public NewChunkListener getNewChunkListener() {
         return newChunkListener;
     }
 
+    @Override
     public void setNewChunkListener(final NewChunkListener listener) {
         this.newChunkListener = listener;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/internal/EnbeddedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/EnbeddedBytes.java
@@ -4,16 +4,16 @@ import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.VanillaBytes;
 import org.jetbrains.annotations.NotNull;
 
-public class EnbeddedBytes<U> extends VanillaBytes<U> {
+public class EnbeddedBytes<Underlying> extends VanillaBytes<Underlying> {
     private EnbeddedBytes(@NotNull BytesStore<?, ?> bytesStore, long writePosition, long writeLimit) throws IllegalStateException, IllegalArgumentException {
         super(bytesStore, writePosition, writeLimit);
     }
 
-    public static <U> EnbeddedBytes<U> wrap(BytesStore<?, ?> bytesStore) {
+    public static <Underlying> EnbeddedBytes<Underlying> wrap(BytesStore<?, ?> bytesStore) {
         return wrap((HeapBytesStore<?>) bytesStore);
     }
 
-    public static <U> EnbeddedBytes<U> wrap(HeapBytesStore<?> bytesStore) {
+    public static <Underlying> EnbeddedBytes<Underlying> wrap(HeapBytesStore<?> bytesStore) {
         long wp = bytesStore.start();
         int length = bytesStore.readUnsignedByte(wp - 1);
         return new EnbeddedBytes<>(bytesStore, wp, wp + length);

--- a/src/main/java/net/openhft/chronicle/bytes/internal/EnbeddedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/EnbeddedBytes.java
@@ -4,16 +4,16 @@ import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.VanillaBytes;
 import org.jetbrains.annotations.NotNull;
 
-public class EnbeddedBytes<Underlying> extends VanillaBytes<Underlying> {
-    private EnbeddedBytes(@NotNull BytesStore bytesStore, long writePosition, long writeLimit) throws IllegalStateException, IllegalArgumentException {
+public class EnbeddedBytes<U> extends VanillaBytes<U> {
+    private EnbeddedBytes(@NotNull BytesStore<?, ?> bytesStore, long writePosition, long writeLimit) throws IllegalStateException, IllegalArgumentException {
         super(bytesStore, writePosition, writeLimit);
     }
 
-    public static <U> EnbeddedBytes<U> wrap(BytesStore bytesStore) {
-        return wrap((HeapBytesStore) bytesStore);
+    public static <U> EnbeddedBytes<U> wrap(BytesStore<?, ?> bytesStore) {
+        return wrap((HeapBytesStore<?>) bytesStore);
     }
 
-    public static <U> EnbeddedBytes<U> wrap(HeapBytesStore bytesStore) {
+    public static <U> EnbeddedBytes<U> wrap(HeapBytesStore<?> bytesStore) {
         long wp = bytesStore.start();
         int length = bytesStore.readUnsignedByte(wp - 1);
         return new EnbeddedBytes<>(bytesStore, wp, wp + length);

--- a/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
@@ -32,22 +32,24 @@ import java.nio.ByteBuffer;
 
 /**
  * Wrapper for Heap ByteBuffers and arrays.
+ *
+ * @param <U> Underlying type
  */
 @SuppressWarnings("restriction")
-public class HeapBytesStore<Underlying>
-        extends AbstractBytesStore<HeapBytesStore<Underlying>, Underlying> {
+public class HeapBytesStore<U>
+        extends AbstractBytesStore<HeapBytesStore<U>, U> {
     @NotNull
     private final Object realUnderlyingObject;
     private final int dataOffset;
     private final long capacity;
     @NotNull
-    private final Underlying underlyingObject;
+    private final U underlyingObject;
     private UnsafeMemory memory = UnsafeMemory.MEMORY;
 
     private HeapBytesStore(@NotNull ByteBuffer byteBuffer) {
         super(false);
         //noinspection unchecked
-        this.underlyingObject = (Underlying) byteBuffer;
+        this.underlyingObject = (U) byteBuffer;
         this.realUnderlyingObject = byteBuffer.array();
         this.dataOffset = Jvm.arrayByteBaseOffset() + byteBuffer.arrayOffset();
         this.capacity = byteBuffer.capacity();
@@ -56,7 +58,7 @@ public class HeapBytesStore<Underlying>
     private HeapBytesStore(@NotNull byte @NotNull [] byteArray) {
         super(false);
         //noinspection unchecked
-        this.underlyingObject = (Underlying) byteArray;
+        this.underlyingObject = (U) byteArray;
         this.realUnderlyingObject = byteArray;
         this.dataOffset = Jvm.arrayByteBaseOffset();
         this.capacity = byteArray.length;
@@ -64,7 +66,7 @@ public class HeapBytesStore<Underlying>
 
     private HeapBytesStore(Object object, long start, long length) {
         super(false);
-        this.underlyingObject = (Underlying) object;
+        this.underlyingObject = (U) object;
         this.realUnderlyingObject = object;
         this.dataOffset = Math.toIntExact(start);
         this.capacity = length;
@@ -74,7 +76,7 @@ public class HeapBytesStore<Underlying>
         final BytesFieldInfo lookup = BytesFieldInfo.lookup(o.getClass());
         final long start = lookup.startOf(groupName);
         final long length = lookup.lengthOf(groupName);
-        return new HeapBytesStore<T>(o, start + padding, length - padding);
+        return new HeapBytesStore<>(o, start + padding, length - padding);
     }
 
     // Used by Chronicle-Map.
@@ -115,7 +117,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public BytesStore<HeapBytesStore<Underlying>, Underlying> copy() {
+    public BytesStore<HeapBytesStore<U>, U> copy() {
         throw new UnsupportedOperationException("todo");
     }
 
@@ -131,7 +133,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public Underlying underlyingObject() {
+    public U underlyingObject() {
         return underlyingObject;
     }
 
@@ -306,7 +308,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeByte(long offset, byte b)
+    public HeapBytesStore<U> writeByte(long offset, byte b)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -320,7 +322,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeShort(long offset, short i16)
+    public HeapBytesStore<U> writeShort(long offset, short i16)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -334,7 +336,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeInt(long offset, int i32)
+    public HeapBytesStore<U> writeInt(long offset, int i32)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -348,7 +350,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeOrderedInt(long offset, int i32)
+    public HeapBytesStore<U> writeOrderedInt(long offset, int i32)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -362,7 +364,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeLong(long offset, long i64)
+    public HeapBytesStore<U> writeLong(long offset, long i64)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -376,7 +378,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeOrderedLong(long offset, long i)
+    public HeapBytesStore<U> writeOrderedLong(long offset, long i)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -390,7 +392,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeFloat(long offset, float f)
+    public HeapBytesStore<U> writeFloat(long offset, float f)
             throws BufferOverflowException {
         try {
             memory.writeFloat(realUnderlyingObject, dataOffset + offset, f);
@@ -403,7 +405,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeDouble(long offset, double d)
+    public HeapBytesStore<U> writeDouble(long offset, double d)
             throws BufferOverflowException {
         try {
             memory.writeDouble(realUnderlyingObject, dataOffset + offset, d);
@@ -416,7 +418,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeVolatileByte(long offset, byte i8)
+    public HeapBytesStore<U> writeVolatileByte(long offset, byte i8)
             throws BufferOverflowException {
         try {
             memory.writeVolatileByte(realUnderlyingObject, dataOffset + offset, i8);
@@ -429,7 +431,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeVolatileShort(long offset, short i16)
+    public HeapBytesStore<U> writeVolatileShort(long offset, short i16)
             throws BufferOverflowException {
         try {
             memory.writeVolatileShort(realUnderlyingObject, dataOffset + offset, i16);
@@ -442,7 +444,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeVolatileInt(long offset, int i32)
+    public HeapBytesStore<U> writeVolatileInt(long offset, int i32)
             throws BufferOverflowException {
         try {
             memory.writeVolatileInt(realUnderlyingObject, dataOffset + offset, i32);
@@ -455,7 +457,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> writeVolatileLong(long offset, long i64)
+    public HeapBytesStore<U> writeVolatileLong(long offset, long i64)
             throws BufferOverflowException {
         try {
             memory.writeVolatileLong(realUnderlyingObject, dataOffset + offset, i64);
@@ -468,7 +470,7 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> write(
+    public HeapBytesStore<U> write(
             long offsetInRDO, byte[] bytes, int offset, int length)
             throws BufferOverflowException {
         try {
@@ -503,8 +505,8 @@ public class HeapBytesStore<Underlying>
 
     @NotNull
     @Override
-    public HeapBytesStore<Underlying> write(long writeOffset,
-                                            @NotNull RandomDataInput bytes, long readOffset, long length)
+    public HeapBytesStore<U> write(long writeOffset,
+                                   @NotNull RandomDataInput bytes, long readOffset, long length)
             throws IllegalStateException, BufferUnderflowException, BufferOverflowException {
         if (length == (int) length) {
             int length0 = (int) length;

--- a/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
@@ -33,23 +33,23 @@ import java.nio.ByteBuffer;
 /**
  * Wrapper for Heap ByteBuffers and arrays.
  *
- * @param <U> Underlying type
+ * @param <Underlying> Underlying type
  */
 @SuppressWarnings("restriction")
-public class HeapBytesStore<U>
-        extends AbstractBytesStore<HeapBytesStore<U>, U> {
+public class HeapBytesStore<Underlying>
+        extends AbstractBytesStore<HeapBytesStore<Underlying>, Underlying> {
     @NotNull
     private final Object realUnderlyingObject;
     private final int dataOffset;
     private final long capacity;
     @NotNull
-    private final U underlyingObject;
+    private final Underlying underlyingObject;
     private UnsafeMemory memory = UnsafeMemory.MEMORY;
 
     private HeapBytesStore(@NotNull ByteBuffer byteBuffer) {
         super(false);
         //noinspection unchecked
-        this.underlyingObject = (U) byteBuffer;
+        this.underlyingObject = (Underlying) byteBuffer;
         this.realUnderlyingObject = byteBuffer.array();
         this.dataOffset = Jvm.arrayByteBaseOffset() + byteBuffer.arrayOffset();
         this.capacity = byteBuffer.capacity();
@@ -58,7 +58,7 @@ public class HeapBytesStore<U>
     private HeapBytesStore(@NotNull byte @NotNull [] byteArray) {
         super(false);
         //noinspection unchecked
-        this.underlyingObject = (U) byteArray;
+        this.underlyingObject = (Underlying) byteArray;
         this.realUnderlyingObject = byteArray;
         this.dataOffset = Jvm.arrayByteBaseOffset();
         this.capacity = byteArray.length;
@@ -66,7 +66,7 @@ public class HeapBytesStore<U>
 
     private HeapBytesStore(Object object, long start, long length) {
         super(false);
-        this.underlyingObject = (U) object;
+        this.underlyingObject = (Underlying) object;
         this.realUnderlyingObject = object;
         this.dataOffset = Math.toIntExact(start);
         this.capacity = length;
@@ -117,7 +117,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public BytesStore<HeapBytesStore<U>, U> copy() {
+    public BytesStore<HeapBytesStore<Underlying>, Underlying> copy() {
         throw new UnsupportedOperationException("todo");
     }
 
@@ -133,7 +133,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public U underlyingObject() {
+    public Underlying underlyingObject() {
         return underlyingObject;
     }
 
@@ -308,7 +308,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeByte(long offset, byte b)
+    public HeapBytesStore<Underlying> writeByte(long offset, byte b)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -322,7 +322,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeShort(long offset, short i16)
+    public HeapBytesStore<Underlying> writeShort(long offset, short i16)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -336,7 +336,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeInt(long offset, int i32)
+    public HeapBytesStore<Underlying> writeInt(long offset, int i32)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -350,7 +350,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeOrderedInt(long offset, int i32)
+    public HeapBytesStore<Underlying> writeOrderedInt(long offset, int i32)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -364,7 +364,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeLong(long offset, long i64)
+    public HeapBytesStore<Underlying> writeLong(long offset, long i64)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -378,7 +378,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeOrderedLong(long offset, long i)
+    public HeapBytesStore<Underlying> writeOrderedLong(long offset, long i)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -392,7 +392,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeFloat(long offset, float f)
+    public HeapBytesStore<Underlying> writeFloat(long offset, float f)
             throws BufferOverflowException {
         try {
             memory.writeFloat(realUnderlyingObject, dataOffset + offset, f);
@@ -405,7 +405,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeDouble(long offset, double d)
+    public HeapBytesStore<Underlying> writeDouble(long offset, double d)
             throws BufferOverflowException {
         try {
             memory.writeDouble(realUnderlyingObject, dataOffset + offset, d);
@@ -418,7 +418,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeVolatileByte(long offset, byte i8)
+    public HeapBytesStore<Underlying> writeVolatileByte(long offset, byte i8)
             throws BufferOverflowException {
         try {
             memory.writeVolatileByte(realUnderlyingObject, dataOffset + offset, i8);
@@ -431,7 +431,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeVolatileShort(long offset, short i16)
+    public HeapBytesStore<Underlying> writeVolatileShort(long offset, short i16)
             throws BufferOverflowException {
         try {
             memory.writeVolatileShort(realUnderlyingObject, dataOffset + offset, i16);
@@ -444,7 +444,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeVolatileInt(long offset, int i32)
+    public HeapBytesStore<Underlying> writeVolatileInt(long offset, int i32)
             throws BufferOverflowException {
         try {
             memory.writeVolatileInt(realUnderlyingObject, dataOffset + offset, i32);
@@ -457,7 +457,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeVolatileLong(long offset, long i64)
+    public HeapBytesStore<Underlying> writeVolatileLong(long offset, long i64)
             throws BufferOverflowException {
         try {
             memory.writeVolatileLong(realUnderlyingObject, dataOffset + offset, i64);
@@ -470,7 +470,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> write(
+    public HeapBytesStore<Underlying> write(
             long offsetInRDO, byte[] bytes, int offset, int length)
             throws BufferOverflowException {
         try {
@@ -505,8 +505,8 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> write(long writeOffset,
-                                   @NotNull RandomDataInput bytes, long readOffset, long length)
+    public HeapBytesStore<Underlying> write(long writeOffset,
+                                            @NotNull RandomDataInput bytes, long readOffset, long length)
             throws IllegalStateException, BufferUnderflowException, BufferOverflowException {
         if (length == (int) length) {
             int length0 = (int) length;

--- a/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
@@ -37,8 +37,8 @@ import static net.openhft.chronicle.bytes.Bytes.MAX_CAPACITY;
 import static net.openhft.chronicle.core.UnsafeMemory.MEMORY;
 
 @SuppressWarnings({"restriction", "rawtypes", "unchecked"})
-public class NativeBytesStore<U>
-        extends AbstractBytesStore<NativeBytesStore<U>, U> {
+public class NativeBytesStore<Underlying>
+        extends AbstractBytesStore<NativeBytesStore<Underlying>, Underlying> {
     private static final long MEMORY_MAPPED_SIZE = 128 << 10;
     private static final Field BB_ADDRESS;
     private static final Field BB_CAPACITY;
@@ -62,7 +62,7 @@ public class NativeBytesStore<U>
     private SimpleCleaner cleaner;
     private boolean elastic;
     @Nullable
-    private U underlyingObject;
+    private Underlying underlyingObject;
 
     private NativeBytesStore() {
         finalizer = null;
@@ -196,7 +196,7 @@ public class NativeBytesStore<U>
     // Used in Chronicle Map
     public void init(@NotNull ByteBuffer bb, boolean elastic) {
         this.elastic = elastic;
-        underlyingObject = (U) bb;
+        underlyingObject = (Underlying) bb;
         setAddress(Jvm.address(bb));
         this.limit = bb.capacity();
     }
@@ -236,7 +236,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public BytesStore<NativeBytesStore<U>, U> copy()
+    public BytesStore<NativeBytesStore<Underlying>, Underlying> copy()
             throws IllegalStateException {
         try {
             if (underlyingObject == null) {
@@ -260,7 +260,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public VanillaBytes<U> bytesForWrite()
+    public VanillaBytes<Underlying> bytesForWrite()
             throws IllegalStateException {
         try {
             return elastic
@@ -283,13 +283,13 @@ public class NativeBytesStore<U>
 
     @Nullable
     @Override
-    public U underlyingObject() {
+    public Underlying underlyingObject() {
         return underlyingObject;
     }
 
     @NotNull
     @Override
-    public NativeBytesStore<U> zeroOut(long start, long end) {
+    public NativeBytesStore<Underlying> zeroOut(long start, long end) {
         if (end <= start)
             return this;
         if (start < start())
@@ -412,7 +412,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeByte(long offset, byte i8)
+    public NativeBytesStore<Underlying> writeByte(long offset, byte i8)
             throws IllegalStateException {
         memory.writeByte(address + translate(offset), i8);
         return this;
@@ -420,7 +420,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeShort(long offset, short i16)
+    public NativeBytesStore<Underlying> writeShort(long offset, short i16)
             throws IllegalStateException {
         memory.writeShort(address + translate(offset), i16);
         return this;
@@ -428,7 +428,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeInt(long offset, int i32)
+    public NativeBytesStore<Underlying> writeInt(long offset, int i32)
             throws IllegalStateException {
         try {
             memory.writeInt(address + translate(offset), i32);
@@ -441,7 +441,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeOrderedInt(long offset, int i)
+    public NativeBytesStore<Underlying> writeOrderedInt(long offset, int i)
             throws IllegalStateException {
         memory.writeOrderedInt(address + translate(offset), i);
         return this;
@@ -449,7 +449,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeLong(long offset, long i64)
+    public NativeBytesStore<Underlying> writeLong(long offset, long i64)
             throws IllegalStateException {
         memory.writeLong(address + translate(offset), i64);
         return this;
@@ -457,7 +457,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeOrderedLong(long offset, long i)
+    public NativeBytesStore<Underlying> writeOrderedLong(long offset, long i)
             throws IllegalStateException {
         memory.writeOrderedLong(address + translate(offset), i);
         return this;
@@ -465,7 +465,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeFloat(long offset, float f)
+    public NativeBytesStore<Underlying> writeFloat(long offset, float f)
             throws IllegalStateException {
         memory.writeFloat(address + translate(offset), f);
         return this;
@@ -473,7 +473,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeDouble(long offset, double d)
+    public NativeBytesStore<Underlying> writeDouble(long offset, double d)
             throws IllegalStateException {
         memory.writeDouble(address + translate(offset), d);
         return this;
@@ -481,7 +481,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeVolatileByte(long offset, byte i8)
+    public NativeBytesStore<Underlying> writeVolatileByte(long offset, byte i8)
             throws IllegalStateException {
         memory.writeVolatileByte(address + translate(offset), i8);
         return this;
@@ -489,7 +489,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeVolatileShort(long offset, short i16)
+    public NativeBytesStore<Underlying> writeVolatileShort(long offset, short i16)
             throws IllegalStateException {
         memory.writeVolatileShort(address + translate(offset), i16);
         return this;
@@ -497,7 +497,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeVolatileInt(long offset, int i32)
+    public NativeBytesStore<Underlying> writeVolatileInt(long offset, int i32)
             throws IllegalStateException {
         memory.writeVolatileInt(address + translate(offset), i32);
         return this;
@@ -505,7 +505,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeVolatileLong(long offset, long i64)
+    public NativeBytesStore<Underlying> writeVolatileLong(long offset, long i64)
             throws IllegalStateException {
         memory.writeVolatileLong(address + translate(offset), i64);
         return this;
@@ -513,7 +513,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> write(
+    public NativeBytesStore<Underlying> write(
             long offsetInRDO, byte[] bytes, int offset, int length)
             throws IllegalStateException {
         memory.copyMemory(bytes, offset, address + translate(offsetInRDO), length);
@@ -534,7 +534,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> write(
+    public NativeBytesStore<Underlying> write(
             long writeOffset, @NotNull RandomDataInput bytes, long readOffset, long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         if (bytes.isDirectMemory()) {

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedBytes.java
@@ -59,6 +59,7 @@ public class SingleMappedBytes extends CommonMappedBytes {
         }
     }
 
+    @Override
     public @NotNull SingleMappedBytes write(final long offsetInRDO,
                                             final byte[] bytes,
                                             int offset,
@@ -96,6 +97,7 @@ public class SingleMappedBytes extends CommonMappedBytes {
 
     }
 
+    @Override
     public @NotNull SingleMappedBytes write(final long writeOffset,
                                             final RandomDataInput bytes,
                                             long readOffset,
@@ -158,12 +160,6 @@ public class SingleMappedBytes extends CommonMappedBytes {
         }
     }
 
-    private long checkSize(long adding) {
-        if (adding < 0 || adding > MAX_CAPACITY)
-            throw new IllegalArgumentException("Invalid size " + adding);
-        return adding;
-    }
-
     @Override
     public @NotNull Bytes<Void> writeSkip(long bytesToSkip)
             throws BufferOverflowException, IllegalStateException {
@@ -175,7 +171,7 @@ public class SingleMappedBytes extends CommonMappedBytes {
     }
 
     @NotNull
-    private BufferOverflowException writeBufferOverflowException(final long offset) {
+    private BufferOverflowException newBufferOverflowException(final long offset) {
         BufferOverflowException exception = new BufferOverflowException();
         exception.initCause(new IllegalArgumentException("Offset out of bound " + offset));
         return exception;
@@ -218,9 +214,8 @@ public class SingleMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         if (offset < 0 || offset > capacity())
-            throw writeBufferOverflowException(offset);
+            throw newBufferOverflowException(offset);
 
-//        super.writeCheckOffset(offset, adding);
         return bytesStore.compareAndSwapLong(offset, expected, value);
     }
 }

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
@@ -71,7 +71,6 @@ public class SingleMappedFile extends MappedFile {
 
             resizeRafIfTooSmall(capacity);
             final long address = OS.map(fileChannel, mode, 0, capacity);
-//            System.out.println("Mapped "+Long.toUnsignedString(address, 16));
             final MappedBytesStore mbs2 = MAPPED_BYTES_STORE_FACTORY.create(this, this, 0, address, capacity, capacity);
 
             final long elapsedNs = System.nanoTime() - beginNs;
@@ -192,10 +191,12 @@ public class SingleMappedFile extends MappedFile {
         return 0;
     }
 
+    @Override
     public NewChunkListener getNewChunkListener() {
         return newChunkListener;
     }
 
+    @Override
     public void setNewChunkListener(final NewChunkListener listener) {
         this.newChunkListener = listener;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
+++ b/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
@@ -35,7 +35,8 @@ public class BytesPool {
                 // ignored
             }
         } else {
-            bytesTL.set(bytes = createBytes());
+            bytes = createBytes();
+            bytesTL.set(bytes);
         }
         return bytes;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -37,7 +37,7 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     protected BytesStore<?, ?> bytes;
     protected long offset;
 
-    public AbstractReference() {
+    protected AbstractReference() {
         // assume thread safe.
         disableThreadSafetyCheck(true);
     }
@@ -64,9 +64,6 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     public long offset() {
         return offset;
     }
-
-    @Override
-    public abstract long maxSize();
 
     protected void acceptNewBytesStore(@NotNull final BytesStore bytes)
             throws IllegalStateException {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
@@ -100,6 +100,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
         return (capacity << SHIFT) + VALUES;
     }
 
+    @Override
     protected void acceptNewBytesStore(@NotNull final BytesStore bytes)
             throws IllegalStateException {
         if (this.bytes != null) {
@@ -207,9 +208,9 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
             throw new IORuntimeException("Corrupt used value");
 
         bytes.readSkip(capacity << SHIFT);
-        long length = bytes.readPosition() - position;
+        long len = bytes.readPosition() - position;
         try {
-            bytesStore((Bytes) bytes, position, length);
+            bytesStore((Bytes) bytes, position, len);
         } catch (IllegalArgumentException | BufferOverflowException e) {
             throw new AssertionError(e);
         }
@@ -268,6 +269,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @NotNull
+    @Override
     public String toString() {
         if (bytes == null)
             return "not set";
@@ -279,7 +281,8 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
             sb.append(", value: ");
             @NotNull String sep = "";
             try {
-                int i, max = (int) Math.min(used, Math.min(getCapacity(), MAX_TO_STRING));
+                int i;
+                int max = (int) Math.min(used, Math.min(getCapacity(), MAX_TO_STRING));
                 for (i = 0; i < max; i++) {
                     long valueAt = getValueAt(i);
                     sb.append(sep).append(valueAt);
@@ -311,11 +314,11 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
         throwExceptionIfClosedInSetter();
 
         BytesStore bytesStore = bytesStore();
-        long length = sizeInBytes(arrayLength);
+        long len = sizeInBytes(arrayLength);
         if (bytesStore == null) {
-            this.length = length;
+            this.length = len;
         } else {
-            assert this.length == length;
+            assert this.length == len;
         }
         return this;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -47,6 +47,7 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
     }
 
     @NotNull
+    @Override
     public String toString() {
         if (bytes == null)
             return "bytes is null";

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
@@ -73,6 +73,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
         binaryLongArrayReferences = null;
     }
 
+    @Override
     protected void acceptNewBytesStore(@NotNull final BytesStore bytes)
             throws IllegalStateException {
         if (this.bytes != null) {
@@ -220,9 +221,9 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
             throw new IORuntimeException("Corrupt used value");
 
         bytes.readSkip(capacity << SHIFT);
-        long length = bytes.readPosition() - position;
+        long len = bytes.readPosition() - position;
         try {
-            bytesStore((Bytes) bytes, position, length);
+            bytesStore((Bytes) bytes, position, len);
         } catch (IllegalArgumentException | BufferOverflowException e) {
             throw new AssertionError(e);
         }
@@ -281,6 +282,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @NotNull
+    @Override
     public String toString() {
         if (bytes == null)
             return "not set";
@@ -291,7 +293,8 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
             sb.append(used);
             sb.append(", value: ");
             @NotNull String sep = "";
-            int i, max = (int) Math.min(used, Math.min(getCapacity(), MAX_TO_STRING));
+            int i;
+            int max = (int) Math.min(used, Math.min(getCapacity(), MAX_TO_STRING));
             for (i = 0; i < max; i++) {
                 long valueAt = getValueAt(i);
                 sb.append(sep).append(valueAt);
@@ -320,11 +323,11 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
         throwExceptionIfClosedInSetter();
 
         BytesStore bytesStore = bytesStore();
-        long length = sizeInBytes(arrayLength);
+        long len = sizeInBytes(arrayLength);
         if (bytesStore == null) {
-            this.length = length;
+            this.length = len;
         } else {
-            assert this.length == length;
+            assert this.length == len;
         }
         return this;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -44,6 +44,7 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
     }
 
     @NotNull
+    @Override
     public String toString() {
         if (bytes == null) return "bytes is null";
         try {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryTwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryTwoLongReference.java
@@ -29,6 +29,7 @@ public class BinaryTwoLongReference extends BinaryLongReference implements TwoLo
     }
 
     @NotNull
+    @Override
     public String toString() {
         try {
             return bytes == null ? "bytes is null" : "value: " + getValue() + ", value2: " + getValue2();

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
@@ -45,6 +45,7 @@ public class TextBooleanReference extends AbstractReference implements BooleanVa
     }
 
     @NotNull
+    @Override
     public String toString() {
         try {
             return "value: " + getValue();

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
@@ -148,11 +148,11 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
     @Override
     public ByteableIntArrayValues capacity(long arrayLength) {
         BytesStore bytesStore = bytesStore();
-        long length = sizeInBytes(arrayLength);
+        long len = sizeInBytes(arrayLength);
         if (bytesStore == null) {
-            this.length = length;
+            this.length = len;
         } else {
-            assert this.length == length;
+            assert this.length == len;
         }
         return this;
     }
@@ -260,6 +260,7 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
     }
 
     @NotNull
+    @Override
     public String toString() {
         if (bytes == null) {
             return "LongArrayTextReference{" +

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
@@ -55,7 +55,7 @@ public class TextIntReference extends AbstractReference implements IntValue {
         }
     }
 
-    private <T extends Throwable> int withLock(@NotNull ThrowingIntSupplier<Exception> call)
+    private int withLock(@NotNull ThrowingIntSupplier<Exception> call)
             throws IllegalStateException {
         try {
             long alignedOffset = roundUpTo8ByteAlign(offset);
@@ -177,6 +177,7 @@ public class TextIntReference extends AbstractReference implements IntValue {
     }
 
     @NotNull
+    @Override
     public String toString() {
         try {
             return "value: " + getValue();

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -136,11 +136,11 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
     @Override
     public ByteableLongArrayValues capacity(long arrayLength) {
         BytesStore bytesStore = bytesStore();
-        long length = sizeInBytes(arrayLength);
+        long len = sizeInBytes(arrayLength);
         if (bytesStore == null) {
-            this.length = length;
+            this.length = len;
         } else {
-            assert this.length == length;
+            assert this.length == len;
         }
         return this;
     }
@@ -254,6 +254,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
     }
 
     @NotNull
+    @Override
     public String toString() {
         if (bytes == null) {
             return "LongArrayTextReference{" +

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
@@ -147,6 +147,7 @@ public class TextLongReference extends AbstractReference implements LongReferenc
     }
 
     @NotNull
+    @Override
     public String toString() {
         try {
             return "value: " + getValue();

--- a/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
@@ -70,6 +70,7 @@ public class UncheckedLongReference extends UnsafeCloseable implements LongRefer
     }
 
     @NotNull
+    @Override
     public String toString() {
         if (address == 0)
             return "addressForRead is 0";

--- a/src/main/java/net/openhft/chronicle/bytes/util/Compression.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Compression.java
@@ -33,7 +33,8 @@ import java.nio.BufferOverflowException;
 @SuppressWarnings("rawtypes")
 public interface Compression {
 
-    static <T> void compress(@NotNull CharSequence cs, @NotNull Bytes uncompressed, @NotNull Bytes compressed) throws IllegalStateException, BufferOverflowException {
+    static void compress(@NotNull CharSequence cs, @NotNull Bytes uncompressed, @NotNull Bytes compressed)
+            throws IllegalStateException, BufferOverflowException {
         switch (cs.charAt(0)) {
             case 'l':
                 if (StringUtils.isEqual("lzw", cs)) {

--- a/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
@@ -92,6 +92,7 @@ public enum PropertyReplacer {
             if (is != null)
                 return convertStreamToString(is);
         } catch (Exception ignored) {
+            // Ignore
         }
         return BytesUtil.readFile(fileName).toString();
     }

--- a/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
@@ -73,7 +73,8 @@ public class StringInternerBytes extends StringInterner {
 
             char[] chars = toCharArray(bytes, position, length);
             final int toPlace = s == null || (s2 != null && toggle()) ? h : h2;
-            return interner[toPlace] = StringUtils.newString(chars);
+            interner[toPlace] = StringUtils.newString(chars);
+            return interner[toPlace];
         } finally {
             bytes.readSkip(length);
         }

--- a/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
@@ -612,11 +612,11 @@ public class ByteStoreTest extends BytesTestCommon {
     @Test
     public void testOverflowReadUtf8()
             throws IORuntimeException {
-        final BytesStore bs = BytesStore.nativeStore(32);
+        final BytesStore<?, ?> bs = BytesStore.nativeStore(32);
         BytesInternal.writeStopBit(bs, 10, 30);
         try {
             bs.readUtf8(10, new StringBuilder());
-            throw new AssertionError("should throw BufferUnderflowException");
+            fail("should throw BufferUnderflowException");
         } catch (BufferUnderflowException e) {
             // expected
         } finally {

--- a/src/test/java/net/openhft/chronicle/bytes/Bytes4Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Bytes4Test.java
@@ -30,17 +30,28 @@ public class Bytes4Test {
     public void bufferOverflow() {
         byte[] arr = new byte[4];
         final BytesStore bs = BytesStore.wrap(arr);
+
+        // Since writeInt can throw AssertionError we need to make it like this
+        boolean fail = false;
         try {
             bs.writeInt(-1000, 1);
-            fail("No address range check");
+            fail = true;
         } catch (AssertionError ignore) {
-
+            // Ignore
         }
+        if (fail)
+            fail("No address range check");
+
+        fail = false;
         try {
             bs.writeInt(4, 2);
-            fail("No address range check");
+            fail = true;
         } catch (AssertionError ignore) {
+            // Ignore
         }
+
+        if (fail)
+            fail("No address range check");
     }
 
     public static void main(String[] args) {

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
@@ -557,7 +557,7 @@ public class BytesTest extends BytesTestCommon {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testMove2() {
         @NotNull Bytes b = alloc1.elasticBytes(16);
 
@@ -565,7 +565,9 @@ public class BytesTest extends BytesTestCommon {
         b.move(3, 1, 3);
         assertEquals("0345456789", b.toString());
         postTest(b);
-        b.move(3, 5, 3);
+        assertThrows(IllegalStateException.class, () ->
+            b.move(3, 5, 3)
+        );
     }
 
     @Test
@@ -588,7 +590,7 @@ public class BytesTest extends BytesTestCommon {
         postTest(b);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testMove2B() {
         @NotNull Bytes b = alloc1.elasticBytes(16);
 
@@ -597,7 +599,9 @@ public class BytesTest extends BytesTestCommon {
         assertEquals("Hlo o World", b.toString());
         postTest(b);
         BackgroundResourceReleaser.releasePendingResources();
-        b.bytesStore().move(3, 5, 3);
+        assertThrows(IllegalStateException.class, () ->
+            b.bytesStore().move(3, 5, 3)
+        );
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/bytes/HeapByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/HeapByteStoreTest.java
@@ -22,8 +22,7 @@ import net.openhft.chronicle.bytes.internal.HeapBytesStore;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 public class HeapByteStoreTest extends BytesTestCommon {
     @SuppressWarnings("rawtypes")
@@ -44,8 +43,10 @@ public class HeapByteStoreTest extends BytesTestCommon {
     @Test
     public void testElasticBytesEnsuringCapacity() {
         Bytes<?> bytes = Bytes.elasticHeapByteBuffer();
+        long initialCapacity = bytes.realCapacity();
         bytes.clearAndPad(bytes.realCapacity() + 128);
         // ensure this succeeds even though we are above the real capacity - this should trigger resize
         bytes.prewriteInt(1);
+        assertTrue(bytes.realCapacity()> initialCapacity);
     }
 }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.*;
 @SuppressWarnings("rawtypes")
 public class MappedBytesTest extends BytesTestCommon {
 
-    final private String
-            smallText = "It's ten years since the iPhone was first unveiled and Apple has marked " +
+    private static final String
+            SMALL_TEXT = "It's ten years since the iPhone was first unveiled and Apple has marked " +
             "the occas" +
             "ion with a new iPhone that doesn't just jump one generation, it jumps several. " +
             "Apple has leapt straight from iPhone 7 (via the iPhone 8, reviewed here) all the way " +
@@ -39,7 +39,7 @@ public class MappedBytesTest extends BytesTestCommon {
 
     {
         for (int i = 0; i < 200; i++) {
-            largeTextBuilder.append(smallText);
+            largeTextBuilder.append(SMALL_TEXT);
         }
 
         text = largeTextBuilder.toString();
@@ -47,7 +47,7 @@ public class MappedBytesTest extends BytesTestCommon {
 
     @Test
     public void testMappedFileSafeLimitTooSmall()
-            throws IOException {
+            throws IOException  {
 
         final int arraySize = 40_000;
 
@@ -65,6 +65,9 @@ public class MappedBytesTest extends BytesTestCommon {
             for (int i = 0; i < 5; i++) {
                 bytesR.write(data);
             }
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
         }
     }
 
@@ -88,6 +91,9 @@ public class MappedBytesTest extends BytesTestCommon {
             for (int i = 0; i < 5; i++) {
                 bytesR.write(data);
             }
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
         }
     }
 
@@ -264,6 +270,7 @@ public class MappedBytesTest extends BytesTestCommon {
         bytes2.releaseLast();
         bytes.releaseLast();
 
+        assertTrue(bytes.isClosed());
     }
 
     @Test
@@ -305,6 +312,8 @@ public class MappedBytesTest extends BytesTestCommon {
         bytes2.releaseLast();
         bytes.releaseLast();
 
+        assertTrue(bytes.isClosed());
+
     }
 
     @Test
@@ -345,6 +354,8 @@ public class MappedBytesTest extends BytesTestCommon {
 
         bytes2.releaseLast();
         bytes.releaseLast();
+
+        assertTrue(bytes.isClosed());
 
     }
 

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
@@ -193,9 +193,11 @@ public class MappedFileTest extends BytesTestCommon {
         try {
             final MappedFile mappedFile2 = MappedFile.mappedFile(file, 1024, 256, 256, false);
             mappedFile2.releaseLast();
+            assertTrue(mappedFile2.isClosed());
         } finally {
             mappedFile.releaseLast();
         }
+        assertTrue(mappedFile.isClosed());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/bytes/MoreBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MoreBytesTest.java
@@ -29,7 +29,7 @@ public class MoreBytesTest {
     @Test
     public void testOneRelease() {
         int count = 0;
-        for (@NotNull Bytes<?> b : new Bytes[]{
+        for (Bytes<?> b : new Bytes[]{
                 Bytes.allocateDirect(10),
                 Bytes.allocateDirect(new byte[5]),
                 Bytes.allocateElasticDirect(100),
@@ -56,7 +56,7 @@ public class MoreBytesTest {
 
     @Test
     public void testAppendLongRandomPosition() {
-        final @NotNull byte[] bytes = "00000".getBytes(ISO_8859_1);
+        final byte[] bytes = "00000".getBytes(ISO_8859_1);
         final ByteBuffer bb = ByteBuffer.wrap(bytes);
         final Bytes<?> to = Bytes.wrapForWrite(bb);
         try {
@@ -69,7 +69,7 @@ public class MoreBytesTest {
 
     @Test
     public void testAppendLongRandomPosition2() {
-        final @NotNull byte[] bytes = "WWWWW00000".getBytes(ISO_8859_1);
+        final byte[] bytes = "WWWWW00000".getBytes(ISO_8859_1);
         final ByteBuffer bb = ByteBuffer.wrap(bytes);
         final Bytes<?> to = Bytes.wrapForWrite(bb);
         try {
@@ -85,7 +85,7 @@ public class MoreBytesTest {
     @Test
     public void testAppendLongRandomPositionShouldThrowBufferOverflowException() {
         try {
-            final @NotNull byte[] bytes = "000".getBytes(ISO_8859_1);
+            final byte[] bytes = "000".getBytes(ISO_8859_1);
             final ByteBuffer bb = ByteBuffer.wrap(bytes);
             final Bytes<?> to = Bytes.wrapForWrite(bb);
             try {
@@ -100,25 +100,22 @@ public class MoreBytesTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testAppendLongRandomPositionShouldThrowIllegalArgumentException() {
+        final byte[] bytes = "000".getBytes(ISO_8859_1);
+        final ByteBuffer bb = ByteBuffer.wrap(bytes);
+        final Bytes<?> to = Bytes.wrapForWrite(bb);
         try {
-            final @NotNull byte[] bytes = "000".getBytes(ISO_8859_1);
-            final ByteBuffer bb = ByteBuffer.wrap(bytes);
-            final Bytes<?> to = Bytes.wrapForWrite(bb);
-            try {
-                to.append(0, 1000, 3);
-            } finally {
-                to.releaseLast();
-            }
-            fail("Should throw Exception");
+            to.append(0, 1000, 3);
         } catch (BufferOverflowException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
+        } finally {
+            to.releaseLast();
         }
     }
 
     @Test
     public void testAppendDoubleRandomPosition() {
-        final @NotNull byte[] bytes = "000000".getBytes(ISO_8859_1);
+        final byte[] bytes = "000000".getBytes(ISO_8859_1);
         final Bytes<?> to = Bytes.wrapForWrite(bytes);
         try {
             to.append(0, 3.14, 2, 6);
@@ -130,31 +127,28 @@ public class MoreBytesTest {
 
     @Test
     public void testAppendDoubleRandomPositionShouldThrowBufferOverflowException() {
+        final byte[] bytes = "000000".getBytes(ISO_8859_1);
+        final Bytes<?> to = Bytes.wrapForWrite(bytes);
         try {
-            final @NotNull byte[] bytes = "000000".getBytes(ISO_8859_1);
-            final Bytes<?> to = Bytes.wrapForWrite(bytes);
-            try {
-                to.append(0, 3.14, 2, 8);
-            } finally {
-                to.releaseLast();
-            }
+            to.append(0, 3.14, 2, 8);
             fail("Should throw Exception");
         } catch (BufferOverflowException ignore) {
             // Ignore
+        } finally {
+            to.releaseLast();
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAppendDoubleRandomPositionShouldThrowIllegalArgumentException() {
 
-        final @NotNull byte[] bytes = "000000".getBytes(ISO_8859_1);
+        final byte[] bytes = "000000".getBytes(ISO_8859_1);
         final Bytes<?> to = Bytes.wrapForWrite(bytes);
         try {
             to.append(0, 33333.14, 2, 6);
         } finally {
             to.releaseLast();
         }
-
     }
 
     @Test
@@ -162,16 +156,20 @@ public class MoreBytesTest {
         int expected = 0;
         for (int i = 0x80; i <= 0xFF; i++)
             for (int j = 0x80; j <= 0xFF; j++) {
-                final @NotNull byte[] b = {(byte) i, (byte) j};
-                final @NotNull String s = new String(b, StandardCharsets.UTF_8);
+                final byte[] b = {(byte) i, (byte) j};
+                final String s = new String(b, StandardCharsets.UTF_8);
                 if (s.charAt(0) == 65533) {
                     final Bytes<?> bytes = Bytes.wrapForRead(b);
+                    // Use a flag so that there are just one method that can throw in the try-block
+                    boolean fail = false;
                     try {
                         bytes.parseUtf8(StopCharTesters.ALL);
-                        fail(Arrays.toString(b));
+                        fail = true;
                     } catch (UTFDataFormatRuntimeException e) {
                         expected++;
                     }
+                    if (fail)
+                        fail(Arrays.toString(b));
                 }
             }
         assertEquals(14464, expected);
@@ -328,9 +326,10 @@ public class MoreBytesTest {
 
     @Test
     public void testDoesNotRequire3xCapacity() {
-        final String SYMBOL_STR = "LCOM1";
-        final Bytes SYMBOL = Bytes.allocateDirect(SYMBOL_STR.length());
-        SYMBOL.clear();
-        SYMBOL.append(SYMBOL_STR);
+        final String symbolStr = "LCOM1";
+        final Bytes<?> symbol = Bytes.allocateDirect(symbolStr.length());
+        symbol.clear();
+        symbol.append(symbolStr);
+        assertTrue(symbol.realCapacity() < 3 * symbolStr.length());
     }
 }

--- a/src/test/java/net/openhft/chronicle/bytes/NativeBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NativeBytesTest.java
@@ -111,7 +111,7 @@ public class NativeBytesTest extends BytesTestCommon {
         b.releaseLast();
     }
 
-    @Test(expected = UTFDataFormatRuntimeException.class )
+    @Test
     public void testAppendCharArrayNonAsciiToShort() {
         Bytes<?> b = alloc.elasticBytes(4);
         try {
@@ -120,8 +120,9 @@ public class NativeBytesTest extends BytesTestCommon {
             assertEquals(Bytes.wrapForRead(bytes).toHexString(), b.toHexString());
 
             StringBuilder sb = new StringBuilder();
-            b.parseUtf8(sb, 1);
-            fail();
+            assertThrows(UTFDataFormatRuntimeException.class, () ->
+                    b.parseUtf8(sb, 1)
+            );
         } finally {
             b.releaseLast();
         }
@@ -141,7 +142,7 @@ public class NativeBytesTest extends BytesTestCommon {
         nativeBytes.releaseLast();
     }
 
-    @Test(expected = DecoratedBufferOverflowException.class)
+    @Test
     public void tryGrowBeyondByteBufferCapacity() {
         Assume.assumeFalse(alloc == HEAP);
         long maxMemory = Runtime.getRuntime().maxMemory();
@@ -153,10 +154,12 @@ public class NativeBytesTest extends BytesTestCommon {
 
         // Trigger growing beyond ByteBuffer
         bytes.writePosition(bytes.realCapacity() - 1);
-        bytes.writeInt(0);
+        assertThrows(DecoratedBufferOverflowException.class, () ->
+                bytes.writeInt(0)
+        );
     }
 
-    @Test(expected = BufferOverflowException.class)
+    @Test
     public void tryGrowBeyondCapacity() {
         final int maxCapacity = 1024;
         @NotNull Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer(128, maxCapacity);
@@ -169,8 +172,9 @@ public class NativeBytesTest extends BytesTestCommon {
         bytes.write(new byte[256]);
         try {
             // Trigger growing beyond maxCapacity
-            bytes.write(new byte[maxCapacity]);
-            Assert.fail("should not get here");
+            assertThrows(BufferOverflowException.class, () ->
+                    bytes.write(new byte[maxCapacity])
+            );
         } finally {
             bytes.releaseLast();
         }

--- a/src/test/java/net/openhft/chronicle/bytes/PointerBytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/PointerBytesStoreTest.java
@@ -47,5 +47,6 @@ public class PointerBytesStoreTest extends BytesTestCommon {
         final Bytes<Void> wrapper = pbs.bytesForRead();
         pbs.set(NoBytesStore.NO_PAGE, 200);
         wrapper.writeLimit(pbs.capacity());
+        assertEquals(pbs.capacity(), wrapper.writeLimit());
     }
 }

--- a/src/test/java/net/openhft/chronicle/bytes/WriteLimitTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/WriteLimitTest.java
@@ -56,21 +56,18 @@ public class WriteLimitTest {
 
     @Test
     public void writeLimit() {
-        Bytes bytes = allocator.elasticBytes(64);
+        Bytes<?> bytes = allocator.elasticBytes(64);
         for (int i = 0; i < 16; i++) {
             int position = (int) (bytes.realCapacity() - length - i);
             bytes.clear().writePosition(position).writeLimit(position + length);
             action.accept(bytes);
 
+            bytes.clear().writePosition(position).writeLimit(position + length - 1);
             try {
-                bytes.clear().writePosition(position).writeLimit(position + length - 1);
-                action.accept(bytes);
-
-                bytes.clear().writePosition(position).writeLimit(position + length - 1);
                 action.accept(bytes);
                 fail("position: " + position);
-            } catch (BufferOverflowException expected) {
-
+            } catch (BufferOverflowException ignored) {
+                // expected
             }
         }
         bytes.releaseLast();

--- a/src/test/java/net/openhft/chronicle/bytes/util/ThreadIndexAssignerTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/ThreadIndexAssignerTest.java
@@ -21,13 +21,13 @@ public class ThreadIndexAssignerTest extends BytesTestCommon {
     public void assignTwo()
             throws InterruptedException {
         assumeTrue(OS.isLinux() && !Jvm.isArm());
-        BlockingQueue t0started = new LinkedBlockingQueue();
-        BlockingQueue t1started = new LinkedBlockingQueue();
-        BlockingQueue t2started = new LinkedBlockingQueue();
-        BlockingQueue testDone = new LinkedBlockingQueue();
+        final BlockingQueue<String> t0started = new LinkedBlockingQueue<>();
+        final BlockingQueue<String> t1started = new LinkedBlockingQueue<>();
+        final BlockingQueue<String> t2started = new LinkedBlockingQueue<>();
+        final BlockingQueue<String> testDone = new LinkedBlockingQueue<>();
 
-        Bytes bytes = Bytes.allocateDirect(64);
-        BinaryIntArrayReference iav = new BinaryIntArrayReference(2);
+        final Bytes<?> bytes = Bytes.allocateDirect(64);
+        final BinaryIntArrayReference iav = new BinaryIntArrayReference(2);
         // write the template
         iav.writeMarshallable(bytes);
         // bind to the template
@@ -72,9 +72,8 @@ public class ThreadIndexAssignerTest extends BytesTestCommon {
         t1started.poll(1, TimeUnit.SECONDS);
         try {
             int id = ta.getId();
-            System.out.println("id=" + id);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException ignore) {
             // expected
         }
         t2started.put("");


### PR DESCRIPTION
Add missing null check

Check for null

Remove redundant && operations

Add assertion for null

Use explicit long in calculation

Remove unused private method

Remove another unused private method

Remove unused private method and rename other method

Fix tests that were incorrect

Remove redundant override

Consolidate to single return

Fix problems in AbstractInterner

Add back override that changed the type

Add assertions to tests

Revert renamed field

Add assertions to tests

Reduce warnings

Deduplicate strings

Fix more warnings

Fix more warnings

Fix warnings

Fix even more warnings

Fix last batch of major issues

Fix remaining issues easily fixable