### PR TITLE
Enable JU5 while retaining backwards compatibility with JU4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,15 +77,17 @@
         </dependency>
 
         <!-- test dependencies -->
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTestCommon.java
@@ -9,6 +9,8 @@ import net.openhft.chronicle.core.threads.ThreadDump;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -24,11 +26,13 @@ public class BytesTestCommon {
     protected Map<ExceptionKey, Integer> exceptions;
 
     @Before
+    @BeforeEach
     public void enableReferenceTracing() {
         AbstractReferenceCounted.enableReferenceTracing();
     }
 
     @Before
+    @BeforeEach
     public void threadDump() {
         threadDump = new ThreadDump();
     }
@@ -38,6 +42,7 @@ public class BytesTestCommon {
     }
 
     @Before
+    @BeforeEach
     public void recordExceptions() {
         exceptions = Jvm.recordExceptions();
     }
@@ -64,6 +69,7 @@ public class BytesTestCommon {
     }
 
     @After
+    @AfterEach
     public void afterChecks() {
         CleaningThread.performCleanup(Thread.currentThread());
 

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTestCommon.java
@@ -18,9 +18,10 @@ import static net.openhft.chronicle.core.io.AbstractCloseable.waitForCloseablesT
 import static net.openhft.chronicle.core.io.AbstractReferenceCounted.assertReferencesReleased;
 
 public class BytesTestCommon {
+
+    private final Map<Predicate<ExceptionKey>, String> expectedExceptions = new LinkedHashMap<>();
     protected ThreadDump threadDump;
     protected Map<ExceptionKey, Integer> exceptions;
-    private Map<Predicate<ExceptionKey>, String> expectedExceptions = new LinkedHashMap<>();
 
     @Before
     public void enableReferenceTracing() {

--- a/src/test/java/net/openhft/chronicle/bytes/VanillaBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/VanillaBytesTest.java
@@ -20,20 +20,20 @@
 package net.openhft.chronicle.bytes;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SuppressWarnings("rawtypes")
-public class VanillaBytesTest extends BytesTestCommon {
+final class VanillaBytesTest extends BytesTestCommon {
+
     @Test
-    public void testBytesForRead() {
-        @NotNull byte[] byteArr = new byte[128];
+    void testBytesForRead() {
+        byte[] byteArr = new byte[128];
         for (int i = 0; i < byteArr.length; i++)
             byteArr[i] = (byte) i;
-        Bytes bytes = Bytes.wrapForRead(byteArr);
+        Bytes<?> bytes = Bytes.wrapForRead(byteArr);
         bytes.readSkip(8);
-        @NotNull Bytes bytes2 = bytes.bytesForRead();
+        @NotNull Bytes<?> bytes2 = bytes.bytesForRead();
         assertEquals(128 - 8, bytes2.readRemaining());
         assertEquals(8, bytes2.readPosition());
         assertEquals(8, bytes2.readByte(bytes2.start()));


### PR DESCRIPTION
This PR introduces the ability to write new tests in either JUnit4 or JUnit5, whichever is deemed most favorable for the issue at hand.

Old JUnit4 test can be migrated to JUnit5 now, later or never.

As @nicktindall indicated, there is a "vintage" dependency that makes this process trivial. 
