### PR TITLE
Make MappedBytes respect the readOnly flag, Fix #239

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
@@ -62,13 +62,13 @@ public abstract class MappedBytes extends AbstractBytes<Void> implements Closeab
     @NotNull
     public static MappedBytes singleMappedBytes(@NotNull final File file, final long capacity)
             throws FileNotFoundException, IllegalStateException {
-        return singleMappedBytes(file, capacity, true);
+        return singleMappedBytes(file, capacity, false);
     }
 
     @NotNull
     public static MappedBytes singleMappedBytes(@NotNull final File file, final long capacity, boolean readOnly)
             throws FileNotFoundException, IllegalStateException {
-        @NotNull final MappedFile rw = MappedFile.ofSingle(file, capacity, false);
+        final MappedFile rw = MappedFile.ofSingle(file, capacity, readOnly);
         try {
             return new SingleMappedBytes(rw);
         } finally {


### PR DESCRIPTION
This PR fixes `MappedBytes::singleMappedBytes` with the `readOnly` flag while retaining the behaviour for the other overloads.