### PR TITLE
Throw if resize does not give us enough room

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
@@ -104,7 +104,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     @Override
     public boolean inside(long offset, long buffer) {
         // this is correct that it uses the maximumLimit, yes it is different than the method above.
-        return start <= offset && offset + buffer < limit;
+        return start <= offset && offset + buffer <= limit;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.bytes.internal;
 
 import net.openhft.chronicle.bytes.*;
 import net.openhft.chronicle.bytes.util.DecoratedBufferOverflowException;
+import net.openhft.chronicle.bytes.util.DecoratedBufferUnderflowException;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Memory;
 import net.openhft.chronicle.core.OS;
@@ -38,7 +39,7 @@ import java.nio.BufferUnderflowException;
  * <p>
  * NOTE These Bytes are single Threaded as are all Bytes.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
+@SuppressWarnings({"rawtypes"})
 public class ChunkedMappedBytes extends CommonMappedBytes {
 
     // assume the mapped file is reserved already.
@@ -240,7 +241,6 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
                                    final boolean given)
             throws BufferUnderflowException, IllegalStateException {
         final long check = adding >= 0 ? offset : offset + adding;
-        //noinspection StatementWithEmptyBody
 
         BytesStore bytesStore = this.bytesStore;
         if (!bytesStore.inside(check, adding)) {
@@ -259,6 +259,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         BytesStore bytesStore = this.bytesStore;
         if (!bytesStore.inside(offset, checkSize0(adding))) {
             acquireNextByteStore0(offset, false);
+            if (!this.bytesStore.inside(offset, checkSize0(adding)))
+                throw new DecoratedBufferUnderflowException(String.format("Acquired the next BytesStore, but still not room to add %d when realCapacity %d", adding, this.bytesStore.realCapacity()));
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
@@ -1,5 +1,6 @@
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.bytes.util.DecoratedBufferUnderflowException;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IOTools;
@@ -230,6 +231,19 @@ public class MappedBytesTest extends BytesTestCommon {
             String actual = bytesR.toString();
             Assert.assertEquals(text.substring(shift), actual);
             from.releaseLast();
+        }
+    }
+
+    @Test
+    public void testWriteLarge8Bit() throws IOException {
+        File tempFile1 = File.createTempFile("mapped", "bytes");
+        try (MappedBytes bytes = MappedBytes.mappedBytes(tempFile1, 64 << 10)) {
+            try {
+                bytes.write8bit(Bytes.from(text + text));
+                fail();
+            } catch (DecoratedBufferUnderflowException ex) {
+                assertTrue(ex.getMessage().startsWith("Acquired the next BytesStore"));
+            }
         }
     }
 


### PR DESCRIPTION
What the new test tries to do is write a 128K text block to a MappedBytes of 64K chunk size. 
Previously it would crash the VM as the ChunkedMappedBytes would (correctly) detect that the new offset was not inside the BytesStore, acquire a new BytesStore, but still not realise that we were still not inside the new BytesStore.

The only thing we can reasonably do here is throw an exception - we cannot write a message which is larger than the chunk size.


Not ready for merge - for discussion at this stage