### PR TITLE
Dont create unclosed objects to count, fix sonar badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ endif::[]
 ifdef::badges[]
 image:https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-bytes/badge.svg["Maven Central",link="https://maven-badges.herokuapp.com/maven-central/>net.openhft/chronicle-bytes"]
 image:https://javadoc.io/badge2/net.openhft/chronicle-bytes/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/chronicle-bytes/latest/index.html"]
-image:https://sonarcloud.io/api/project_badges/measure?project=apache_isis&metric=alert_status[link="https://sonarqube.chronicle.software/api/project_badges/measure?project=net.openhft%3Achronicle-bytes&metric=alert_status"]
+image:https://sonarcloud.io/api/project_badges/measure?project=OpenHFT_Chronicle-Bytes&metric=alert_status[link="https://sonarcloud.io/dashboard?id=OpenHFT_Chronicle-Bytes"]
 
 endif::[]
 

--- a/src/test/java/net/openhft/chronicle/bytes/BytesJavaDocComplianceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesJavaDocComplianceTest.java
@@ -13,6 +13,7 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -33,15 +34,17 @@ final class BytesJavaDocComplianceTest extends BytesTestCommon {
     @BeforeEach
     void beforeEach() {
         if (INITIAL_INFO_MAP.isEmpty()) {
+            AtomicInteger count = new AtomicInteger(0);
             provideBytesObjects()
                     .forEach(args -> {
+                        count.incrementAndGet();
                         final Bytes<Object> bytes = bytes(args);
                         INITIAL_INFO_MAP.put(createCommand(args), new BytesInitialInfo(bytes));
                         releaseAndAssertReleased(bytes);
                         Jvm.pause(100);
                     });
             // Make sure we have unique keys
-            assertEquals(provideBytesObjects().count(), INITIAL_INFO_MAP.size());
+            assertEquals(count.get(), INITIAL_INFO_MAP.size());
         }
     }
 


### PR DESCRIPTION
Fixes an issue where Bytes were being created but not closed. Fix the Sonarcloud badge.