### PR TITLE
Rename EnbeddedBytes to EmbeddedBytes, Fix #260

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -19,7 +19,7 @@
 package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.bytes.internal.BytesInternal;
-import net.openhft.chronicle.bytes.internal.EnbeddedBytes;
+import net.openhft.chronicle.bytes.internal.EmbeddedBytes;
 import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.annotation.UsedViaReflection;
@@ -198,7 +198,7 @@ public interface Bytes<Underlying> extends
         requireNonNull(groupName);
         @NotNull BytesStore<?, T> bs = BytesStore.forFields(object, groupName, 1);
         try {
-            final EnbeddedBytes<T> bytes = EnbeddedBytes.wrap(bs);
+            final EmbeddedBytes<T> bytes = EmbeddedBytes.wrap(bs);
             return bytes.writeLimit(bs.writeLimit());
         } catch (IllegalArgumentException | IllegalStateException e) {
             throw new AssertionError(e);

--- a/src/main/java/net/openhft/chronicle/bytes/internal/EmbeddedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/EmbeddedBytes.java
@@ -4,19 +4,19 @@ import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.VanillaBytes;
 import org.jetbrains.annotations.NotNull;
 
-public class EnbeddedBytes<Underlying> extends VanillaBytes<Underlying> {
-    private EnbeddedBytes(@NotNull BytesStore<?, ?> bytesStore, long writePosition, long writeLimit) throws IllegalStateException, IllegalArgumentException {
+public class EmbeddedBytes<Underlying> extends VanillaBytes<Underlying> {
+    private EmbeddedBytes(@NotNull BytesStore<?, ?> bytesStore, long writePosition, long writeLimit) throws IllegalStateException, IllegalArgumentException {
         super(bytesStore, writePosition, writeLimit);
     }
 
-    public static <Underlying> EnbeddedBytes<Underlying> wrap(BytesStore<?, ?> bytesStore) {
+    public static <Underlying> EmbeddedBytes<Underlying> wrap(BytesStore<?, ?> bytesStore) {
         return wrap((HeapBytesStore<?>) bytesStore);
     }
 
-    public static <Underlying> EnbeddedBytes<Underlying> wrap(HeapBytesStore<?> bytesStore) {
+    public static <Underlying> EmbeddedBytes<Underlying> wrap(HeapBytesStore<?> bytesStore) {
         long wp = bytesStore.start();
         int length = bytesStore.readUnsignedByte(wp - 1);
-        return new EnbeddedBytes<>(bytesStore, wp, wp + length);
+        return new EmbeddedBytes<>(bytesStore, wp, wp + length);
     }
 
     @Override

--- a/src/test/java/net/openhft/chronicle/bytes/BytesJavaDocComplianceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesJavaDocComplianceTest.java
@@ -1,7 +1,7 @@
 package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.bytes.internal.ChunkedMappedBytes;
-import net.openhft.chronicle.bytes.internal.EnbeddedBytes;
+import net.openhft.chronicle.bytes.internal.EmbeddedBytes;
 import net.openhft.chronicle.core.Jvm;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -135,7 +135,7 @@ final class BytesJavaDocComplianceTest extends BytesTestCommon {
                         if (!(ChunkedMappedBytes.class.isInstance(bytes))) {
                             // Unfortunately, inspecting a ChunkedMappedBytes may change its actualSize(), so no check there
 
-                            if (EnbeddedBytes.class.isInstance(bytes)) {
+                            if (EmbeddedBytes.class.isInstance(bytes)) {
                                 int foo = 1;
                             }
 


### PR DESCRIPTION
Thanks to "EnebeddedBytes" being in the `internal` package, we can now rename it.