### PR TITLE
Provide more info in ReferenceCountedUtil. Fix #308

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/ReferenceCountedUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ReferenceCountedUtil.java
@@ -19,7 +19,10 @@ public final class ReferenceCountedUtil {
      */
     public static void throwExceptionIfReleased(final ReferenceCounted referenceCounted) {
         if (referenceCounted.refCount() <= 0) {
-            throw new ClosedIllegalStateException("Released");
+            // Rather than throwing a new ClosedIllegalStateException, we invoke releaseLast() that
+            // will provide much more tracing information.
+            // Once the ref count reaches zero, this is guaranteed to throw an exception
+            referenceCounted.releaseLast();
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/bytes/internal/ReferenceCountedUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/ReferenceCountedUtilTest.java
@@ -1,0 +1,33 @@
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.io.ClosedIllegalStateException;
+import net.openhft.chronicle.core.io.ReferenceCounted;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReferenceCountedUtilTest {
+
+    @Test
+    void throwExceptionIfReleased() {
+        test(o -> ReferenceCountedUtil.throwExceptionIfReleased((ReferenceCounted) o));
+    }
+
+    @Test
+    void testThrowExceptionIfReleased() {
+        test(ReferenceCountedUtil::throwExceptionIfReleased);
+        assertDoesNotThrow(() -> ReferenceCountedUtil.throwExceptionIfReleased("Foo"));
+        assertThrows(NullPointerException.class, () -> ReferenceCountedUtil.throwExceptionIfReleased(null));
+    }
+
+    private void test(Consumer<Object> method) {
+        final Bytes<?> bytes = Bytes.from("A");
+        assertDoesNotThrow(() -> method.accept(bytes));
+        bytes.releaseLast();
+        assertThrows(ClosedIllegalStateException.class, () -> method.accept(bytes));
+    }
+
+}


### PR DESCRIPTION
This might also solve issues with custom ByteStore implementations (e.g. in CME)