### PR TITLE
Rewrite regexp. Fix #319

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 public enum PropertyReplacer {
     ; // none
 
-    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{\\s*([^}]*?)\\s*\\}");
+    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{\\s*+([^}\\s]*+)\\s*+}");
 
     public static String replaceTokensWithProperties(String expression) throws IllegalArgumentException {
 


### PR DESCRIPTION
This PR fixed the issue addressed in https://github.com/OpenHFT/Chronicle-Bytes/pull/315 by using a possessive construct with mutually excluded paths in the regexp, thereby preventing backtracing. 

This PR, if accepted, would remove the need of merging https://github.com/OpenHFT/Chronicle-Bytes/pull/315 which could be closed instead.