### PR TITLE
Fix for JVM crash when writing trivially copyable to elastic buffer

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
@@ -533,8 +533,8 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     default S unsafeWriteObject(Object o, int offset, int length)
             throws BufferOverflowException, IllegalStateException {
         if (this.isDirectMemory()) {
-            final long dest = addressForWrite(writePosition());
             writeSkip(length); // blow up here if this isn't going to work
+            final long dest = addressForWrite(writePosition() - length);
             UnsafeMemory.MEMORY.copyMemory(o, offset, dest, length);
             return (S) this;
         }
@@ -553,8 +553,8 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
      */
     default S unsafeWrite(long address, int length) {
         if (isDirectMemory()) {
-            long destAddress = addressForWrite(writePosition());
             writeSkip(length); // blow up if there isn't that much space left
+            long destAddress = addressForWrite(writePosition() - length);
             UnsafeMemory.copyMemory(address, destAddress, length);
         } else {
             int i = 0;

--- a/src/test/java/net/openhft/chronicle/bytes/UnsafeRWObjectTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UnsafeRWObjectTest.java
@@ -32,6 +32,8 @@ public class UnsafeRWObjectTest extends BytesTestCommon {
         assertEquals(bb1.l5, bb2.l5);
         assertEquals(bb1.l6, bb2.l6);
         assertEquals(bb1.l7, bb2.l7);
+
+        directElastic.releaseLast();
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/bytes/UnsafeRWObjectTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UnsafeRWObjectTest.java
@@ -10,6 +10,31 @@ import static org.junit.Assume.assumeTrue;
 
 public class UnsafeRWObjectTest extends BytesTestCommon {
     @Test
+    public void longObjectElasticBuffer() {
+        assumeTrue(Jvm.is64bit() && !Jvm.isAzulZing());
+        assertEquals("[16, 80]", Arrays.toString(BytesUtil.triviallyCopyableRange(BB.class)));
+
+        Bytes<?> directElastic = Bytes.allocateElasticDirect(32);
+
+        BB bb1 = new BB(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L);
+
+        directElastic.unsafeWriteObject(bb1, 16, 8 * 8);
+
+        BB bb2 = new BB(0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
+
+        directElastic.unsafeReadObject(bb2, 16, 8 * 8);
+
+        assertEquals(bb1.l0, bb2.l0);
+        assertEquals(bb1.l1, bb2.l1);
+        assertEquals(bb1.l2, bb2.l2);
+        assertEquals(bb1.l3, bb2.l3);
+        assertEquals(bb1.l4, bb2.l4);
+        assertEquals(bb1.l5, bb2.l5);
+        assertEquals(bb1.l6, bb2.l6);
+        assertEquals(bb1.l7, bb2.l7);
+    }
+
+    @Test
     public void shortObject() {
         assumeTrue(Jvm.is64bit() && !Jvm.isAzulZing());
         assertEquals("[12, 32]",


### PR DESCRIPTION
I've bumped into this while trying to support efficient `copyTo` for `TriviallyCopyableEvent`.
```
    default S unsafeWriteObject(Object o, int offset, int length)
            throws BufferOverflowException, IllegalStateException {
        if (this.isDirectMemory()) {
            final long dest = addressForWrite(writePosition());
            writeSkip(length); // blow up here if this isn't going to work
            UnsafeMemory.MEMORY.copyMemory(o, offset, dest, length);
```
There's a bug: `writeSkip` may cause grow of underlying bytes store (in fact, grow creates a new store that replaces the old one), and `dest` becomes invalid.