### PR TITLE
Don't readInt with existing offset when setting BytesStore on AbstractReference

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -70,7 +70,6 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
         if (this.bytes != null) {
             this.bytes.release(this);
         }
-        bytes.readInt(offset); // wake it up if it's not pointing to anything yet.
         this.bytes = bytes.bytesStore();
 
         this.bytes.reserve(this);


### PR DESCRIPTION
Fixes #342