### PR TITLE
Consistently introduce @NonNegative across the public API, Fix #290

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -70,12 +70,12 @@ public abstract class AbstractBytes<U>
     private boolean lenient = false;
     private boolean lastNumberHadDigits = false;
 
-    AbstractBytes(@NotNull BytesStore<Bytes<U>, U> bytesStore, long writePosition, long writeLimit)
+    AbstractBytes(@NotNull BytesStore<Bytes<U>, U> bytesStore, @NonNegative long writePosition, @NonNegative long writeLimit)
             throws IllegalStateException {
         this(bytesStore, writePosition, writeLimit, "");
     }
 
-    AbstractBytes(@NotNull BytesStore<Bytes<U>, U> bytesStore, long writePosition, long writeLimit, String name)
+    AbstractBytes(@NotNull BytesStore<Bytes<U>, U> bytesStore, @NonNegative long writePosition, @NonNegative long writeLimit, String name)
             throws IllegalStateException {
         super(bytesStore.isDirectMemory());
         this.bytesStore(bytesStore);
@@ -93,13 +93,13 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public boolean canReadDirect(long length) {
+    public boolean canReadDirect(@NonNegative long length) {
         long remaining = writePosition() - readPosition;
         return bytesStore.isDirectMemory() && remaining >= length;
     }
 
     @Override
-    public void move(long from, long to, long length)
+    public void move(@NonNegative long from, @NonNegative long to, @NonNegative long length)
             throws BufferUnderflowException, IllegalStateException, ArithmeticException {
         long start = start();
         bytesStore.move(from - start, to - start, length);
@@ -136,7 +136,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> clearAndPad(long length)
+    public Bytes<U> clearAndPad(@NonNegative long length)
             throws BufferOverflowException {
         final long start = start();
         if ((start + length) > capacity()) {
@@ -160,17 +160,18 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public long realCapacity() {
+    public @NonNegative long realCapacity() {
         return bytesStore.capacity();
     }
 
     @Override
-    public boolean canWriteDirect(long count) {
+    public boolean canWriteDirect(@NonNegative long count) {
         return isDirectMemory() &&
                 Math.min(writeLimit, bytesStore.realCapacity())
                         >= count + writePosition();
     }
 
+    @NonNegative
     @Override
     public long capacity() {
         return bytesStore.capacity();
@@ -182,37 +183,38 @@ public abstract class AbstractBytes<U>
         return bytesStore.underlyingObject();
     }
 
+    @NonNegative
     @Override
     public long start() {
         return bytesStore.start();
     }
 
     @Override
-    public long readPosition() {
+    public @NonNegative long readPosition() {
         return readPosition;
     }
 
     @Override
-    public long writePosition() {
+    public @NonNegative long writePosition() {
         return writePosition;
     }
 
     @Override
-    public boolean compareAndSwapInt(long offset, int expected, int value)
+    public boolean compareAndSwapInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         return bytesStore.compareAndSwapInt(offset, expected, value);
     }
 
     @Override
-    public void testAndSetInt(long offset, int expected, int value)
+    public void testAndSetInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.testAndSetInt(offset, expected, value);
     }
 
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value)
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         return bytesStore.compareAndSwapLong(offset, expected, value);
@@ -242,7 +244,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> readPosition(long position)
+    public Bytes<U> readPosition(@NonNegative long position)
             throws BufferUnderflowException, IllegalStateException {
         if (position < start()) {
             throw new DecoratedBufferUnderflowException(String.format("readPosition failed. Position: %d < start: %d", position, start()));
@@ -257,7 +259,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> readLimit(long limit)
+    public Bytes<U> readLimit(@NonNegative long limit)
             throws BufferUnderflowException {
         if (limit < start())
             throw limitLessThanStart(limit);
@@ -279,7 +281,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writePosition(long position)
+    public Bytes<U> writePosition(@NonNegative long position)
             throws BufferOverflowException {
         if (position > writeLimit())
             throw writePositionTooLarge(position);
@@ -295,11 +297,11 @@ public abstract class AbstractBytes<U>
     }
 
     @NotNull
-    private DecoratedBufferOverflowException writePositionTooSmall(long position) {
+    private DecoratedBufferOverflowException writePositionTooSmall(@NonNegative long position) {
         return new DecoratedBufferOverflowException(String.format("writePosition failed. Position: %d < start: %d", position, start()));
     }
 
-    private DecoratedBufferOverflowException writePositionTooLarge(long position) {
+    private DecoratedBufferOverflowException writePositionTooLarge(@NonNegative long position) {
         return new DecoratedBufferOverflowException(
                 String.format("writePosition failed. Position: %d > writeLimit: %d", position, writeLimit()));
     }
@@ -337,7 +339,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLimit(long limit)
+    public Bytes<U> writeLimit(@NonNegative long limit)
             throws BufferOverflowException {
         if (limit < start()) {
             throw writeLimitTooSmall(limit);
@@ -351,12 +353,12 @@ public abstract class AbstractBytes<U>
     }
 
     @NotNull
-    private DecoratedBufferOverflowException writeLimitTooBig(long limit, long capacity) {
+    private DecoratedBufferOverflowException writeLimitTooBig(@NonNegative long limit, @NonNegative long capacity) {
         return new DecoratedBufferOverflowException(String.format("writeLimit failed. Limit: %d > capacity: %d", limit, capacity));
     }
 
     @NotNull
-    private DecoratedBufferOverflowException writeLimitTooSmall(long limit) {
+    private DecoratedBufferOverflowException writeLimitTooSmall(@NonNegative long limit) {
         return new DecoratedBufferOverflowException(String.format("writeLimit failed. Limit: %d < start: %d", limit, start()));
     }
 
@@ -382,7 +384,7 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public int readUnsignedByte(long offset)
+    public int readUnsignedByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return readByte(offset) & 0xFF;
     }
@@ -452,28 +454,28 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public byte readVolatileByte(long offset)
+    public byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 1, true);
         return bytesStore.readVolatileByte(offset);
     }
 
     @Override
-    public short readVolatileShort(long offset)
+    public short readVolatileShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 2, true);
         return bytesStore.readVolatileShort(offset);
     }
 
     @Override
-    public int readVolatileInt(long offset)
+    public int readVolatileInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 4, true);
         return bytesStore.readVolatileInt(offset);
     }
 
     @Override
-    public long readVolatileLong(long offset)
+    public long readVolatileLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 8, true);
         return bytesStore.readVolatileLong(offset);
@@ -549,7 +551,7 @@ public abstract class AbstractBytes<U>
         }
     }
 
-    protected long readOffsetPositionMoved(long adding)
+    protected long readOffsetPositionMoved(@NonNegative long adding)
             throws BufferUnderflowException, IllegalStateException {
         long offset = readPosition;
         readCheckOffset(readPosition, Math.toIntExact(adding), false);
@@ -560,7 +562,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(long offset, byte i)
+    public Bytes<U> writeByte(@NonNegative long offset, byte i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeByte(offset, i);
@@ -569,7 +571,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeShort(long offset, short i)
+    public Bytes<U> writeShort(@NonNegative long offset, short i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeShort(offset, i);
@@ -578,7 +580,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeInt(long offset, int i)
+    public Bytes<U> writeInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeInt(offset, i);
@@ -587,7 +589,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedInt(long offset, int i)
+    public Bytes<U> writeOrderedInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeOrderedInt(offset, i);
@@ -596,7 +598,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLong(long offset, long i)
+    public Bytes<U> writeLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeLong(offset, i);
@@ -605,7 +607,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedLong(long offset, long i)
+    public Bytes<U> writeOrderedLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeOrderedLong(offset, i);
@@ -614,7 +616,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeFloat(long offset, float d)
+    public Bytes<U> writeFloat(@NonNegative long offset, float d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeFloat(offset, d);
@@ -623,7 +625,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeDouble(long offset, double d)
+    public Bytes<U> writeDouble(@NonNegative long offset, double d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeDouble(offset, d);
@@ -632,7 +634,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileByte(long offset, byte i8)
+    public Bytes<U> writeVolatileByte(@NonNegative long offset, byte i8)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeVolatileByte(offset, i8);
@@ -641,7 +643,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileShort(long offset, short i16)
+    public Bytes<U> writeVolatileShort(@NonNegative long offset, short i16)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeVolatileShort(offset, i16);
@@ -650,7 +652,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileInt(long offset, int i32)
+    public Bytes<U> writeVolatileInt(@NonNegative long offset, int i32)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeVolatileInt(offset, i32);
@@ -659,7 +661,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileLong(long offset, long i64)
+    public Bytes<U> writeVolatileLong(@NonNegative long offset, long i64)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeVolatileLong(offset, i64);
@@ -702,7 +704,7 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public void write(long offsetInRDO, @NotNull ByteBuffer bytes, int offset, int length)
+    public void write(@NonNegative long offsetInRDO, @NotNull ByteBuffer bytes, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException {
         requireNonNull(bytes);
         if (this.bytesStore.inside(offsetInRDO, length)) {
@@ -729,7 +731,7 @@ public abstract class AbstractBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> write(long writeOffset, @NotNull RandomDataInput bytes, long readOffset, long length)
+    public Bytes<U> write(@NonNegative long writeOffset, @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
 
         requireNonNegative(writeOffset);
@@ -750,7 +752,7 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public @NotNull Bytes<U> write8bit(@NotNull String text, int start, int length) throws BufferOverflowException, IndexOutOfBoundsException, ArithmeticException, IllegalStateException, BufferUnderflowException {
+    public @NotNull Bytes<U> write8bit(@NotNull String text, @NonNegative int start, @NonNegative int length) throws BufferOverflowException, IndexOutOfBoundsException, ArithmeticException, IllegalStateException, BufferUnderflowException {
         requireNonNull(text); // This needs to be checked or else the JVM might crash
         final long toWriteLength = UnsafeMemory.INSTANCE.stopBitLength(length) + (long) length;
         final long position = writeOffsetPositionMoved(toWriteLength, 0);
@@ -773,23 +775,23 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public long write8bit(long position, @NotNull BytesStore bs) {
+    public long write8bit(@NonNegative long position, @NotNull BytesStore bs) {
         return bytesStore.write8bit(position, bs);
     }
 
     @Override
-    public long write8bit(long position, @NotNull String s, int start, int length) {
+    public long write8bit(@NonNegative long position, @NotNull String s, @NonNegative int start, @NonNegative int length) {
         return bytesStore.write8bit(position, s, start, length);
     }
 
-    protected void writeCheckOffset(long offset, long adding)
+    protected void writeCheckOffset(@NonNegative long offset, @NonNegative long adding)
             throws BufferOverflowException, IllegalStateException {
         if (BYTES_BOUNDS_UNCHECKED)
             return;
         writeCheckOffset0(offset, adding);
     }
 
-    private void writeCheckOffset0(long offset, long adding)
+    private void writeCheckOffset0(@NonNegative long offset, @NonNegative long adding)
             throws DecoratedBufferOverflowException {
         final long start = start();
         if (offset < start || offset + adding < start) {
@@ -801,72 +803,72 @@ public abstract class AbstractBytes<U>
     }
 
     @NotNull
-    private DecoratedBufferOverflowException newBOERange(long offset, long adding, String msg, long limit) {
+    private DecoratedBufferOverflowException newBOERange(@NonNegative long offset, long adding, String msg, @NonNegative long limit) {
         return new DecoratedBufferOverflowException(
                 String.format(msg, offset, adding, limit));
     }
 
     @NotNull
-    private DecoratedBufferOverflowException newBOELower(long offset) {
+    private DecoratedBufferOverflowException newBOELower(@NonNegative long offset) {
         return new DecoratedBufferOverflowException(String.format("writeCheckOffset failed. Offset: %d < start: %d", offset, start()));
     }
 
     @Override
-    public byte readByte(long offset)
+    public byte readByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 1, true);
         return bytesStore.readByte(offset);
     }
 
     @Override
-    public int peekUnsignedByte(long offset)
+    public int peekUnsignedByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return offset >= readLimit() ? -1 : bytesStore.peekUnsignedByte(offset);
     }
 
     @Override
-    public short readShort(long offset)
+    public short readShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 2, true);
         return bytesStore.readShort(offset);
     }
 
     @Override
-    public int readInt(long offset)
+    public int readInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 4, true);
         return bytesStore.readInt(offset);
     }
 
     @Override
-    public long readLong(long offset)
+    public long readLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 8, true);
         return bytesStore.readLong(offset);
     }
 
     @Override
-    public float readFloat(long offset)
+    public float readFloat(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 4, true);
         return bytesStore.readFloat(offset);
     }
 
     @Override
-    public double readDouble(long offset)
+    public double readDouble(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         readCheckOffset(offset, 8, true);
         return bytesStore.readDouble(offset);
     }
 
-    protected void readCheckOffset(long offset, long adding, boolean given)
+    protected void readCheckOffset(@NonNegative long offset, long adding, boolean given)
             throws BufferUnderflowException, IllegalStateException {
         if (BYTES_BOUNDS_UNCHECKED)
             return;
         readCheckOffset0(offset, adding, given);
     }
 
-    private void readCheckOffset0(long offset, long adding, boolean given)
+    private void readCheckOffset0(@NonNegative long offset, long adding, boolean given)
             throws DecoratedBufferUnderflowException {
         if (offset < start()) {
             throw newBOEReadLower(offset);
@@ -878,25 +880,25 @@ public abstract class AbstractBytes<U>
     }
 
     @NotNull
-    private DecoratedBufferUnderflowException newBOEReadUpper(long offset, long adding, boolean given) {
+    private DecoratedBufferUnderflowException newBOEReadUpper(@NonNegative long offset, long adding, boolean given) {
         long limit2 = given ? writeLimit() : readLimit();
         return new DecoratedBufferUnderflowException(String
                 .format("readCheckOffset0 failed. Offset: %d + adding: %d > limit: %d (given: %s)", offset, adding, limit2, given));
     }
 
     @NotNull
-    private DecoratedBufferUnderflowException newBOEReadLower(long offset) {
+    private DecoratedBufferUnderflowException newBOEReadLower(@NonNegative long offset) {
         return new DecoratedBufferUnderflowException(String.format("readCheckOffset0 failed. Offset: %d < start: %d", offset, start()));
     }
 
-    void prewriteCheckOffset(long offset, long subtracting)
+    void prewriteCheckOffset(@NonNegative long offset, long subtracting)
             throws BufferOverflowException, IllegalStateException {
         if (BYTES_BOUNDS_UNCHECKED)
             return;
         prewriteCheckOffset0(offset, subtracting);
     }
 
-    private void prewriteCheckOffset0(long offset, long subtracting)
+    private void prewriteCheckOffset0(@NonNegative long offset, long subtracting)
             throws BufferOverflowException {
         if ((offset - subtracting) < start()) {
             throw newBOERange(offset, subtracting, "prewriteCheckOffset0 failed. Offset: %d - subtracting: %d < start: %d", start());
@@ -971,12 +973,12 @@ public abstract class AbstractBytes<U>
         return this;
     }
 
-    protected final long writeOffsetPositionMoved(long adding)
+    protected final long writeOffsetPositionMoved(@NonNegative long adding)
             throws BufferOverflowException, IllegalStateException {
         return writeOffsetPositionMoved(adding, adding);
     }
 
-    protected long writeOffsetPositionMoved(long adding, long advance)
+    protected long writeOffsetPositionMoved(@NonNegative long adding, @NonNegative long advance)
             throws BufferOverflowException, IllegalStateException {
         long oldPosition = writePosition();
         writeCheckOffset(oldPosition, adding);
@@ -984,11 +986,11 @@ public abstract class AbstractBytes<U>
         return oldPosition;
     }
 
-    protected void uncheckedWritePosition(long writePosition) {
+    protected void uncheckedWritePosition(@NonNegative long writePosition) {
         this.writePosition = writePosition;
     }
 
-    protected long prewriteOffsetPositionMoved(long subtracting)
+    protected long prewriteOffsetPositionMoved(@NonNegative long subtracting)
             throws BufferOverflowException, IllegalStateException {
         prewriteCheckOffset(readPosition, subtracting);
         readPosition -= subtracting;
@@ -1015,7 +1017,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeIntAdv(int i, int advance)
+    public Bytes<U> writeIntAdv(int i, @NonNegative int advance)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(4, advance);
         bytesStore.writeInt(offset, i);
@@ -1033,7 +1035,7 @@ public abstract class AbstractBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLongAdv(long i64, int advance)
+    public Bytes<U> writeLongAdv(long i64, @NonNegative int advance)
             throws BufferOverflowException, IllegalStateException {
         long offset = writeOffsetPositionMoved(8, advance);
         bytesStore.writeLong(offset, i64);
@@ -1069,7 +1071,7 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public int read(byte[] bytes, int off, int len) throws BufferUnderflowException, IllegalStateException {
+    public int read(byte[] bytes, @NonNegative int off, @NonNegative int len) throws BufferUnderflowException, IllegalStateException {
         requireNonNull(bytes);
         long remaining = readRemaining();
         if (remaining <= 0)
@@ -1088,7 +1090,7 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public long read(long offsetInRDI, byte[] bytes, int offset, int length) throws IllegalStateException {
+    public long read(@NonNegative long offsetInRDI, byte[] bytes, @NonNegative int offset, @NonNegative int length) throws IllegalStateException {
         return bytesStore.read(offsetInRDI, bytes, offset, length);
     }
 
@@ -1158,13 +1160,13 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public long addressForRead(long offset)
+    public long addressForRead(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return bytesStore.addressForRead(offset);
     }
 
     @Override
-    public long addressForWrite(long offset)
+    public long addressForWrite(@NonNegative long offset)
             throws BufferOverflowException, IllegalStateException {
         return bytesStore.addressForWrite(offset);
     }
@@ -1201,13 +1203,13 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public void nativeRead(long position, long address, long size)
+    public void nativeRead(@NonNegative long position, long address, @NonNegative long size)
             throws BufferUnderflowException, IllegalStateException {
         bytesStore.nativeRead(position, address, size);
     }
 
     @Override
-    public void nativeWrite(long address, long position, long size)
+    public void nativeWrite(long address, @NonNegative long position, @NonNegative long size)
             throws BufferOverflowException, IllegalStateException {
         bytesStore.nativeWrite(address, position, size);
     }
@@ -1269,7 +1271,7 @@ public abstract class AbstractBytes<U>
     }
 
     @Override
-    public int byteCheckSum(long start, long end)
+    public int byteCheckSum(@NonNegative long start, @NonNegative long end)
             throws BufferUnderflowException, IllegalStateException {
         if (end < Integer.MAX_VALUE && isDirectMemory())
             return byteCheckSum((int) start, (int) end);
@@ -1284,27 +1286,27 @@ public abstract class AbstractBytes<U>
     private final class UncheckedRandomDataInputHolder implements UncheckedRandomDataInput {
 
         @Override
-        public byte readByte(long offset) {
+        public byte readByte(@NonNegative long offset) {
             return bytesStore.readByte(offset);
         }
 
         @Override
-        public short readShort(long offset) {
+        public short readShort(@NonNegative long offset) {
             return bytesStore.readShort(offset);
         }
 
         @Override
-        public int readInt(long offset) {
+        public int readInt(@NonNegative long offset) {
             return bytesStore.readInt(offset);
         }
 
         @Override
-        public long readLong(long offset) {
+        public long readLong(@NonNegative long offset) {
             return bytesStore.readLong(offset);
         }
     }
 
-    public int byteCheckSum(int start, int end)
+    public int byteCheckSum(@NonNegative int start, @NonNegative int end)
             throws BufferUnderflowException, IllegalStateException {
         int sum = 0;
         for (int i = start; i < end; i++) {

--- a/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.bytes.internal.NativeBytesStore;
 import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.annotation.Java9;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,7 +39,7 @@ public enum AppendableUtil {
 
     private static final String MALFORMED_INPUT_AROUND_BYTE = "malformed input around byte ";
 
-    public static void setCharAt(@NotNull Appendable sb, int index, char ch)
+    public static void setCharAt(@NotNull Appendable sb, @NonNegative int index, char ch)
             throws IllegalArgumentException, BufferOverflowException {
         if (sb instanceof StringBuilder)
             ((StringBuilder) sb).setCharAt(index, ch);
@@ -52,12 +53,12 @@ public enum AppendableUtil {
             throw new IllegalArgumentException("" + sb.getClass());
     }
 
-    public static void parseUtf8(@NotNull BytesStore bs, StringBuilder sb, boolean utf, int length)
+    public static void parseUtf8(@NotNull BytesStore bs, StringBuilder sb, boolean utf, @NonNegative int length)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, IllegalStateException {
         BytesInternal.parseUtf8(bs, bs.readPosition(), sb, utf, length);
     }
 
-    public static void setLength(@NotNull Appendable sb, int newLength)
+    public static void setLength(@NotNull Appendable sb, @NonNegative int newLength)
             throws IllegalArgumentException, IllegalStateException, BufferUnderflowException {
         requireNonNull(sb);
         if (sb instanceof StringBuilder)
@@ -206,7 +207,7 @@ public enum AppendableUtil {
         return new UTFDataFormatException(MALFORMED_INPUT_AROUND_BYTE + Integer.toHexString(c));
     }
 
-    public static void parse8bit_SB1(@NotNull Bytes bytes, @NotNull StringBuilder sb, int length)
+    public static void parse8bit_SB1(@NotNull Bytes bytes, @NotNull StringBuilder sb, @NonNegative int length)
             throws BufferUnderflowException, IllegalStateException {
         if (length > bytes.readRemaining())
             throw new BufferUnderflowException();
@@ -216,7 +217,7 @@ public enum AppendableUtil {
         bytes.readSkip(count);
     }
 
-    public static void parse8bit(@NotNull StreamingDataInput bytes, Appendable appendable, int utflen)
+    public static void parse8bit(@NotNull StreamingDataInput bytes, Appendable appendable, @NonNegative int utflen)
             throws BufferUnderflowException, IOException, IllegalStateException {
         if (appendable instanceof StringBuilder) {
             @NotNull final StringBuilder sb = (StringBuilder) appendable;
@@ -230,7 +231,7 @@ public enum AppendableUtil {
         }
     }
 
-    public static <C extends Appendable & CharSequence> void append(C a, CharSequence cs, long start, long len)
+    public static <C extends Appendable & CharSequence> void append(C a, CharSequence cs, @NonNegative long start, @NonNegative long len)
             throws ArithmeticException, BufferUnderflowException, IllegalStateException, BufferOverflowException {
         if (a instanceof StringBuilder) {
             if (cs instanceof Bytes)
@@ -322,7 +323,7 @@ public enum AppendableUtil {
         return utflen;
     }
 
-    public static long findUtf8Length(char[] chars, int offset, int length) {
+    public static long findUtf8Length(char[] chars, @NonNegative int offset, @NonNegative int length) {
         requireNonNull(chars);
         long utflen = length;
         for (int i = offset, end = offset + length; i < end; i++) {

--- a/src/main/java/net/openhft/chronicle/bytes/ByteStringAppender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ByteStringAppender.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.bytes;
 import net.openhft.chronicle.bytes.internal.ByteStringWriter;
 import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.core.Maths;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.UnsafeText;
 import org.jetbrains.annotations.NotNull;
@@ -265,7 +266,7 @@ public interface ByteStringAppender<B extends ByteStringAppender<B>> extends Str
      */
     @Override
     @NotNull
-    default B append(@NotNull CharSequence cs, int start, int end)
+    default B append(@NotNull CharSequence cs, @NonNegative int start, @NonNegative int end)
             throws IndexOutOfBoundsException {
         BytesInternal.appendUtf8(this, cs, start, end - start);
         return (B) this;
@@ -335,7 +336,7 @@ public interface ByteStringAppender<B extends ByteStringAppender<B>> extends Str
      * @throws BufferUnderflowException if the capacity of the underlying buffer was exceeded
      * @throws IndexOutOfBoundsException if the start or the end are not valid for the CharSequence
      */
-    default B append8bit(@NotNull CharSequence cs, int start, int end)
+    default B append8bit(@NotNull CharSequence cs, @NonNegative int start, @NonNegative int end)
             throws IllegalArgumentException, BufferOverflowException, BufferUnderflowException, IndexOutOfBoundsException, IllegalStateException {
         if (cs instanceof BytesStore) {
             return write((BytesStore) cs, (long) start, end);
@@ -361,7 +362,7 @@ public interface ByteStringAppender<B extends ByteStringAppender<B>> extends Str
      * @throws IndexOutOfBoundsException if the specified indexes for the BytesStore are out of range
      * @throws IllegalStateException     if the underlying Bytes is closed
      */
-    default B append8bit(@NotNull BytesStore bs, long start, long end)
+    default B append8bit(@NotNull BytesStore bs, @NonNegative long start, @NonNegative long end)
             throws IllegalArgumentException, BufferOverflowException, BufferUnderflowException, IndexOutOfBoundsException, IllegalStateException {
         return write(bs, start, end);
     }

--- a/src/main/java/net/openhft/chronicle/bytes/Byteable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Byteable.java
@@ -18,6 +18,8 @@
 
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -36,12 +38,11 @@ import java.nio.channels.FileLock;
 public interface Byteable<B extends BytesStore<B, U>, U> {
     /**
      * This setter for a data type which points to an underlying ByteStore.
-     *
-     * @param bytesStore the fix point ByteStore
+     *  @param bytesStore the fix point ByteStore
      * @param offset     the offset within the ByteStore
      * @param length     the length in the ByteStore
      */
-    void bytesStore(BytesStore<B, U> bytesStore, long offset, long length)
+    void bytesStore(@NotNull BytesStore<B, U> bytesStore, @NonNegative long offset, @NonNegative long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException;
 
     @Nullable

--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -669,7 +669,7 @@ public interface Bytes<U> extends
      */
     @NotNull
     static String toString(@NotNull final Bytes<?> buffer,
-                           final long maxLen) throws
+                           @NonNegative final long maxLen) throws
             BufferUnderflowException, IllegalStateException, IllegalArgumentException {
         requireNonNegative(maxLen);
         if (buffer.refCount() < 1)
@@ -834,7 +834,7 @@ public interface Bytes<U> extends
      * lower than the virtual {@link #capacity()}.
      */
     @Override
-    default long realCapacity() {
+    default @NonNegative long realCapacity() {
         return BytesStore.super.realCapacity();
     }
 
@@ -870,7 +870,7 @@ public interface Bytes<U> extends
      * @throws IllegalArgumentException if the provided {@code maxLength} is negative.
      */
     @NotNull
-    default String toHexString(long maxLength) {
+    default String toHexString(@NonNegative long maxLength) {
         return toHexString(readPosition(), maxLength);
     }
 
@@ -884,7 +884,7 @@ public interface Bytes<U> extends
      * @throws IllegalArgumentException if the provided {@code maxLength}  or provided {@code maxLength} is negative.
      */
     @NotNull
-    default String toHexString(long offset, long maxLength) {
+    default String toHexString(@NonNegative long offset, @NonNegative long maxLength) {
         requireNonNegative(offset);
         requireNonNegative(maxLength);
 
@@ -1017,7 +1017,7 @@ public interface Bytes<U> extends
      * @param fromOffset the offset from the target bytes
      * @param count      the number of bytes to un-write
      */
-    default void unwrite(long fromOffset, int count)
+    default void unwrite(@NonNegative long fromOffset, @NonNegative int count)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         long wp = writePosition();
 
@@ -1151,7 +1151,7 @@ public interface Bytes<U> extends
      * @return index of equal contents or -1
      * @throws NullPointerException if the provided {@code source } is {@code null}
      */
-    default int indexOf(@NotNull BytesStore source, int fromIndex)
+    default int indexOf(@NotNull BytesStore source, @NonNegative int fromIndex)
             throws IllegalStateException {
         throwExceptionIfReleased(this);
         throwExceptionIfReleased(source);
@@ -1224,7 +1224,7 @@ public interface Bytes<U> extends
      * @throws IllegalArgumentException if the provided {@code length} is negative.
      * @throws NullPointerException     if the provided {@code bytesOut} is {@code null}.
      */
-    default void readWithLength(long length, @NotNull BytesOut<U> bytesOut)
+    default void readWithLength(@NonNegative long length, @NotNull BytesOut<U> bytesOut)
             throws BufferUnderflowException, IORuntimeException, BufferOverflowException, IllegalStateException {
         requireNonNegative(length);
         if (length > readRemaining())

--- a/src/main/java/net/openhft/chronicle/bytes/BytesPrepender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesPrepender.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.bytes.internal.BytesInternal;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,7 +36,7 @@ public interface BytesPrepender<B extends BytesPrepender<B>> {
      * @throws BufferOverflowException if the length &gt; capacity() - start()
      */
     @NotNull
-    B clearAndPad(long length)
+    B clearAndPad(@NonNegative long length)
             throws BufferOverflowException, IllegalStateException;
 
     /**

--- a/src/main/java/net/openhft/chronicle/bytes/BytesRingBuffer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesRingBuffer.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.Closeable;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,7 +38,7 @@ public interface BytesRingBuffer extends BytesRingBufferStats, BytesConsumer, Cl
     @NotNull
     static MultiReaderBytesRingBuffer newInstance(
             @NotNull BytesStore<?, Void> bytesStore,
-            int numReaders) {
+            @NonNegative int numReaders) {
         try {
             @NotNull final Class<MultiReaderBytesRingBuffer> aClass = clazz();
             final Constructor<MultiReaderBytesRingBuffer> constructor = aClass
@@ -60,11 +61,11 @@ public interface BytesRingBuffer extends BytesRingBufferStats, BytesConsumer, Cl
                 "software.chronicle.enterprise.ring.EnterpriseRingBuffer");
     }
 
-    static long sizeFor(long capacity) {
+    static long sizeFor(@NonNegative long capacity) {
         return sizeFor(capacity, 1);
     }
 
-    static long sizeFor(long capacity, int numReaders) {
+    static long sizeFor(@NonNegative long capacity, @NonNegative int numReaders) {
         try {
             final Method sizeFor = Class.forName(
                     "software.chronicle.enterprise.queue.ChronicleRingBuffer").getMethod("sizeFor", long.class, int.class);

--- a/src/main/java/net/openhft/chronicle/bytes/BytesRingBufferStats.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesRingBufferStats.java
@@ -18,6 +18,8 @@
 
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
+
 import java.util.List;
 
 public interface BytesRingBufferStats {
@@ -27,17 +29,22 @@ public interface BytesRingBufferStats {
      *
      * @return Long.MAX_VALUE if no read calls were made since the last time this method was called.
      */
+    @NonNegative
     long minNumberOfWriteBytesRemaining();
 
     /**
      * @return the total capacity in bytes
      */
+    @NonNegative
     long capacity();
 
+    @NonNegative
     long getAndClearWriteCount();
 
+    @NonNegative
     long getAndClearMissedWriteCount();
 
+    @NonNegative
     long getAndClearContentionCount();
 
     List<RingBufferReaderStats> readers();

--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -24,6 +24,7 @@ import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.bytes.internal.HeapBytesStore;
 import net.openhft.chronicle.bytes.internal.NativeBytesStore;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.ReferenceCounted;
 import org.jetbrains.annotations.NotNull;
@@ -122,19 +123,19 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      *
      * @param capacity of the buffer
      */
-    static BytesStore<?, Void> nativeStore(long capacity) {
+    static BytesStore<?, Void> nativeStore(@NonNegative long capacity) {
         return NativeBytesStore.nativeStore(capacity);
     }
 
-    static BytesStore<?, Void> nativeStoreWithFixedCapacity(long capacity) {
+    static BytesStore<?, Void> nativeStoreWithFixedCapacity(@NonNegative long capacity) {
         return NativeBytesStore.nativeStoreWithFixedCapacity(capacity);
     }
 
-    static BytesStore<?, Void> lazyNativeBytesStoreWithFixedCapacity(long capacity) {
+    static BytesStore<?, Void> lazyNativeBytesStoreWithFixedCapacity(@NonNegative long capacity) {
         return NativeBytesStore.lazyNativeBytesStoreWithFixedCapacity(capacity);
     }
 
-    static BytesStore<?, ByteBuffer> elasticByteBuffer(int size, long maxSize) {
+    static BytesStore<?, ByteBuffer> elasticByteBuffer(@NonNegative int size, @NonNegative long maxSize) {
         return NativeBytesStore.elasticByteBuffer(size, maxSize);
     }
 
@@ -168,7 +169,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @return a PointerBytesStore
      */
     @NotNull
-    static PointerBytesStore wrap(long address, long length) {
+    static PointerBytesStore wrap(long address, @NonNegative long length) {
         @NotNull PointerBytesStore pbs = nativePointer();
         pbs.set(address, length);
         return pbs;
@@ -252,7 +253,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @return the actual capacity available before resizing
      */
     @Override
-    default long realCapacity() {
+    default @NonNegative long realCapacity() {
         return capacity();
     }
 
@@ -260,6 +261,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @return The maximum limit you can set.
      */
     @Override
+    @NonNegative
     long capacity();
 
     /**
@@ -276,7 +278,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param offset the specified offset to check
      * @return <code>true</code> if offset is safe
      */
-    default boolean inside(long offset) {
+    default boolean inside(@NonNegative long offset) {
         return start() <= offset && offset < safeLimit();
     }
 
@@ -287,7 +289,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param buffer the number of bytes after the offset to check
      * @return <code>true</code> if the bytes between the offset and offset+buffer are inside the BytesStore
      */
-    default boolean inside(long offset, long buffer) {
+    default boolean inside(@NonNegative long offset, @NonNegative long buffer) {
         return start() <= offset && offset + buffer < safeLimit();
     }
 
@@ -348,7 +350,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      */
     @Override
     @NotNull
-    default B zeroOut(long start, long end)
+    default B zeroOut(@NonNegative long start, @NonNegative long end)
             throws IllegalStateException {
         if (end <= start)
             return (B) this;
@@ -376,6 +378,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @return length in bytes to read or Integer.MAX_VALUE if longer.
      */
     @Override
+    @NonNegative
     default int length() {
         return (int) Math.min(Integer.MAX_VALUE, readRemaining());
     }
@@ -384,7 +387,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * Assume ISO-8859-1 encoding, subclasses can override this.
      */
     @Override
-    default char charAt(int index)
+    default char charAt(@NonNegative int index)
             throws IndexOutOfBoundsException {
         try {
             return (char) readUnsignedByte(readPosition() + index);
@@ -404,7 +407,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      */
     @NotNull
     @Override
-    default CharSequence subSequence(int start, int end) {
+    default CharSequence subSequence(@NonNegative int start, @NonNegative int end) {
         if (start < 0 || end > length() || end < start)
             throw new IndexOutOfBoundsException("start " + start + ", end " + end + ", length " + length());
 
@@ -431,7 +434,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @return this BytesStore as a DebugString.
      */
     @NotNull
-    default String toDebugString(long maxLength)
+    default String toDebugString(@NonNegative long maxLength)
             throws IllegalStateException, ArithmeticException {
         return BytesInternal.toDebugString(this, maxLength);
     }
@@ -451,7 +454,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param length     the length to match
      * @return <code>true</code> if the bytes up to min(length, this.length(), bytesStore.length()) matched.
      */
-    default boolean equalBytes(@NotNull BytesStore bytesStore, long length)
+    default boolean equalBytes(@NotNull BytesStore bytesStore, @NonNegative long length)
             throws BufferUnderflowException, IllegalStateException {
         return length == 8 && bytesStore.length() >= 8
                 ? readLong(readPosition()) == bytesStore.readLong(bytesStore.readPosition())
@@ -482,7 +485,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @throws BufferUnderflowException if the specified indexes are outside the limits of the BytesStore
      * @throws IllegalStateException    if the BytesStore has been released
      */
-    default int byteCheckSum(long start, long end)
+    default int byteCheckSum(@NonNegative long start, @NonNegative long end)
             throws BufferUnderflowException, IllegalStateException {
         int sum = 0;
         for (long i = start; i < end; i++) {
@@ -563,7 +566,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param adding value to add, can be 1
      * @return the sum
      */
-    default int addAndGetUnsignedByteNotAtomic(long offset, int adding)
+    default int addAndGetUnsignedByteNotAtomic(@NonNegative long offset, int adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             int r = (readUnsignedByte(offset) + adding) & 0xFF;
@@ -581,7 +584,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param adding value to add, can be 1
      * @return the sum
      */
-    default short addAndGetShortNotAtomic(long offset, short adding)
+    default short addAndGetShortNotAtomic(@NonNegative long offset, short adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             short r = (short) (readShort(offset) + adding);
@@ -599,7 +602,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param adding value to add, can be 1
      * @return the sum
      */
-    default int addAndGetIntNotAtomic(long offset, int adding)
+    default int addAndGetIntNotAtomic(@NonNegative long offset, int adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             int r = readInt(offset) + adding;
@@ -617,7 +620,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param adding value to add, can be 1
      * @return the sum
      */
-    default double addAndGetDoubleNotAtomic(long offset, double adding)
+    default double addAndGetDoubleNotAtomic(@NonNegative long offset, double adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             double r = readDouble(offset) + adding;
@@ -635,7 +638,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param adding value to add, can be 1
      * @return the sum
      */
-    default float addAndGetFloatNotAtomic(long offset, float adding)
+    default float addAndGetFloatNotAtomic(@NonNegative long offset, float adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             float r = readFloat(offset) + adding;
@@ -646,7 +649,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
         }
     }
 
-    void move(long from, long to, long length)
+    void move(@NonNegative long from, @NonNegative long to, @NonNegative long length)
             throws BufferUnderflowException, IllegalStateException, ArithmeticException;
 
     /**
@@ -655,7 +658,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param offset  the offset to write to
      * @param atLeast the long value that is to be written at offset if it is not less than the current value at offset
      */
-    default void writeMaxLong(long offset, long atLeast)
+    default void writeMaxLong(@NonNegative long offset, long atLeast)
             throws BufferUnderflowException, IllegalStateException {
         try {
             for (; ; ) {
@@ -677,7 +680,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param offset  the offset to write to
      * @param atLeast the int value that is to be written at offset if it is not less than the current value at offset
      */
-    default void writeMaxInt(long offset, int atLeast)
+    default void writeMaxInt(@NonNegative long offset, int atLeast)
             throws BufferUnderflowException, IllegalStateException {
         try {
             for (; ; ) {
@@ -762,7 +765,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
      * @param s      the String to compare to
      * @return <code>true</code> if the specified portion of this BytesStore is equal to s
      */
-    default boolean isEqual(long start, long length, String s) {
+    default boolean isEqual(@NonNegative long start, @NonNegative long length, String s) {
         if (s == null || s.length() != length)
             return false;
         int length2 = (int) length;

--- a/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.bytes;
 import net.openhft.chronicle.bytes.internal.BytesFieldInfo;
 import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.core.*;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -100,9 +101,11 @@ public enum BytesUtil {
      * Are all the fields in the range given trivially copyable
      *
      * @param clazz to check
+     * @param offset start of field area
+     * @param length of the field area
      * @return true if the fields in range are trivially copyable.
      */
-    public static boolean isTriviallyCopyable(Class clazz, int offset, int length) {
+    public static boolean isTriviallyCopyable(Class clazz, @NonNegative int offset, @NonNegative int length) {
         int[] ints = TRIVIALLY_COPYABLE.get(clazz);
         if (ints.length == 0)
             return false;
@@ -200,7 +203,7 @@ public enum BytesUtil {
         return true;
     }
 
-    public static boolean bytesEqual(@Nullable CharSequence cs, @NotNull RandomDataInput bs, long offset, int length)
+    public static boolean bytesEqual(@Nullable CharSequence cs, @NotNull RandomDataInput bs, @NonNegative long offset, @NonNegative int length)
             throws IllegalStateException, BufferUnderflowException {
         if (cs == null || cs.length() != length)
             return false;
@@ -245,7 +248,7 @@ public enum BytesUtil {
     }
 
     @NotNull
-    public static char[] toCharArray(@NotNull Bytes bytes, long position, int length)
+    public static char[] toCharArray(@NotNull Bytes bytes, @NonNegative long position, @NonNegative int length)
             throws IllegalStateException, BufferUnderflowException {
         @NotNull final char[] chars = new char[length];
 
@@ -269,7 +272,7 @@ public enum BytesUtil {
     /**
      * @return the resulting offset
      */
-    public static long writeStopBit(BytesStore bs, long offset, long n)
+    public static long writeStopBit(BytesStore bs, @NonNegative long offset, @NonNegative long n)
             throws IllegalStateException, BufferOverflowException {
         return BytesInternal.writeStopBit(bs, offset, n);
     }
@@ -283,7 +286,7 @@ public enum BytesUtil {
     }
 
     public static void parseUtf8(
-            @NotNull StreamingDataInput in, Appendable appendable, int utflen)
+            @NotNull StreamingDataInput in, Appendable appendable, @NonNegative int utflen)
             throws UTFDataFormatRuntimeException, IllegalStateException, BufferUnderflowException {
         BytesInternal.parseUtf8(in, appendable, true, utflen);
     }
@@ -294,7 +297,7 @@ public enum BytesUtil {
     }
 
     // used by Chronicle FIX.
-    public static void appendBytesFromStart(@NotNull Bytes bytes, long startPosition, @NotNull StringBuilder sb)
+    public static void appendBytesFromStart(@NotNull Bytes bytes, @NonNegative long startPosition, @NotNull StringBuilder sb)
             throws IllegalStateException {
         try {
             BytesInternal.parse8bit(startPosition, bytes, sb, (int) (bytes.readPosition() - startPosition));
@@ -352,13 +355,13 @@ public enum BytesUtil {
         bytes.zeroOut(start, end);
     }
 
-    public static String toDebugString(@NotNull RandomDataInput bytes, long start, long maxLength)
+    public static String toDebugString(@NotNull RandomDataInput bytes, @NonNegative long start, @NonNegative long maxLength)
             throws IllegalStateException, BufferUnderflowException, ArithmeticException {
         BytesStore bytes2 = bytes.subBytes(start, maxLength);
         return bytes2.toDebugString(maxLength);
     }
 
-    public static void copy8bit(BytesStore bs, long addressForWrite, long length) {
+    public static void copy8bit(BytesStore bs, long addressForWrite, @NonNegative long length) {
         BytesInternal.copy8bit(bs, addressForWrite, length);
     }
 
@@ -375,7 +378,7 @@ public enum BytesUtil {
         }
     }
 
-    public static void reverse(Bytes<?> text, int start) {
+    public static void reverse(Bytes<?> text, @NonNegative int start) {
         long rp = text.readPosition();
         int end = text.length() - 1;
         int mid = (start + end + 1) / 2;

--- a/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProvider.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.bytes;
 import net.openhft.chronicle.bytes.ref.BinaryLongArrayReference;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.*;
 import net.openhft.chronicle.core.time.SystemTimeProvider;
 import net.openhft.chronicle.core.time.TimeProvider;
@@ -37,7 +38,7 @@ public class DistributedUniqueTimeProvider extends SimpleCloseable implements Ti
     static final int HOST_IDS = 100;
     private static final int NANOS_PER_MICRO = 1000;
 
-    private DistributedUniqueTimeProvider(int hostId, boolean unmonitor) {
+    private DistributedUniqueTimeProvider(@NonNegative int hostId, boolean unmonitor) {
         hostId(hostId);
         try {
             file = MappedFile.ofSingle(new File(BytesUtil.TIME_STAMP_PATH), OS.pageSize(), false);
@@ -75,11 +76,11 @@ public class DistributedUniqueTimeProvider extends SimpleCloseable implements Ti
         file.releaseLast();
     }
 
-    public static DistributedUniqueTimeProvider forHostId(int hostId) {
+    public static DistributedUniqueTimeProvider forHostId(@NonNegative int hostId) {
         return new DistributedUniqueTimeProvider(hostId, false);
     }
 
-    public DistributedUniqueTimeProvider hostId(int hostId) {
+    public DistributedUniqueTimeProvider hostId(@NonNegative int hostId) {
         if (hostId < 0)
             throw new IllegalArgumentException("Invalid hostId: " + hostId);
         this.hostId = hostId % HOST_IDS;

--- a/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
@@ -219,7 +219,7 @@ public class HexDumpBytes
         startOfLine = this.text.writePosition();
     }
 
-    private void appendOffset(long offset)
+    private void appendOffset(@NonNegative long offset)
             throws IllegalStateException, BufferUnderflowException {
         if (offsetFormat == null) return;
         offsetFormat.append(offset, this.text);
@@ -241,7 +241,7 @@ public class HexDumpBytes
     }
 
     @Override
-    public void ensureCapacity(long desiredCapacity)
+    public void ensureCapacity(@NonNegative long desiredCapacity)
             throws IllegalArgumentException, IllegalStateException {
         base.ensureCapacity(desiredCapacity);
     }
@@ -275,19 +275,19 @@ public class HexDumpBytes
     }
 
     @Override
-    public long capacity() {
+    public @NonNegative long capacity() {
         return base.capacity();
     }
 
     @Override
-    public long addressForRead(long offset)
+    public long addressForRead(@NonNegative long offset)
             throws UnsupportedOperationException, IllegalStateException, BufferUnderflowException {
         requireNonNegative(offset);
         return base.addressForRead(offset);
     }
 
     @Override
-    public long addressForWrite(long offset)
+    public long addressForWrite(@NonNegative long offset)
             throws UnsupportedOperationException {
         requireNonNegative(offset);
         throw new UnsupportedOperationException();
@@ -300,7 +300,7 @@ public class HexDumpBytes
     }
 
     @Override
-    public boolean compareAndSwapInt(long offset, int expected, int value)
+    public boolean compareAndSwapInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException {
         if (base.compareAndSwapInt(offset & MASK, expected, value)) {
             copyToText(offset & MASK, offset >>> 32, 4);
@@ -310,7 +310,7 @@ public class HexDumpBytes
     }
 
     @Override
-    public void testAndSetInt(long offset, int expected, int value)
+    public void testAndSetInt(@NonNegative long offset, int expected, int value)
             throws IllegalStateException, BufferOverflowException {
         long off = offset & MASK;
         base.testAndSetInt(off, expected, value);
@@ -318,7 +318,7 @@ public class HexDumpBytes
     }
 
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value)
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws BufferOverflowException, IllegalStateException {
         if (base.compareAndSwapLong(offset & MASK, expected, value)) {
             copyToText(offset & MASK, offset >>> 32, 8);
@@ -334,7 +334,7 @@ public class HexDumpBytes
     }
 
     @Override
-    public void move(long from, long to, long length) {
+    public void move(@NonNegative long from, @NonNegative long to, @NonNegative long length) {
         throw new UnsupportedOperationException();
     }
 
@@ -383,7 +383,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeByte(long offset, byte i8)
+    public Bytes<Void> writeByte(@NonNegative long offset, byte i8)
             throws BufferOverflowException, IllegalStateException {
         base.writeByte(offset & MASK, i8);
         copyToText(offset & MASK, offset >>> 32, 1);
@@ -392,7 +392,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeShort(long offset, short i)
+    public Bytes<Void> writeShort(@NonNegative long offset, short i)
             throws BufferOverflowException, IllegalStateException {
         base.writeShort(offset & MASK, i);
         copyToText(offset & MASK, offset >>> 32, 2);
@@ -401,7 +401,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeInt24(long offset, int i)
+    public Bytes<Void> writeInt24(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         base.writeInt24(offset & MASK, i);
         copyToText(offset & MASK, offset >>> 32, 3);
@@ -410,14 +410,14 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeInt(long offset, int i)
+    public Bytes<Void> writeInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         return writeOrderedInt(offset, i);
     }
 
     @Override
     @NotNull
-    public Bytes<Void> writeOrderedInt(long offset, int i)
+    public Bytes<Void> writeOrderedInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         base.writeOrderedInt(offset & MASK, i);
         copyToText(offset & MASK, offset >>> 32, 4);
@@ -426,14 +426,14 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeLong(long offset, long i)
+    public Bytes<Void> writeLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         return writeOrderedLong(offset, i);
     }
 
     @Override
     @NotNull
-    public Bytes<Void> writeOrderedLong(long offset, long i)
+    public Bytes<Void> writeOrderedLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         base.writeOrderedLong(offset & MASK, i);
         copyToText(offset & MASK, offset >>> 32, 8);
@@ -442,7 +442,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeFloat(long offset, float d)
+    public Bytes<Void> writeFloat(@NonNegative long offset, float d)
             throws BufferOverflowException, IllegalStateException {
         base.writeFloat(offset & MASK, d);
         copyToText(offset & MASK, offset >>> 32, 4);
@@ -451,7 +451,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeDouble(long offset, double d)
+    public Bytes<Void> writeDouble(@NonNegative long offset, double d)
             throws BufferOverflowException, IllegalStateException {
         base.writeDouble(offset & MASK, d);
         copyToText(offset & MASK, offset >>> 32, 8);
@@ -460,28 +460,28 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeVolatileByte(long offset, byte i8)
+    public Bytes<Void> writeVolatileByte(@NonNegative long offset, byte i8)
             throws BufferOverflowException {
         throw new UnsupportedOperationException();
     }
 
     @Override
     @NotNull
-    public Bytes<Void> writeVolatileShort(long offset, short i16)
+    public Bytes<Void> writeVolatileShort(@NonNegative long offset, short i16)
             throws BufferOverflowException {
         throw new UnsupportedOperationException();
     }
 
     @Override
     @NotNull
-    public Bytes<Void> writeVolatileInt(long offset, int i32)
+    public Bytes<Void> writeVolatileInt(@NonNegative long offset, int i32)
             throws BufferOverflowException {
         throw new UnsupportedOperationException();
     }
 
     @Override
     @NotNull
-    public Bytes<Void> writeVolatileLong(long offset, long i64)
+    public Bytes<Void> writeVolatileLong(@NonNegative long offset, long i64)
             throws BufferOverflowException {
         throw new UnsupportedOperationException();
     }
@@ -500,14 +500,14 @@ public class HexDumpBytes
     }
 
     @Override
-    public void write(long offsetInRDO, @NotNull ByteBuffer bytes, int offset, int length) {
+    public void write(@NonNegative long offsetInRDO, @NotNull ByteBuffer bytes, @NonNegative int offset, @NonNegative int length) {
         requireNonNull(bytes);
         throw new UnsupportedOperationException();
     }
 
     @Override
     @NotNull
-    public Bytes<Void> write(long writeOffset, @NotNull RandomDataInput bytes, long readOffset, long length) {
+    public Bytes<Void> write(@NonNegative long writeOffset, @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length) {
         requireNonNegative(writeOffset);
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
         requireNonNegative(readOffset);
@@ -516,30 +516,30 @@ public class HexDumpBytes
     }
 
     @Override
-    public long write8bit(long position, @NotNull BytesStore bs) {
+    public long write8bit(@NonNegative long position, @NotNull BytesStore bs) {
         requireNonNull(bs);
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long write8bit(long position, @NotNull String s, int start, int length) {
+    public long write8bit(@NonNegative long position, @NotNull String s, @NonNegative int start, @NonNegative int length) {
         requireNonNull(s);
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void nativeWrite(long address, long position, long size) {
+    public void nativeWrite(long address, @NonNegative long position, @NonNegative long size) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public @NotNull Bytes<Void> zeroOut(long start, long end) throws IllegalStateException {
+    public @NotNull Bytes<Void> zeroOut(@NonNegative long start, @NonNegative long end) throws IllegalStateException {
         return base.zeroOut(start & MASK, end & MASK);
     }
 
     @Override
     @NotNull
-    public Bytes<Void> readPosition(long position)
+    public Bytes<Void> readPosition(@NonNegative long position)
             throws BufferUnderflowException, IllegalStateException {
         base.readPosition(position & MASK);
         text.readPosition(position >>> 32);
@@ -548,7 +548,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> readLimit(long limit)
+    public Bytes<Void> readLimit(@NonNegative long limit)
             throws BufferUnderflowException {
         base.readLimit(limit & MASK);
         text.readPosition(limit >>> 32);
@@ -697,7 +697,7 @@ public class HexDumpBytes
     }
 
     @Override
-    public void readWithLength(long length, @NotNull BytesOut<Void> bytesOut)
+    public void readWithLength(@NonNegative long length, @NotNull BytesOut<Void> bytesOut)
             throws BufferUnderflowException, IORuntimeException, IllegalStateException, BufferOverflowException {
         base.readWithLength(length, bytesOut);
     }
@@ -710,27 +710,27 @@ public class HexDumpBytes
 
     @NotNull
     @Override
-    public Bytes<Void> readPositionUnlimited(long position)
+    public Bytes<Void> readPositionUnlimited(@NonNegative long position)
             throws BufferUnderflowException, IllegalStateException {
         return base.readPositionUnlimited(position);
     }
 
     @NotNull
     @Override
-    public Bytes<Void> readPositionRemaining(long position, long remaining)
+    public Bytes<Void> readPositionRemaining(@NonNegative long position, @NonNegative long remaining)
             throws BufferUnderflowException, IllegalStateException {
         return base.readPositionRemaining(position, remaining);
     }
 
     @Override
-    public void readWithLength0(long length, @NotNull ThrowingConsumerNonCapturing<Bytes<Void>, IORuntimeException, BytesOut> bytesConsumer,
+    public void readWithLength0(@NonNegative long length, @NotNull ThrowingConsumerNonCapturing<Bytes<Void>, IORuntimeException, BytesOut> bytesConsumer,
                                 StringBuilder sb, BytesOut toBytes)
             throws BufferUnderflowException, IORuntimeException, IllegalStateException {
         base.readWithLength0(length, bytesConsumer, sb, toBytes);
     }
 
     @Override
-    public void readWithLength(long length, @NotNull ThrowingConsumer<Bytes<Void>, IORuntimeException> bytesConsumer)
+    public void readWithLength(@NonNegative long length, @NotNull ThrowingConsumer<Bytes<Void>, IORuntimeException> bytesConsumer)
             throws BufferUnderflowException, IORuntimeException, IllegalStateException {
         base.readWithLength(length, bytesConsumer);
     }
@@ -793,19 +793,19 @@ public class HexDumpBytes
     }
 
     @Override
-    public <C extends Appendable & CharSequence> long readUtf8(long offset, @NotNull C sb)
+    public <C extends Appendable & CharSequence> long readUtf8(@NonNegative long offset, @NotNull C sb)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, ArithmeticException, IllegalStateException {
         return base.readUtf8(offset, sb);
     }
 
     @Override
-    public <C extends Appendable & CharSequence> long readUtf8Limited(long offset, @NotNull C sb, int maxUtf8Len)
+    public <C extends Appendable & CharSequence> long readUtf8Limited(@NonNegative long offset, @NotNull C sb, @NonNegative int maxUtf8Len)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, IllegalStateException {
         return base.readUtf8Limited(offset, sb, maxUtf8Len);
     }
 
     @Override
-    public @Nullable String readUtf8Limited(long offset, int maxUtf8Len)
+    public @Nullable String readUtf8Limited(@NonNegative long offset, @NonNegative int maxUtf8Len)
             throws BufferUnderflowException, IORuntimeException, IllegalArgumentException, IllegalStateException {
         return base.readUtf8Limited(offset, maxUtf8Len);
     }
@@ -837,13 +837,13 @@ public class HexDumpBytes
     }
 
     @Override
-    public int read(byte[] bytes, int off, int len)
+    public int read(byte[] bytes, @NonNegative int off, @NonNegative int len)
             throws IllegalStateException, BufferUnderflowException {
         return base.read(bytes, off, len);
     }
 
     @Override
-    public int read(char[] bytes, int off, int len)
+    public int read(char[] bytes, int off, @NonNegative int len)
             throws IllegalStateException {
         return base.read(bytes, off, len);
     }
@@ -855,7 +855,7 @@ public class HexDumpBytes
     }
 
     @Override
-    public void read(@NotNull Bytes<?> bytes, int length)
+    public void read(@NotNull Bytes<?> bytes, @NonNegative int length)
             throws BufferUnderflowException, IllegalStateException, BufferOverflowException {
         base.read(bytes, length);
 
@@ -884,7 +884,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writePosition(long position)
+    public Bytes<Void> writePosition(@NonNegative long position)
             throws BufferOverflowException {
         requireNonNegative(position);
         base.writePosition(position & MASK);
@@ -894,7 +894,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeLimit(long limit)
+    public Bytes<Void> writeLimit(@NonNegative long limit)
             throws BufferOverflowException {
         base.writeLimit(limit);
         return this;
@@ -932,7 +932,7 @@ public class HexDumpBytes
      * @return the base and text writePositions.
      */
     @Override
-    public long writePosition() {
+    public @NonNegative long writePosition() {
         return base.writePosition() | (text.writePosition() << 32);
     }
 
@@ -1040,7 +1040,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeIntAdv(int i, int advance)
+    public Bytes<Void> writeIntAdv(int i, @NonNegative int advance)
             throws BufferOverflowException, IllegalStateException {
         long pos = base.writePosition();
         try {
@@ -1068,7 +1068,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> writeLongAdv(long i64, int advance)
+    public Bytes<Void> writeLongAdv(long i64, @NonNegative int advance)
             throws BufferOverflowException, IllegalStateException {
         long pos = base.writePosition();
         try {
@@ -1181,7 +1181,7 @@ public class HexDumpBytes
 
     @Override
     @NotNull
-    public Bytes<Void> clearAndPad(long length)
+    public Bytes<Void> clearAndPad(@NonNegative long length)
             throws BufferOverflowException, IllegalStateException {
         long pos = base.writePosition();
         try {
@@ -1230,79 +1230,79 @@ public class HexDumpBytes
     }
 
     @Override
-    public byte readByte(long offset)
+    public byte readByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readByte(offset);
     }
 
     @Override
-    public int peekUnsignedByte(long offset)
+    public int peekUnsignedByte(@NonNegative long offset)
             throws IllegalStateException, BufferUnderflowException {
         return base.peekUnsignedByte(offset);
     }
 
     @Override
-    public short readShort(long offset)
+    public short readShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readShort(offset);
     }
 
     @Override
-    public int readInt(long offset)
+    public int readInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readInt(offset);
     }
 
     @Override
-    public long readLong(long offset)
+    public long readLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readLong(offset);
     }
 
     @Override
-    public float readFloat(long offset)
+    public float readFloat(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readFloat(offset);
     }
 
     @Override
-    public double readDouble(long offset)
+    public double readDouble(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readDouble(offset);
     }
 
     @Override
-    public byte readVolatileByte(long offset)
+    public byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readVolatileByte(offset);
     }
 
     @Override
-    public short readVolatileShort(long offset)
+    public short readVolatileShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readVolatileShort(offset);
     }
 
     @Override
-    public int readVolatileInt(long offset)
+    public int readVolatileInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readVolatileInt(offset);
     }
 
     @Override
-    public long readVolatileLong(long offset)
+    public long readVolatileLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return base.readVolatileLong(offset);
     }
 
     @Override
-    public void nativeRead(long position, long address, long size)
+    public void nativeRead(@NonNegative long position, long address, @NonNegative long size)
             throws BufferUnderflowException, IllegalStateException {
         base.nativeRead(position, address, size);
     }
 
     @Override
-    public long readPosition() {
+    public @NonNegative long readPosition() {
         return base.readPosition() | (text.readPosition() << 32);
     }
 
@@ -1444,7 +1444,7 @@ public class HexDumpBytes
 
     @NotNull
     @Override
-    public Bytes<Void> write8bit(@NotNull CharSequence text, int start, int length)
+    public Bytes<Void> write8bit(@NotNull CharSequence text, @NonNegative int start, @NonNegative int length)
             throws BufferOverflowException, IndexOutOfBoundsException, IllegalStateException, BufferUnderflowException, ArithmeticException {
         long pos = base.writePosition();
         try {
@@ -1458,7 +1458,7 @@ public class HexDumpBytes
 
     @NotNull
     @Override
-    public Bytes<Void> write8bit(@NotNull String text, int start, int length)
+    public Bytes<Void> write8bit(@NotNull String text, @NonNegative int start, @NonNegative int length)
             throws BufferOverflowException, IndexOutOfBoundsException, IllegalStateException, BufferUnderflowException, ArithmeticException {
         long pos = base.writePosition();
         try {
@@ -1485,7 +1485,7 @@ public class HexDumpBytes
 
     @NotNull
     @Override
-    public Bytes<Void> write(@NotNull CharSequence text, int startText, int length)
+    public Bytes<Void> write(@NotNull CharSequence text, @NonNegative int startText, @NonNegative int length)
             throws BufferOverflowException, IndexOutOfBoundsException, IllegalStateException {
         long pos = base.writePosition();
         try {
@@ -1644,7 +1644,7 @@ public class HexDumpBytes
 
     @NotNull
     @Override
-    public Bytes<Void> write(@NotNull RandomDataInput bytes, long offset, long length)
+    public Bytes<Void> write(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
         throwExceptionIfReleased(bytes);
         requireNonNegative(offset);
@@ -1661,7 +1661,7 @@ public class HexDumpBytes
 
     @NotNull
     @Override
-    public Bytes<Void> write(@NotNull BytesStore bytes, long offset, long length)
+    public Bytes<Void> write(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
         throwExceptionIfReleased(bytes);
         requireNonNegative(offset);
@@ -1718,7 +1718,7 @@ public class HexDumpBytes
     }
 
     @Override
-    public void writePositionRemaining(long position, long length)
+    public void writePositionRemaining(@NonNegative long position, @NonNegative long length)
             throws BufferOverflowException {
         requireNonNegative(position);
         requireNonNegative(length);

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.internal.ChunkedMappedBytes;
 import net.openhft.chronicle.bytes.internal.SingleMappedBytes;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.io.ManagedCloseable;
 import org.jetbrains.annotations.NotNull;
@@ -54,19 +55,19 @@ public abstract class MappedBytes extends AbstractBytes<Void> implements Closeab
     }
 
     @NotNull
-    public static MappedBytes singleMappedBytes(@NotNull final String filename, final long capacity)
+    public static MappedBytes singleMappedBytes(@NotNull final String filename, @NonNegative final long capacity)
             throws FileNotFoundException, IllegalStateException {
         return singleMappedBytes(new File(filename), capacity);
     }
 
     @NotNull
-    public static MappedBytes singleMappedBytes(@NotNull final File file, final long capacity)
+    public static MappedBytes singleMappedBytes(@NotNull final File file, @NonNegative final long capacity)
             throws FileNotFoundException, IllegalStateException {
         return singleMappedBytes(file, capacity, false);
     }
 
     @NotNull
-    public static MappedBytes singleMappedBytes(@NotNull File file, long capacity, boolean readOnly)
+    public static MappedBytes singleMappedBytes(@NotNull File file, @NonNegative long capacity, boolean readOnly)
             throws FileNotFoundException, IllegalStateException {
         final MappedFile rw = MappedFile.ofSingle(file, capacity, readOnly);
         try {
@@ -77,19 +78,19 @@ public abstract class MappedBytes extends AbstractBytes<Void> implements Closeab
     }
 
     @NotNull
-    public static MappedBytes mappedBytes(@NotNull final String filename, final long chunkSize)
+    public static MappedBytes mappedBytes(@NotNull final String filename, @NonNegative final long chunkSize)
             throws FileNotFoundException, IllegalStateException {
         return mappedBytes(new File(filename), chunkSize);
     }
 
     @NotNull
-    public static MappedBytes mappedBytes(@NotNull final File file, final long chunkSize)
+    public static MappedBytes mappedBytes(@NotNull final File file, @NonNegative final long chunkSize)
             throws FileNotFoundException, IllegalStateException {
         return mappedBytes(file, chunkSize, OS.pageSize());
     }
 
     @NotNull
-    public static MappedBytes mappedBytes(@NotNull final File file, final long chunkSize, final long overlapSize)
+    public static MappedBytes mappedBytes(@NotNull final File file, @NonNegative final long chunkSize, @NonNegative final long overlapSize)
             throws FileNotFoundException, IllegalStateException {
         final MappedFile rw = MappedFile.of(file, chunkSize, overlapSize, false);
         try {
@@ -101,8 +102,8 @@ public abstract class MappedBytes extends AbstractBytes<Void> implements Closeab
 
     @NotNull
     public static MappedBytes mappedBytes(@NotNull final File file,
-                                          final long chunkSize,
-                                          final long overlapSize,
+                                          @NonNegative final long chunkSize,
+                                          @NonNegative final long overlapSize,
                                           final boolean readOnly)
             throws FileNotFoundException,
             IllegalStateException {

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
@@ -46,7 +46,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     private final long safeLimit;
     protected final Runnable writeCheck;
 
-    protected MappedBytesStore(ReferenceOwner owner, MappedFile mappedFile, long start, long address, long capacity, long safeCapacity)
+    protected MappedBytesStore(ReferenceOwner owner, MappedFile mappedFile, @NonNegative long start, long address, @NonNegative long capacity, @NonNegative long safeCapacity)
             throws IllegalStateException {
         super(address, start + capacity, new OS.Unmapper(address, capacity), false);
         this.mappedFile = mappedFile;
@@ -102,12 +102,12 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     }
 
     @Override
-    public boolean inside(long offset) {
+    public boolean inside(@NonNegative long offset) {
         return start <= offset && offset < safeLimit;
     }
 
     @Override
-    public boolean inside(long offset, long buffer) {
+    public boolean inside(@NonNegative long offset, @NonNegative long buffer) {
         // this is correct that it uses the maximumLimit, yes it is different than the method above.
         return start <= offset && offset + buffer <= limit;
     }
@@ -118,13 +118,13 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     }
 
     @Override
-    public byte readByte(long offset) {
+    public byte readByte(@NonNegative long offset) {
         return memory.readByte(address - start + offset);
     }
 
     @NotNull
     @Override
-    public MappedBytesStore writeOrderedInt(long offset, int i)
+    public MappedBytesStore writeOrderedInt(@NonNegative long offset, int i)
             throws IllegalStateException {
         writeCheck.run();
 
@@ -133,7 +133,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     }
 
     @Override
-    public long translate(long offset) {
+    public long translate(@NonNegative long offset) {
         assert offset >= start;
         assert offset < limit;
 
@@ -141,19 +141,19 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     }
 
     @Override
-    public long start() {
+    public @NonNegative long start() {
         return start;
     }
 
     @Override
-    public long readPosition() {
+    public @NonNegative long readPosition() {
         return start();
     }
 
     /**
      * Calls lock on the underlying file channel
      */
-    public FileLock lock(long position, long size, boolean shared) throws IOException {
+    public FileLock lock(@NonNegative long position, @NonNegative long size, boolean shared) throws IOException {
 
         return mappedFile.lock(position, size, shared);
     }
@@ -161,27 +161,27 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     /**
      * Calls tryLock on the underlying file channel
      */
-    public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+    public FileLock tryLock(@NonNegative long position, @NonNegative long size, boolean shared) throws IOException {
         return mappedFile.tryLock(position, size, shared);
     }
 
     @NotNull
     @Override
-    public MappedBytesStore zeroOut(long start, long end) {
+    public MappedBytesStore zeroOut(@NonNegative long start, @NonNegative long end) {
         writeCheck.run();
         super.zeroOut(start, end);
         return this;
     }
 
     @Override
-    public boolean compareAndSwapInt(long offset, int expected, int value)
+    public boolean compareAndSwapInt(@NonNegative long offset, int expected, int value)
             throws IllegalStateException {
         writeCheck.run();
         return super.compareAndSwapInt(offset, expected, value);
     }
 
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value)
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws IllegalStateException {
         writeCheck.run();
         return super.compareAndSwapLong(offset, expected, value);
@@ -189,7 +189,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeByte(long offset, byte i8)
+    public MappedBytesStore writeByte(@NonNegative long offset, byte i8)
             throws IllegalStateException {
         writeCheck.run();
         super.writeByte(offset, i8);
@@ -198,7 +198,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeShort(long offset, short i16)
+    public MappedBytesStore writeShort(@NonNegative long offset, short i16)
             throws IllegalStateException {
         writeCheck.run();
         super.writeShort(offset, i16);
@@ -207,7 +207,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeInt(long offset, int i32)
+    public MappedBytesStore writeInt(@NonNegative long offset, int i32)
             throws IllegalStateException {
         writeCheck.run();
         super.writeInt(offset, i32);
@@ -216,7 +216,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeLong(long offset, long i64)
+    public MappedBytesStore writeLong(@NonNegative long offset, long i64)
             throws IllegalStateException {
         writeCheck.run();
         super.writeLong(offset, i64);
@@ -225,7 +225,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeOrderedLong(long offset, long i)
+    public MappedBytesStore writeOrderedLong(@NonNegative long offset, long i)
             throws IllegalStateException {
         writeCheck.run();
         super.writeOrderedLong(offset, i);
@@ -234,7 +234,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeFloat(long offset, float f)
+    public MappedBytesStore writeFloat(@NonNegative long offset, float f)
             throws IllegalStateException {
         writeCheck.run();
         super.writeFloat(offset, f);
@@ -243,7 +243,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeDouble(long offset, double d)
+    public MappedBytesStore writeDouble(@NonNegative long offset, double d)
             throws IllegalStateException {
         writeCheck.run();
         super.writeDouble(offset, d);
@@ -252,7 +252,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeVolatileByte(long offset, byte i8)
+    public MappedBytesStore writeVolatileByte(@NonNegative long offset, byte i8)
             throws IllegalStateException {
         writeCheck.run();
         super.writeVolatileByte(offset, i8);
@@ -261,7 +261,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeVolatileShort(long offset, short i16)
+    public MappedBytesStore writeVolatileShort(@NonNegative long offset, short i16)
             throws IllegalStateException {
         writeCheck.run();
         super.writeVolatileShort(offset, i16);
@@ -270,7 +270,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeVolatileInt(long offset, int i32)
+    public MappedBytesStore writeVolatileInt(@NonNegative long offset, int i32)
             throws IllegalStateException {
         writeCheck.run();
         super.writeVolatileInt(offset, i32);
@@ -280,7 +280,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore writeVolatileLong(long offset, long i64)
+    public MappedBytesStore writeVolatileLong(@NonNegative long offset, long i64)
             throws IllegalStateException {
         writeCheck.run();
         super.writeVolatileLong(offset, i64);
@@ -300,7 +300,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     }
 
     @Override
-    public void write(long offsetInRDO, @NotNull ByteBuffer bytes, int offset, int length)
+    public void write(@NonNegative long offsetInRDO, @NotNull ByteBuffer bytes, @NonNegative int offset, @NonNegative int length)
             throws IllegalStateException {
         requireNonNull(bytes);
         writeCheck.run();
@@ -309,7 +309,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @NotNull
     @Override
-    public MappedBytesStore write(long writeOffset, @NotNull RandomDataInput bytes, long readOffset, long length)
+    public MappedBytesStore write(@NonNegative long writeOffset, @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         requireNonNegative(writeOffset);
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
@@ -322,7 +322,7 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     }
 
     @Override
-    public void write0(long offsetInRDO, @NotNull RandomDataInput bytes, long offset, long length)
+    public void write0(@NonNegative long offsetInRDO, @NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
             throws IllegalStateException {
         requireNonNull(bytes);
         writeCheck.run();
@@ -330,14 +330,14 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     }
 
     @Override
-    public void nativeWrite(long address, long position, long size)
+    public void nativeWrite(long address, @NonNegative long position, @NonNegative long size)
             throws IllegalStateException {
         writeCheck.run();
         super.nativeWrite(address, position, size);
     }
 
     @Override
-    public long appendUtf8(long pos, char[] chars, int offset, int length)
+    public long appendUtf8(@NonNegative long pos, char[] chars, @NonNegative int offset, @NonNegative int length)
             throws IllegalStateException {
         writeCheck.run();
         return super.appendUtf8(pos, chars, offset, length);

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytesStoreFactory.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytesStoreFactory.java
@@ -18,12 +18,13 @@
 
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.ReferenceOwner;
 import org.jetbrains.annotations.NotNull;
 
 @FunctionalInterface
 public interface MappedBytesStoreFactory {
     @NotNull
-    MappedBytesStore create(ReferenceOwner owner, MappedFile mappedFile, long start, long address, long capacity, long safeCapacity)
+    MappedBytesStore create(ReferenceOwner owner, MappedFile mappedFile, @NonNegative long start, @NonNegative long address, @NonNegative long capacity, @NonNegative long safeCapacity)
             throws IllegalStateException;
 }

--- a/src/main/java/net/openhft/chronicle/bytes/MappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedFile.java
@@ -25,6 +25,7 @@ import net.openhft.chronicle.bytes.internal.SingleMappedFile;
 import net.openhft.chronicle.core.CleaningRandomAccessFile;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.AbstractCloseableReferenceCounted;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.ReferenceOwner;
@@ -62,7 +63,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
     }
 
     static void logNewChunk(final String filename,
-                            final int chunk,
+                            @NonNegative final int chunk,
                             final long delayMicros) {
         if (delayMicros < 100 || !Jvm.isDebugEnabled(MappedFile.class))
             return;
@@ -78,8 +79,8 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
 
     @NotNull
     public static MappedFile of(@NotNull final File file,
-                                final long chunkSize,
-                                final long overlapSize,
+                                @NonNegative final long chunkSize,
+                                @NonNegative final long overlapSize,
                                 final boolean readOnly)
             throws FileNotFoundException {
 
@@ -90,7 +91,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
 
     @NotNull
     public static MappedFile ofSingle(@NotNull final File file,
-                                      final long capacity,
+                                      @NonNegative final long capacity,
                                       final boolean readOnly)
             throws FileNotFoundException {
 
@@ -99,37 +100,37 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
     }
 
     @NotNull
-    public static MappedFile mappedFile(@NotNull final File file, final long chunkSize)
+    public static MappedFile mappedFile(@NotNull final File file, @NonNegative final long chunkSize)
             throws FileNotFoundException {
         return mappedFile(file, chunkSize, OS.pageSize());
     }
 
     @NotNull
-    public static MappedFile mappedFile(@NotNull final String filename, final long chunkSize)
+    public static MappedFile mappedFile(@NotNull final String filename, @NonNegative final long chunkSize)
             throws FileNotFoundException {
         return mappedFile(filename, chunkSize, OS.pageSize());
     }
 
     @NotNull
     public static MappedFile mappedFile(@NotNull final String filename,
-                                        final long chunkSize,
-                                        final long overlapSize)
+                                        @NonNegative final long chunkSize,
+                                        @NonNegative final long overlapSize)
             throws FileNotFoundException {
         return mappedFile(new File(filename), chunkSize, overlapSize);
     }
 
     @NotNull
     public static MappedFile mappedFile(@NotNull final File file,
-                                        final long chunkSize,
-                                        final long overlapSize)
+                                        @NonNegative final long chunkSize,
+                                        @NonNegative final long overlapSize)
             throws FileNotFoundException {
         return mappedFile(file, chunkSize, overlapSize, false);
     }
 
     @NotNull
     public static MappedFile mappedFile(@NotNull final File file,
-                                        final long chunkSize,
-                                        final long overlapSize,
+                                        @NonNegative final long chunkSize,
+                                        @NonNegative final long overlapSize,
                                         final boolean readOnly)
             throws FileNotFoundException {
         return MappedFile.of(file, chunkSize, overlapSize, readOnly);
@@ -150,9 +151,9 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
 
     @NotNull
     public static MappedFile mappedFile(@NotNull final File file,
-                                        final long capacity,
-                                        final long chunkSize,
-                                        final long overlapSize,
+                                        @NonNegative final long capacity,
+                                        @NonNegative final long chunkSize,
+                                        @NonNegative final long overlapSize,
                                         final boolean readOnly)
             throws IOException {
         final RandomAccessFile raf = new CleaningRandomAccessFile(file, readOnly ? "r" : "rw");
@@ -181,7 +182,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
     @NotNull
     public MappedBytesStore acquireByteStore(
             ReferenceOwner owner,
-            final long position)
+            @NonNegative final long position)
             throws IOException, IllegalArgumentException, IllegalStateException {
         return acquireByteStore(owner, position, null, MappedBytesStore::new);
     }
@@ -189,7 +190,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
     @NotNull
     public MappedBytesStore acquireByteStore(
             ReferenceOwner owner,
-            final long position,
+            @NonNegative final long position,
             BytesStore oldByteStore)
             throws IOException, IllegalStateException {
         try {
@@ -202,7 +203,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
     @NotNull
     public abstract MappedBytesStore acquireByteStore(
             ReferenceOwner owner,
-            final long position,
+            @NonNegative final long position,
             BytesStore oldByteStore,
             @NotNull final MappedBytesStoreFactory mappedBytesStoreFactory)
             throws IOException,
@@ -213,7 +214,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
      * Convenience method so you don't need to release the BytesStore
      */
     @NotNull
-    public Bytes acquireBytesForRead(ReferenceOwner owner, final long position)
+    public Bytes acquireBytesForRead(ReferenceOwner owner, @NonNegative final long position)
             throws IOException, IllegalStateException, BufferUnderflowException {
         throwExceptionIfClosed();
 
@@ -225,7 +226,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
         return bytes;
     }
 
-    public void acquireBytesForRead(ReferenceOwner owner, final long position, @NotNull final VanillaBytes bytes)
+    public void acquireBytesForRead(ReferenceOwner owner, @NonNegative final long position, @NotNull final VanillaBytes bytes)
             throws IOException, IllegalStateException, IllegalArgumentException, BufferUnderflowException, BufferOverflowException {
         throwExceptionIfClosed();
 
@@ -234,7 +235,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
     }
 
     @NotNull
-    public Bytes acquireBytesForWrite(ReferenceOwner owner, final long position)
+    public Bytes acquireBytesForWrite(ReferenceOwner owner, @NonNegative final long position)
             throws IOException, IllegalStateException, IllegalArgumentException, BufferOverflowException {
         throwExceptionIfClosed();
 
@@ -246,7 +247,7 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
         return bytes;
     }
 
-    public void acquireBytesForWrite(ReferenceOwner owner, final long position, @NotNull final VanillaBytes bytes)
+    public void acquireBytesForWrite(ReferenceOwner owner, @NonNegative final long position, @NotNull final VanillaBytes bytes)
             throws IOException, IllegalStateException, IllegalArgumentException, BufferUnderflowException, BufferOverflowException {
         throwExceptionIfClosed();
 
@@ -319,12 +320,12 @@ public abstract class MappedFile extends AbstractCloseableReferenceCounted {
     /**
      * Calls lock on the underlying file channel
      */
-    public abstract FileLock lock(long position, long size, boolean shared) throws IOException;
+    public abstract FileLock lock(@NonNegative long position, @NonNegative long size, boolean shared) throws IOException;
 
     /**
      * Calls tryLock on the underlying file channel
      */
-    public abstract FileLock tryLock(long position, long size, boolean shared) throws IOException;
+    public abstract FileLock tryLock(@NonNegative long position, @NonNegative long size, boolean shared) throws IOException;
 
     public abstract long chunkCount();
 

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
@@ -24,6 +24,7 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.StackTrace;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.AbstractReferenceCounted;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -50,7 +51,7 @@ public class NativeBytes<U>
     private static boolean newGuarded = BYTES_GUARDED;
     private long capacity;
 
-    public NativeBytes(@NotNull final BytesStore store, final long capacity)
+    public NativeBytes(@NotNull final BytesStore store, @NonNegative final long capacity)
             throws IllegalStateException, IllegalArgumentException {
         super(store, 0, capacity);
         this.capacity = capacity;
@@ -101,7 +102,7 @@ public class NativeBytes<U>
     }
 
     @NotNull
-    public static NativeBytes<Void> nativeBytes(final long initialCapacity)
+    public static NativeBytes<Void> nativeBytes(@NonNegative final long initialCapacity)
             throws IllegalArgumentException {
         @NotNull final BytesStore<?, Void> store = nativeStoreWithFixedCapacity(initialCapacity);
         try {
@@ -136,7 +137,7 @@ public class NativeBytes<U>
     }
 
     @NotNull
-    public static <T> NativeBytes<T> wrapWithNativeBytes(@NotNull final BytesStore<?, T> bs, long capacity)
+    public static <T> NativeBytes<T> wrapWithNativeBytes(@NotNull final BytesStore<?, T> bs, @NonNegative long capacity)
             throws IllegalStateException, IllegalArgumentException {
         requireNonNull(bs);
         return newGuarded
@@ -152,12 +153,12 @@ public class NativeBytes<U>
     }
 
     @Override
-    public long capacity() {
+    public @NonNegative long capacity() {
         return capacity;
     }
 
     @Override
-    protected void writeCheckOffset(final long offset, final long adding)
+    protected void writeCheckOffset(final @NonNegative long offset, final @NonNegative long adding)
             throws BufferOverflowException, IllegalStateException {
         if (offset >= bytesStore.start() && offset + adding >= bytesStore.start()) {
             final long writeEnd = offset + adding;
@@ -173,7 +174,7 @@ public class NativeBytes<U>
     }
 
     @Override
-    void prewriteCheckOffset(long offset, long subtracting)
+    void prewriteCheckOffset(@NonNegative long offset, long subtracting)
             throws BufferOverflowException, IllegalStateException {
         if (offset - subtracting >= bytesStore.start()) {
             if (offset <= bytesStore.safeLimit()) {
@@ -188,7 +189,7 @@ public class NativeBytes<U>
     }
 
     @Override
-    public void ensureCapacity(final long desiredCapacity)
+    public void ensureCapacity(final @NonNegative long desiredCapacity)
             throws IllegalArgumentException, IllegalStateException {
         try {
             assert desiredCapacity >= 0;
@@ -200,7 +201,7 @@ public class NativeBytes<U>
         }
     }
 
-    private void checkResize(final long endOfBuffer)
+    private void checkResize(@NonNegative final long endOfBuffer)
             throws BufferOverflowException, IllegalStateException {
         if (isElastic())
             resize(endOfBuffer);
@@ -214,12 +215,12 @@ public class NativeBytes<U>
     }
 
     @Override
-    public boolean isEqual(long start, long length, String s) {
+    public boolean isEqual(@NonNegative long start, @NonNegative long length, String s) {
         return bytesStore.isEqual(start, length, s);
     }
 
     // the endOfBuffer is the minimum capacity and one byte more than the last addressable byte.
-    private void resize(final long endOfBuffer)
+    private void resize(@NonNegative final long endOfBuffer)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfReleased();
         if (endOfBuffer < 0)
@@ -264,7 +265,7 @@ public class NativeBytes<U>
         resizeHelper(size, isByteBufferBacked);
     }
 
-    private void resizeHelper(final long size,
+    private void resizeHelper(@NonNegative final long size,
                               final boolean isByteBufferBacked) {
         final BytesStore store;
         int position = 0;
@@ -303,7 +304,7 @@ public class NativeBytes<U>
     }
 
     @NotNull
-    private BytesStore allocate(long size) {
+    private BytesStore allocate(@NonNegative long size) {
         final BytesStore store;
         try {
             store = allocateNewByteBufferBackedStore(Maths.toInt32(size));
@@ -321,7 +322,7 @@ public class NativeBytes<U>
     }
 
     @Override
-    public void bytesStore(@NotNull BytesStore<Bytes<U>, U> byteStore, long offset, long length) throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
+    public void bytesStore(@NotNull BytesStore<Bytes<U>, U> byteStore, @NonNegative long offset, @NonNegative long length) throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
         requireNonNull(byteStore);
         if (capacity < offset + length)
             capacity = offset + length;
@@ -329,7 +330,7 @@ public class NativeBytes<U>
     }
 
     @NotNull
-    private BytesStore allocateNewByteBufferBackedStore(final int size) {
+    private BytesStore allocateNewByteBufferBackedStore(@NonNegative final int size) {
         if (isDirectMemory()) {
             return BytesStore.elasticByteBuffer(size, capacity());
         } else {
@@ -364,7 +365,7 @@ public class NativeBytes<U>
     }
 
     @Override
-    protected long writeOffsetPositionMoved(final long adding, final long advance)
+    protected long writeOffsetPositionMoved(final @NonNegative long adding, final @NonNegative long advance)
             throws BufferOverflowException, IllegalStateException {
         final long oldPosition = writePosition();
         if (writePosition < bytesStore.start())
@@ -378,7 +379,7 @@ public class NativeBytes<U>
         return oldPosition;
     }
 
-    private void throwBeyondWriteLimit(long advance, long writeEnd)
+    private void throwBeyondWriteLimit(@NonNegative long advance, @NonNegative long writeEnd)
             throws DecoratedBufferOverflowException {
         throw new DecoratedBufferOverflowException("attempt to write " + advance + " bytes to " + writeEnd + " limit: " + writeLimit);
     }

--- a/src/main/java/net/openhft/chronicle/bytes/NewChunkListener.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NewChunkListener.java
@@ -18,7 +18,9 @@
 
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
+
 @FunctionalInterface
 public interface NewChunkListener {
-    void onNewChunk(String filename, int chunk, long delayMicros);
+    void onNewChunk(String filename, @NonNegative int chunk, @NonNegative long delayMicros);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/NoBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NoBytesStore.java
@@ -96,73 +96,73 @@ public enum NoBytesStore implements BytesStore {
 
     @NotNull
     @Override
-    public RandomDataOutput writeByte(long offset, byte i8) {
+    public RandomDataOutput writeByte(@NonNegative long offset, byte i8) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeShort(long offset, short i) {
+    public RandomDataOutput writeShort(@NonNegative long offset, short i) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeInt(long offset, int i) {
+    public RandomDataOutput writeInt(@NonNegative long offset, int i) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeOrderedInt(long offset, int i) {
+    public RandomDataOutput writeOrderedInt(@NonNegative long offset, int i) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeLong(long offset, long i) {
+    public RandomDataOutput writeLong(@NonNegative long offset, long i) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeOrderedLong(long offset, long i) {
+    public RandomDataOutput writeOrderedLong(@NonNegative long offset, long i) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeFloat(long offset, float d) {
+    public RandomDataOutput writeFloat(@NonNegative long offset, float d) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeDouble(long offset, double d) {
+    public RandomDataOutput writeDouble(@NonNegative long offset, double d) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeVolatileByte(long offset, byte i8) {
+    public RandomDataOutput writeVolatileByte(@NonNegative long offset, byte i8) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeVolatileShort(long offset, short i16) {
+    public RandomDataOutput writeVolatileShort(@NonNegative long offset, short i16) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeVolatileInt(long offset, int i32) {
+    public RandomDataOutput writeVolatileInt(@NonNegative long offset, int i32) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public RandomDataOutput writeVolatileLong(long offset, long i64) {
+    public RandomDataOutput writeVolatileLong(@NonNegative long offset, long i64) {
         throw new UnsupportedOperationException();
     }
 
@@ -182,7 +182,7 @@ public enum NoBytesStore implements BytesStore {
     }
 
     @Override
-    public void write(long offsetInRDO, @NotNull ByteBuffer bytes, int offset, int length) {
+    public void write(@NonNegative long offsetInRDO, @NotNull ByteBuffer bytes, @NonNegative int offset, @NonNegative int length) {
         requireNonNull(bytes);
         if (length != 0)
             throw new UnsupportedOperationException();
@@ -190,7 +190,7 @@ public enum NoBytesStore implements BytesStore {
 
     @NotNull
     @Override
-    public RandomDataOutput write(long writeOffset, RandomDataInput bytes, long readOffset, long length) {
+    public RandomDataOutput write(@NonNegative long writeOffset, @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length) {
         requireNonNegative(writeOffset);
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
         requireNonNegative(readOffset);
@@ -201,60 +201,60 @@ public enum NoBytesStore implements BytesStore {
     }
 
     @Override
-    public byte readByte(long offset) {
+    public byte readByte(@NonNegative long offset) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int peekUnsignedByte(long offset) {
+    public int peekUnsignedByte(@NonNegative long offset) {
         return -1;
     }
 
     @Override
-    public short readShort(long offset) {
+    public short readShort(@NonNegative long offset) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int readInt(long offset) {
+    public int readInt(@NonNegative long offset) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long readLong(long offset) {
+    public long readLong(@NonNegative long offset) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public float readFloat(long offset) {
+    public float readFloat(@NonNegative long offset) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public double readDouble(long offset) {
+    public double readDouble(@NonNegative long offset) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public byte readVolatileByte(long offset)
+    public byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public short readVolatileShort(long offset)
+    public short readVolatileShort(@NonNegative long offset)
             throws BufferUnderflowException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int readVolatileInt(long offset)
+    public int readVolatileInt(@NonNegative long offset)
             throws BufferUnderflowException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long readVolatileLong(long offset)
+    public long readVolatileLong(@NonNegative long offset)
             throws BufferUnderflowException {
         throw new BufferUnderflowException();
     }
@@ -276,7 +276,7 @@ public enum NoBytesStore implements BytesStore {
     }
 
     @Override
-    public long capacity() {
+    public @NonNegative long capacity() {
         return 0;
     }
 
@@ -286,12 +286,12 @@ public enum NoBytesStore implements BytesStore {
     }
 
     @Override
-    public boolean inside(long offset) {
+    public boolean inside(@NonNegative long offset) {
         return false;
     }
 
     @Override
-    public boolean inside(long offset, long buffer) {
+    public boolean inside(@NonNegative long offset, @NonNegative long buffer) {
         return false;
     }
 
@@ -303,39 +303,39 @@ public enum NoBytesStore implements BytesStore {
     }
 
     @Override
-    public void nativeWrite(long address, long position, long size) {
+    public void nativeWrite(long address, @NonNegative long position, @NonNegative long size) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long write8bit(long position, @NotNull BytesStore bs) {
+    public long write8bit(@NonNegative long position, @NotNull BytesStore bs) {
         requireNonNull(bs);
         throw new BufferOverflowException();
     }
 
     @Override
-    public long write8bit(long position, @NotNull String s, int start, int length) {
+    public long write8bit(@NonNegative long position, @NotNull String s, @NonNegative int start, @NonNegative int length) {
         requireNonNull(s);
         throw new BufferOverflowException();
     }
 
     @Override
-    public void nativeRead(long position, long address, long size) {
+    public void nativeRead(@NonNegative long position, long address, @NonNegative long size) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean compareAndSwapInt(long offset, int expected, int value) {
+    public boolean compareAndSwapInt(@NonNegative long offset, int expected, int value) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void testAndSetInt(long offset, int expected, int value) {
+    public void testAndSetInt(@NonNegative long offset, int expected, int value) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value) {
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value) {
         throw new UnsupportedOperationException();
     }
 
@@ -346,12 +346,12 @@ public enum NoBytesStore implements BytesStore {
     }
 
     @Override
-    public void move(long from, long to, long length) {
+    public void move(@NonNegative long from, @NonNegative long to, @NonNegative long length) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long addressForRead(long offset)
+    public long addressForRead(@NonNegative long offset)
             throws BufferUnderflowException {
         if (offset != 0)
             throw new BufferUnderflowException();
@@ -359,7 +359,7 @@ public enum NoBytesStore implements BytesStore {
     }
 
     @Override
-    public long addressForWrite(long offset)
+    public long addressForWrite(@NonNegative long offset)
             throws BufferOverflowException {
         if (offset != 0)
             throw new BufferOverflowException();

--- a/src/main/java/net/openhft/chronicle/bytes/OffsetFormat.java
+++ b/src/main/java/net/openhft/chronicle/bytes/OffsetFormat.java
@@ -17,8 +17,10 @@
  */
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
+
 @FunctionalInterface
 public interface OffsetFormat {
     @SuppressWarnings("rawtypes")
-    void append(long offset, Bytes bytes);
+    void append(@NonNegative long offset, Bytes bytes);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/OnHeapBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/OnHeapBytes.java
@@ -2,6 +2,7 @@ package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.bytes.util.DecoratedBufferOverflowException;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.BufferOverflowException;
@@ -37,12 +38,12 @@ public class OnHeapBytes extends VanillaBytes<byte[]> {
     }
 
     @Override
-    public long capacity() {
+    public @NonNegative long capacity() {
         return capacity;
     }
 
     @Override
-    public void ensureCapacity(long desiredCapacity) throws IllegalArgumentException, IllegalStateException {
+    public void ensureCapacity(@NonNegative long desiredCapacity) throws IllegalArgumentException, IllegalStateException {
         if (isElastic() && bytesStore.capacity() < desiredCapacity)
             resize(desiredCapacity);
         else
@@ -55,7 +56,7 @@ public class OnHeapBytes extends VanillaBytes<byte[]> {
     }
 
     @Override
-    protected void writeCheckOffset(long offset, long adding)
+    protected void writeCheckOffset(@NonNegative long offset, @NonNegative long adding)
             throws BufferOverflowException, IllegalStateException {
         if (offset >= bytesStore.start() && offset + adding >= bytesStore.start()) {
             long writeEnd = offset + adding;
@@ -70,12 +71,12 @@ public class OnHeapBytes extends VanillaBytes<byte[]> {
         }
     }
 
-    private void throwBeyondWriteLimit(long advance, long writeEnd)
+    private void throwBeyondWriteLimit(@NonNegative long advance, @NonNegative long writeEnd)
             throws DecoratedBufferOverflowException {
         throw new DecoratedBufferOverflowException("attempt to write " + advance + " bytes to " + writeEnd + " limit: " + writeLimit);
     }
 
-    private void checkResize(long endOfBuffer)
+    private void checkResize(@NonNegative long endOfBuffer)
             throws BufferOverflowException, IllegalStateException {
         if (isElastic())
             resize(endOfBuffer);
@@ -84,7 +85,7 @@ public class OnHeapBytes extends VanillaBytes<byte[]> {
     }
 
     // the endOfBuffer is the minimum capacity and one byte more than the last addressable byte.
-    private void resize(long endOfBuffer)
+    private void resize(@NonNegative long endOfBuffer)
             throws BufferOverflowException, IllegalStateException {
         if (endOfBuffer < 0)
             throw new BufferOverflowException();

--- a/src/main/java/net/openhft/chronicle/bytes/PointerBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/PointerBytesStore.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.bytes.internal.NativeBytesStore;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -30,7 +31,7 @@ public class PointerBytesStore extends NativeBytesStore<Void> {
         super(NoBytesStore.NO_PAGE, 0, null, false, false);
     }
 
-    public void set(long address, long capacity) {
+    public void set(long address, @NonNegative long capacity) {
         setAddress(address);
         this.limit = maximumLimit = capacity;
     }
@@ -46,11 +47,13 @@ public class PointerBytesStore extends NativeBytesStore<Void> {
         }
     }
 
+    @NonNegative
     @Override
     public long safeLimit() {
         return limit;
     }
 
+    @NonNegative
     @Override
     public long start() {
         return 0;

--- a/src/main/java/net/openhft/chronicle/bytes/RandomCommon.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomCommon.java
@@ -18,6 +18,7 @@
 
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.ReferenceCounted;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,6 +30,7 @@ interface RandomCommon extends ReferenceCounted {
     /**
      * @return The smallest position allowed in this buffer.
      */
+    @NonNegative
     default long start() {
         return 0L;
     }
@@ -36,6 +38,7 @@ interface RandomCommon extends ReferenceCounted {
     /**
      * @return the highest limit allowed for this buffer.
      */
+    @NonNegative
     default long capacity() {
         return Bytes.MAX_CAPACITY;
     }
@@ -43,6 +46,7 @@ interface RandomCommon extends ReferenceCounted {
     /**
      * @return the limit for this buffer without resizing
      */
+    @NonNegative
     default long realCapacity() {
         return capacity();
     }
@@ -52,6 +56,7 @@ interface RandomCommon extends ReferenceCounted {
      *
      * @return position to read from.
      */
+    @NonNegative
     default long readPosition() {
         return start();
     }
@@ -61,6 +66,7 @@ interface RandomCommon extends ReferenceCounted {
      *
      * @return position to write to.
      */
+    @NonNegative
     default long writePosition() {
         return start();
     }
@@ -71,8 +77,7 @@ interface RandomCommon extends ReferenceCounted {
      * @param startPosition to compare against
      * @return the length from the startPosition
      */
-
-    default long lengthWritten(long startPosition) {
+    default long lengthWritten(@NonNegative long startPosition) {
         return writePosition() - startPosition;
     }
 
@@ -107,10 +112,12 @@ interface RandomCommon extends ReferenceCounted {
     /**
      * @return the highest offset or position allowed for this buffer.
      */
+    @NonNegative
     default long readLimit() {
         return realCapacity();
     }
 
+    @NonNegative
     default long writeLimit() {
         return realCapacity();
     }
@@ -123,10 +130,10 @@ interface RandomCommon extends ReferenceCounted {
      * @throws UnsupportedOperationException if the underlying buffer is on the heap
      * @throws BufferUnderflowException      if the offset is before the start() or the after the capacity()
      */
-    long addressForRead(long offset)
+    long addressForRead(@NonNegative long offset)
             throws UnsupportedOperationException, BufferUnderflowException, IllegalStateException;
 
-    default long addressForRead(long offset, int buffer)
+    default long addressForRead(@NonNegative long offset, @NonNegative int buffer)
             throws UnsupportedOperationException, BufferUnderflowException, IllegalStateException {
         return addressForRead(offset);
     }
@@ -139,7 +146,7 @@ interface RandomCommon extends ReferenceCounted {
      * @throws UnsupportedOperationException if the underlying buffer is on the heap
      * @throws BufferOverflowException       if the offset is before the start() or the after the capacity()
      */
-    long addressForWrite(long offset)
+    long addressForWrite(@NonNegative long offset)
             throws UnsupportedOperationException, BufferOverflowException, IllegalStateException;
 
     long addressForWritePosition()
@@ -173,10 +180,10 @@ interface RandomCommon extends ReferenceCounted {
      * @param value    to set
      * @return true, if successful.
      */
-    boolean compareAndSwapInt(long offset, int expected, int value)
+    boolean compareAndSwapInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException;
 
-    void testAndSetInt(long offset, int expected, int value)
+    void testAndSetInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -187,7 +194,7 @@ interface RandomCommon extends ReferenceCounted {
      * @param value    to set
      * @return true, if successful.
      */
-    boolean compareAndSwapLong(long offset, long expected, long value)
+    boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -198,7 +205,7 @@ interface RandomCommon extends ReferenceCounted {
      * @param value    to set
      * @return true, if successful.
      */
-    default boolean compareAndSwapFloat(long offset, float expected, float value)
+    default boolean compareAndSwapFloat(@NonNegative long offset, float expected, float value)
             throws BufferOverflowException, IllegalStateException {
         return compareAndSwapInt(offset, Float.floatToRawIntBits(expected), Float.floatToRawIntBits(value));
     }
@@ -211,7 +218,7 @@ interface RandomCommon extends ReferenceCounted {
      * @param value    to set
      * @return true, if successful.
      */
-    default boolean compareAndSwapDouble(long offset, double expected, double value)
+    default boolean compareAndSwapDouble(@NonNegative long offset, double expected, double value)
             throws BufferOverflowException, IllegalStateException {
         return compareAndSwapLong(offset, Double.doubleToRawLongBits(expected), Double.doubleToRawLongBits(value));
     }

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.core.Maths;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,7 +66,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default boolean readBoolean(long offset)
+    default boolean readBoolean(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return BytesUtil.byteToBoolean(readByte(offset));
     }
@@ -78,7 +79,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    byte readByte(long offset)
+    byte readByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
 
@@ -90,7 +91,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default int readUnsignedByte(long offset)
+    default int readUnsignedByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return readByte(offset) & 0xFF;
     }
@@ -103,7 +104,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    int peekUnsignedByte(long offset)
+    int peekUnsignedByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -114,7 +115,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    short readShort(long offset)
+    short readShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -125,7 +126,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default int readUnsignedShort(long offset)
+    default int readUnsignedShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return readShort(offset) & 0xFFFF;
     }
@@ -138,7 +139,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default int readUnsignedInt24(long offset)
+    default int readUnsignedInt24(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return readUnsignedShort(offset) | (readUnsignedByte(offset) << 16);
     }
@@ -151,7 +152,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    int readInt(long offset)
+    int readInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -162,7 +163,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default long readUnsignedInt(long offset)
+    default long readUnsignedInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return readInt(offset) & 0xFFFFFFFFL;
     }
@@ -175,7 +176,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    long readLong(long offset)
+    long readLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -186,7 +187,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    float readFloat(long offset)
+    float readFloat(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -197,7 +198,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    double readDouble(long offset)
+    double readDouble(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -208,7 +209,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default String printable(long offset)
+    default String printable(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return charToString[readUnsignedByte(offset)];
     }
@@ -221,7 +222,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    byte readVolatileByte(long offset)
+    byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -232,7 +233,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    short readVolatileShort(long offset)
+    short readVolatileShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -243,7 +244,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    int readVolatileInt(long offset)
+    int readVolatileInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -254,7 +255,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default float readVolatileFloat(long offset)
+    default float readVolatileFloat(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return Float.intBitsToFloat(readVolatileInt(offset));
     }
@@ -267,7 +268,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    long readVolatileLong(long offset)
+    long readVolatileLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -278,12 +279,12 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default double readVolatileDouble(long offset)
+    default double readVolatileDouble(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return Double.longBitsToDouble(readVolatileLong(offset));
     }
 
-    default long parseLong(long offset)
+    default long parseLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.parseLong(this, offset);
     }
@@ -297,7 +298,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    void nativeRead(long position, long address, long size)
+    void nativeRead(@NonNegative long position, long address, @NonNegative long size)
             throws BufferUnderflowException, IllegalStateException;
 
     /**
@@ -351,7 +352,7 @@ public interface RandomDataInput extends RandomCommon {
      * @return the long which might be padded.
      * @throws IllegalStateException if released
      */
-    default long readIncompleteLong(long offset)
+    default long readIncompleteLong(@NonNegative long offset)
             throws IllegalStateException {
         long left = readLimit() - offset;
         long l;
@@ -376,6 +377,7 @@ public interface RandomDataInput extends RandomCommon {
      * @return the actual capacity that can be potentially read.
      */
     @Override
+    @NonNegative
     long realCapacity();
 
     /**
@@ -387,7 +389,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default int addAndGetInt(long offset, int adding)
+    default int addAndGetInt(@NonNegative long offset, int adding)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.addAndGetInt(this, offset, adding);
     }
@@ -401,7 +403,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default long addAndGetLong(long offset, long adding)
+    default long addAndGetLong(@NonNegative long offset, long adding)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.addAndGetLong(this, offset, adding);
     }
@@ -414,7 +416,7 @@ public interface RandomDataInput extends RandomCommon {
      * @return the sum
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      */
-    default float addAndGetFloat(long offset, float adding)
+    default float addAndGetFloat(@NonNegative long offset, float adding)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.addAndGetFloat(this, offset, adding);
     }
@@ -428,7 +430,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    default double addAndGetDouble(long offset, double adding)
+    default double addAndGetDouble(@NonNegative long offset, double adding)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.addAndGetDouble(this, offset, adding);
     }
@@ -443,7 +445,7 @@ public interface RandomDataInput extends RandomCommon {
      */
     @SuppressWarnings("rawtypes")
     @NotNull
-    default BytesStore subBytes(long start, long length)
+    default BytesStore subBytes(@NonNegative long start, @NonNegative long length)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.subBytes(this, start, length);
     }
@@ -460,15 +462,15 @@ public interface RandomDataInput extends RandomCommon {
      * was observed (in this case, {@code sb} is truncated too, but not updated then, by querying
      * {@code sb} only this case is indistinguishable from reading an empty char sequence).
      *
+     * @param <T>    buffer type, must be {@code StringBuilder} or {@code Bytes}
      * @param offset the offset in this {@code RandomDataInput} to read char sequence from
      * @param sb     the buffer to read char sequence into (truncated first)
-     * @param <T>    buffer type, must be {@code StringBuilder} or {@code Bytes}
      * @return offset after the normal read char sequence, or -1 - offset, if char sequence is
      * {@code null}
      * @throws IllegalStateException if released
      * @see RandomDataOutput#writeUtf8(long, CharSequence)
      */
-    default <T extends Appendable & CharSequence> long readUtf8(long offset, @NotNull T sb)
+    default <T extends Appendable & CharSequence> long readUtf8(@NonNegative long offset, @NotNull T sb)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException, ArithmeticException, IllegalStateException {
         AppendableUtil.setLength(sb, 0);
         // TODO insert some bounds check here
@@ -510,18 +512,18 @@ public interface RandomDataInput extends RandomCommon {
      * length of Utf8 encoding of the char sequence exceeds {@code maxUtf8Len},
      * {@code IllegalStateException} is thrown.
      *
+     * @param <T>        buffer type, must be {@code StringBuilder} or {@code Bytes}
      * @param offset     the offset in this {@code RandomDataInput} to read char sequence from
      * @param sb         the buffer to read char sequence into (truncated first)
      * @param maxUtf8Len the maximum allowed length of the char sequence in Utf8 encoding
-     * @param <T>        buffer type, must be {@code StringBuilder} or {@code Bytes}
      * @return offset after the normal read char sequence, or -1 - offset, if char sequence is
      * {@code null}
      * @throws IllegalStateException if released
      * @see RandomDataOutput#writeUtf8Limited(long, CharSequence, int)
      */
-    default <T extends Appendable & CharSequence> long readUtf8Limited(long offset,
-                                                                       final @NotNull T sb,
-                                                                       final int maxUtf8Len)
+    default <T extends Appendable & CharSequence> long readUtf8Limited(@NonNegative long offset,
+                                                                       @NotNull final T sb,
+                                                                       @NonNegative final int maxUtf8Len)
             throws IORuntimeException, IllegalArgumentException, BufferUnderflowException,
             IllegalStateException {
         AppendableUtil.setLength(sb, 0);
@@ -569,7 +571,7 @@ public interface RandomDataInput extends RandomCommon {
      * @see RandomDataOutput#writeUtf8Limited(long, CharSequence, int)
      */
     @Nullable
-    default String readUtf8Limited(long offset, int maxUtf8Len)
+    default String readUtf8Limited(@NonNegative long offset, @NonNegative int maxUtf8Len)
             throws BufferUnderflowException, IORuntimeException, IllegalArgumentException,
             IllegalStateException {
         return BytesInternal.readUtf8(this, offset, maxUtf8Len);
@@ -587,7 +589,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws IllegalStateException if released
      * @throws IORuntimeException    if the contents are not a valid string.
      */
-    default boolean compareUtf8(long offset, @Nullable CharSequence other)
+    default boolean compareUtf8(@NonNegative long offset, @Nullable CharSequence other)
             throws IORuntimeException, BufferUnderflowException, IllegalStateException {
         return BytesInternal.compareUtf8(this, offset, other);
     }
@@ -597,7 +599,7 @@ public interface RandomDataInput extends RandomCommon {
         return BytesInternal.toByteArray(this);
     }
 
-    default long read(long offsetInRDI, byte[] bytes, int offset, int length)
+    default long read(@NonNegative long offsetInRDI, byte[] bytes, @NonNegative int offset, @NonNegative int length)
             throws IllegalStateException {
         requireNonNull(bytes);
         try {
@@ -624,7 +626,7 @@ public interface RandomDataInput extends RandomCommon {
         }
     }
 
-    default int fastHash(long offset, int length)
+    default int fastHash(@NonNegative long offset, @NonNegative int length)
             throws BufferUnderflowException, IllegalStateException {
         long hash = 0;
         int i = 0;
@@ -647,7 +649,11 @@ public interface RandomDataInput extends RandomCommon {
         return (int) (hash ^ (hash >> 32));
     }
 
-    default boolean canReadDirect(long length) {
+    default boolean canReadDirect() {
+        return canReadDirect();
+    }
+
+    default boolean canReadDirect(@NonNegative long length) {
         return isDirectMemory() && readRemaining() >= length;
     }
 }

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataOutput.java
@@ -120,7 +120,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException if the capacity was exceeded
      */
     @NotNull
-    R writeByte(long offset, byte i8)
+    R writeByte(@NonNegative long offset, byte i8)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -132,11 +132,11 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException if the capacity was exceeded
      */
     @NotNull
-    R writeShort(long offset, short i)
+    R writeShort(@NonNegative long offset, short i)
             throws BufferOverflowException, IllegalStateException;
 
     @NotNull
-    default R writeInt24(long offset, int i)
+    default R writeInt24(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeShort(offset, (short) i);
         return writeByte(offset + 2, (byte) (i >> 16));
@@ -151,7 +151,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException if the capacity was exceeded
      */
     @NotNull
-    R writeInt(long offset, int i)
+    R writeInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -163,7 +163,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException if the capacity was exceeded
      */
     @NotNull
-    R writeOrderedInt(long offset, int i)
+    R writeOrderedInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -189,7 +189,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException if the capacity was exceeded
      */
     @NotNull
-    R writeLong(long offset, long i)
+    R writeLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -200,7 +200,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @return this
      */
     @NotNull
-    R writeOrderedLong(long offset, long i)
+    R writeOrderedLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -225,7 +225,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException if the capacity was exceeded
      */
     @NotNull
-    R writeFloat(long offset, float d)
+    R writeFloat(@NonNegative long offset, float d)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -237,33 +237,33 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException if the capacity was exceeded
      */
     @NotNull
-    R writeDouble(long offset, double d)
+    R writeDouble(@NonNegative long offset, double d)
             throws BufferOverflowException, IllegalStateException;
 
     @NotNull
-    R writeVolatileByte(long offset, byte i8)
+    R writeVolatileByte(@NonNegative long offset, byte i8)
             throws BufferOverflowException, IllegalStateException;
 
     @NotNull
-    R writeVolatileShort(long offset, short i16)
+    R writeVolatileShort(@NonNegative long offset, short i16)
             throws BufferOverflowException, IllegalStateException;
 
     @NotNull
-    R writeVolatileInt(long offset, int i32)
+    R writeVolatileInt(@NonNegative long offset, int i32)
             throws BufferOverflowException, IllegalStateException;
 
     @NotNull
-    R writeVolatileLong(long offset, long i64)
+    R writeVolatileLong(@NonNegative long offset, long i64)
             throws BufferOverflowException, IllegalStateException;
 
     @NotNull
-    default R writeVolatileFloat(long offset, float f)
+    default R writeVolatileFloat(@NonNegative long offset, float f)
             throws BufferOverflowException, IllegalStateException {
         return writeVolatileInt(offset, Float.floatToRawIntBits(f));
     }
 
     @NotNull
-    default R writeVolatileDouble(long offset, double d)
+    default R writeVolatileDouble(@NonNegative long offset, double d)
             throws BufferOverflowException, IllegalStateException {
         return writeVolatileLong(offset, Double.doubleToRawLongBits(d));
     }
@@ -272,7 +272,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * Copies whole byte[] into this. See {@link #write(long, byte[], int, int)}
      */
     @NotNull
-    default R write(long offsetInRDO, @NotNull byte[] bytes)
+    default R write(@NonNegative long offsetInRDO, byte[] bytes)
             throws BufferOverflowException, IllegalStateException {
         requireNonNull(bytes);
         return write(offsetInRDO, bytes, 0, bytes.length);
@@ -312,14 +312,14 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException
      * @throws IllegalStateException
      */
-    void write(long writeOffset, @NotNull ByteBuffer bytes, int readOffset, int length)
+    void write(@NonNegative long writeOffset, @NotNull ByteBuffer bytes, @NonNegative int readOffset, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException;
 
     /**
      * Copies whole BytesStore into this - see {@link #write(long, RandomDataInput, long, long)}
      */
     @NotNull
-    default R write(long offsetInRDO, @NotNull BytesStore bytes)
+    default R write(@NonNegative long offsetInRDO, @NotNull BytesStore bytes)
             throws BufferOverflowException, IllegalStateException {
         requireNonNull(bytes);
         try {
@@ -342,7 +342,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws IllegalStateException
      */
     @NotNull
-    R write(long writeOffset, @NotNull RandomDataInput bytes, long readOffset, long length)
+    R write(@NonNegative long writeOffset, @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException;
 
     /**
@@ -354,18 +354,18 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @throws BufferOverflowException if the capacity was exceeded
      */
     @NotNull
-    R zeroOut(long start, long end)
+    R zeroOut(@NonNegative long start, @NonNegative long end)
             throws IllegalStateException;
 
     @NotNull
-    default R append(long offset, long value, int digits)
+    default R append(@NonNegative long offset, long value, int digits)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         BytesInternal.append(this, offset, value, digits);
         return (R) this;
     }
 
     @NotNull
-    default R append(long offset, double value, int decimalPlaces, int digits)
+    default R append(@NonNegative long offset, double value, int decimalPlaces, int digits)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException, ArithmeticException {
         if (decimalPlaces < 20) {
             double d2 = value * Maths.tens(decimalPlaces);
@@ -380,12 +380,11 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
 
     /**
      * expert level method to copy data from native memory into the BytesStore
-     *
-     * @param address  in native memory to copy from
+     *  @param address  in native memory to copy from
      * @param position in BytesStore to copy to
      * @param size     in bytes
      */
-    void nativeWrite(long address, long position, long size)
+    void nativeWrite(long address, @NonNegative long position, @NonNegative long size)
             throws BufferOverflowException, IllegalStateException;
 
     /**
@@ -397,7 +396,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @return the writeOffset after the char sequence written, in this {@code RandomDataOutput}
      * @see RandomDataInput#readUtf8(long, Appendable)
      */
-    default long writeUtf8(long writeOffset, @Nullable CharSequence text)
+    default long writeUtf8(@NonNegative long writeOffset, @Nullable CharSequence text)
             throws BufferOverflowException, IllegalStateException, ArithmeticException {
         return BytesInternal.writeUtf8(this, writeOffset, text);
     }
@@ -418,7 +417,7 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @see RandomDataInput#readUtf8Limited(long, Appendable, int)
      * @see RandomDataInput#readUtf8Limited(long, int)
      */
-    default long writeUtf8Limited(long writeOffset, @Nullable CharSequence text, int maxUtf8Len)
+    default long writeUtf8Limited(@NonNegative long writeOffset, @Nullable CharSequence text, @NonNegative int maxUtf8Len)
             throws BufferOverflowException, IllegalStateException, ArithmeticException {
         return BytesInternal.writeUtf8(this, writeOffset, text, maxUtf8Len);
     }
@@ -430,8 +429,8 @@ public interface RandomDataOutput<R extends RandomDataOutput<R>> extends RandomC
      * @param bs       to copy.
      * @return the offset after the char sequence written, in this {@code RandomDataOutput}
      */
-    long write8bit(long position, @NotNull BytesStore bs);
+    long write8bit(@NonNegative long position, @NotNull BytesStore bs);
 
-    long write8bit(long position, @NotNull String s, int start, int length);
+    long write8bit(@NonNegative long position, @NotNull String s, @NonNegative int start, @NonNegative int length);
 
 }

--- a/src/main/java/net/openhft/chronicle/bytes/RingBufferReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RingBufferReader.java
@@ -17,6 +17,7 @@
  */
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.Closeable;
 
 public interface RingBufferReader extends RingBufferReaderStats, Closeable {
@@ -39,11 +40,12 @@ public interface RingBufferReader extends RingBufferReaderStats, Closeable {
      * @return nextReadPosition which should be passed to {@link RingBufferReader#afterRead(long)}
      */
     @SuppressWarnings("rawtypes")
+    @NonNegative
     long beforeRead(Bytes bytes);
 
-    void afterRead(long next);
+    void afterRead(@NonNegative long next);
 
-    void afterRead(long next, long payloadStart, long underlyingIndex);
+    void afterRead(@NonNegative long next, long payloadStart, long underlyingIndex);
 
     long underlyingIndex();
 

--- a/src/main/java/net/openhft/chronicle/bytes/RingBufferReaderStats.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RingBufferReaderStats.java
@@ -17,11 +17,16 @@
  */
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
+
 public interface RingBufferReaderStats {
 
+    @NonNegative
     long getAndClearReadCount();
 
+    @NonNegative
     long getAndClearMissedReadCount();
 
+    @NonNegative
     long behind();
 }

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataInput.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.util.Histogram;
 import net.openhft.chronicle.core.util.ThrowingConsumer;
@@ -45,24 +46,24 @@ import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface StreamingDataInput<S extends StreamingDataInput<S>> extends StreamingCommon<S> {
     @NotNull
-    S readPosition(long position)
+    S readPosition(@NonNegative long position)
             throws BufferUnderflowException, IllegalStateException;
 
     @NotNull
-    default S readPositionUnlimited(long position)
+    default S readPositionUnlimited(@NonNegative long position)
             throws BufferUnderflowException, IllegalStateException {
         return readLimitToCapacity().readPosition(position);
     }
 
     @NotNull
-    default S readPositionRemaining(long position, long remaining)
+    default S readPositionRemaining(@NonNegative long position, @NonNegative long remaining)
             throws BufferUnderflowException, IllegalStateException {
         readLimit(position + remaining);
         return readPosition(position);
     }
 
     @NotNull
-    S readLimit(long limit)
+    S readLimit(@NonNegative long limit)
             throws BufferUnderflowException;
 
     default S readLimitToCapacity()
@@ -107,7 +108,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
     /**
      * Perform a set of actions with a temporary bounds mode.
      */
-    default void readWithLength0(long length, @NotNull ThrowingConsumerNonCapturing<S, IORuntimeException, BytesOut> bytesConsumer, StringBuilder sb, BytesOut toBytes)
+    default void readWithLength0(@NonNegative long length, @NotNull ThrowingConsumerNonCapturing<S, IORuntimeException, BytesOut> bytesConsumer, StringBuilder sb, BytesOut toBytes)
             throws BufferUnderflowException, IORuntimeException, IllegalStateException {
         requireNonNull(bytesConsumer);
         if (length > readRemaining())
@@ -126,7 +127,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
     /**
      * Perform a set of actions with a temporary bounds mode.
      */
-    default void readWithLength(long length, @NotNull ThrowingConsumer<S, IORuntimeException> bytesConsumer)
+    default void readWithLength(@NonNegative long length, @NotNull ThrowingConsumer<S, IORuntimeException> bytesConsumer)
             throws BufferUnderflowException, IORuntimeException, IllegalStateException {
         requireNonNull(bytesConsumer);
         if (length > readRemaining())
@@ -384,7 +385,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
         return read(bytes, 0, bytes.length);
     }
 
-    default int read(byte[] bytes, int off, int len)
+    default int read(byte[] bytes, @NonNegative int off, @NonNegative int len)
             throws BufferUnderflowException, IllegalStateException {
         requireNonNull(bytes);
         long remaining = readRemaining();
@@ -399,7 +400,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
         return len2;
     }
 
-    default int read(char[] bytes, int off, int len)
+    default int read(char[] bytes, @NonNegative int off, @NonNegative int len)
             throws IllegalStateException {
         requireNonNull(bytes);
         long remaining = readRemaining();
@@ -431,7 +432,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
     }
 
     default void read(@NotNull final Bytes<?> bytes,
-                      final int length)
+                      @NonNegative final int length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         requireNonNull(bytes);
         int len2 = (int) Math.min(length, readRemaining());
@@ -442,12 +443,12 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
             bytes.rawWriteByte(rawReadByte());
     }
 
-    default void unsafeReadObject(@NotNull Object o, int length)
+    default void unsafeReadObject(@NotNull Object o, @NonNegative int length)
             throws BufferUnderflowException, IllegalStateException {
         unsafeReadObject(o, (o.getClass().isArray() ? 4 : 0) + Jvm.objectHeaderSize(), length);
     }
 
-    default void unsafeReadObject(@NotNull Object o, int offset, int length)
+    default void unsafeReadObject(@NotNull Object o, @NonNegative int offset, @NonNegative int length)
             throws BufferUnderflowException, IllegalStateException {
         requireNonNull(o);
         assert BytesUtil.isTriviallyCopyable(o.getClass(), offset, length);
@@ -470,7 +471,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
             UnsafeMemory.unsafePutByte(o, (long) offset + i, rawReadByte());
     }
 
-    default S unsafeRead(long address, int length) {
+    default S unsafeRead(long address, @NonNegative int length) {
         if (isDirectMemory()) {
             long src = addressForRead(readPosition());
             readSkip(length);
@@ -507,7 +508,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
      * @param sb            buffer to copy into
      * @param encodedLength length of the UTF encoded data in bytes
      */
-    default void parseUtf8(@NotNull Appendable sb, int encodedLength)
+    default void parseUtf8(@NotNull Appendable sb, @NonNegative int encodedLength)
             throws IllegalArgumentException, BufferUnderflowException, UTFDataFormatRuntimeException, IllegalStateException {
         parseUtf8(sb, true, encodedLength);
     }
@@ -519,7 +520,7 @@ public interface StreamingDataInput<S extends StreamingDataInput<S>> extends Str
      * @param utf    true if the length is the UTF-8 encoded length, false if the length is the length of chars
      * @param length to limit the read.
      */
-    default void parseUtf8(@NotNull Appendable sb, boolean utf, int length)
+    default void parseUtf8(@NotNull Appendable sb, boolean utf, @NonNegative int length)
             throws IllegalArgumentException, BufferUnderflowException, UTFDataFormatRuntimeException, IllegalStateException {
         AppendableUtil.setLength(sb, 0);
         BytesInternal.parseUtf8(this, sb, utf, length);

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
@@ -55,11 +55,11 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     int JAVA9_STRING_CODER_UTF16 = 1;
 
     @NotNull
-    S writePosition(long position)
+    S writePosition(@NonNegative long position)
             throws BufferOverflowException;
 
     @NotNull
-    S writeLimit(long limit)
+    S writeLimit(@NonNegative long limit)
             throws BufferOverflowException;
 
     /**
@@ -201,7 +201,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     }
 
     @NotNull
-    default S write8bit(@NotNull CharSequence text, int start, int length)
+    default S write8bit(@NotNull CharSequence text, @NonNegative int start, @NonNegative int length)
             throws BufferOverflowException, IndexOutOfBoundsException, ArithmeticException, IllegalStateException, BufferUnderflowException {
         requireNonNull(text);
         if (text instanceof String)
@@ -216,7 +216,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     }
 
     @NotNull
-    S write8bit(@NotNull String text, int start, int length);
+    S write8bit(@NotNull String text, @NonNegative int start, @NonNegative int length);
 
     /**
      * Writes the provided {@code text} to this StreamingDataOutput at the current writePosition().
@@ -251,8 +251,8 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
      */
     @NotNull
     default S write(@NotNull final CharSequence text,
-                    final int startText,
-                    final int length)
+                    @NonNegative final int startText,
+                    @NonNegative final int length)
             throws BufferOverflowException, IndexOutOfBoundsException, IllegalStateException {
         requireNonNull(text);
         requireNonNegative(startText);
@@ -337,7 +337,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     }
 
     @NotNull
-    S writeIntAdv(int i, int advance)
+    S writeIntAdv(int i, @NonNegative int advance)
             throws BufferOverflowException, IllegalStateException;
 
     @NotNull
@@ -362,7 +362,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     }
 
     @NotNull
-    S writeLongAdv(long i64, int advance)
+    S writeLongAdv(long i64, @NonNegative int advance)
             throws BufferOverflowException, IllegalStateException;
 
     @NotNull
@@ -427,6 +427,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
      * @return capacity without resize or -1 if closed
      */
     @Override
+    @NonNegative
     long realCapacity();
 
     default boolean canWriteDirect(long count) {
@@ -465,7 +466,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
      * Calling this method will update the cursors of this, but not the bytes we read from.
      */
     @NotNull
-    default S write(@NotNull RandomDataInput bytes, long readOffset, long length)
+    default S write(@NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
         BytesInternal.writeFully(bytes, readOffset, length, this);
         return (S) this;
@@ -477,7 +478,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
      * Calling this method will update the cursors of this, but not the bytes we read from.
      */
     @NotNull
-    default S write(@NotNull BytesStore<?, ?> bytes, long readOffset, long length)
+    default S write(@NotNull BytesStore<?, ?> bytes, @NonNegative long readOffset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
         requireNonNull(bytes);
         requireNonNegative(readOffset);
@@ -522,12 +523,12 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
             @NonNegative final int offset,
             @NonNegative final int length) throws BufferOverflowException, IllegalStateException, IllegalArgumentException, ArrayIndexOutOfBoundsException;
 
-    default S unsafeWriteObject(Object o, int length)
+    default S unsafeWriteObject(Object o, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException {
         return unsafeWriteObject(o, (o.getClass().isArray() ? 4 : 0) + Jvm.objectHeaderSize(), length);
     }
 
-    default S unsafeWriteObject(Object o, int offset, int length)
+    default S unsafeWriteObject(Object o, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException {
         if (this.isDirectMemory()) {
             writeSkip(length); // blow up here if this isn't going to work
@@ -548,7 +549,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
      *
      * @return this
      */
-    default S unsafeWrite(long address, int length) {
+    default S unsafeWrite(long address, @NonNegative int length) {
         if (isDirectMemory()) {
             writeSkip(length); // blow up if there isn't that much space left
             long destAddress = addressForWrite(writePosition() - length);
@@ -605,7 +606,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     }
 
     @NotNull
-    default S appendUtf8(char[] chars, int offset, int length)
+    default S appendUtf8(char[] chars, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException, BufferUnderflowException, IllegalArgumentException {
         int i;
         ascii:
@@ -626,7 +627,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     }
 
     @NotNull
-    default S appendUtf8(@NotNull CharSequence cs, int offset, int length)
+    default S appendUtf8(@NotNull CharSequence cs, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IndexOutOfBoundsException, IllegalStateException, BufferUnderflowException {
         BytesInternal.appendUtf8(this, cs, offset, length);
         return (S) this;
@@ -635,7 +636,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     // length is number of characters (not bytes)
     @Java9
     @NotNull
-    default S appendUtf8(final byte[] bytes, int offset, int length, byte coder)
+    default S appendUtf8(final byte[] bytes, @NonNegative int offset, @NonNegative int length, byte coder)
             throws BufferOverflowException, IllegalStateException {
         if (coder == JAVA9_STRING_CODER_LATIN) {
             for (int i = 0; i < length; i++) {
@@ -658,7 +659,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
 
     @Java9
     @NotNull
-    default S appendUtf8(final byte[] bytes, int offset, int length)
+    default S appendUtf8(final byte[] bytes, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException {
         for (int i = 0; i < length; i++) {
             int b = bytes[offset + i] & 0xFF; // unsigned byte
@@ -699,7 +700,7 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
         BytesInternal.copy(input, this);
     }
 
-    default void writePositionRemaining(long position, long length)
+    default void writePositionRemaining(@NonNegative long position, @NonNegative long length)
             throws BufferOverflowException {
         requireNonNegative(position);
         requireNonNegative(length);

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingInputStream.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingInputStream.java
@@ -18,6 +18,7 @@
 
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -62,7 +63,7 @@ public class StreamingInputStream extends InputStream {
     }
 
     @Override
-    public int read(byte[] b, int off, int len)
+    public int read(byte[] b, @NonNegative int off, @NonNegative int len)
             throws IOException {
         try {
             if (len == 0) {

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingOutputStream.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingOutputStream.java
@@ -18,6 +18,7 @@
 
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class StreamingOutputStream extends OutputStream {
     }
 
     @Override
-    public void write(byte[] b, int off, int len)
+    public void write(byte[] b, @NonNegative int off, @NonNegative int len)
             throws IOException {
         try {
             sdo.write(b, off, len);

--- a/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
@@ -18,6 +18,7 @@
 
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.BufferUnderflowException;
@@ -38,7 +39,7 @@ public class SubBytes<U> extends VanillaBytes<U> {
      * @throws BufferUnderflowException if capacity is less than start
      * @throws IllegalArgumentException
      */
-    public SubBytes(@NotNull BytesStore bytesStore, long start, long capacity)
+    public SubBytes(@NotNull BytesStore bytesStore, @NonNegative long start, @NonNegative long capacity)
             throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
         super(bytesStore);
         this.start = start;
@@ -47,16 +48,19 @@ public class SubBytes<U> extends VanillaBytes<U> {
         readLimit(writeLimit());
     }
 
+    @NonNegative
     @Override
     public long capacity() {
         return capacity;
     }
 
+    @NonNegative
     @Override
     public long start() {
         return start;
     }
 
+    @NonNegative
     @Override
     public long realCapacity() {
         return capacity;

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.bytes.internal.ReferenceCountedUtil;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -70,7 +71,7 @@ public class UncheckedBytes<U>
     }
 
     @Override
-    public void ensureCapacity(long desiredCapacity)
+    public void ensureCapacity(@NonNegative long desiredCapacity)
             throws IllegalArgumentException, IllegalStateException {
         if (desiredCapacity > realCapacity()) {
             underlyingBytes.ensureCapacity(desiredCapacity);
@@ -91,37 +92,37 @@ public class UncheckedBytes<U>
     }
 
     @Override
-    protected void writeCheckOffset(long offset, long adding) {
+    protected void writeCheckOffset(@NonNegative long offset, @NonNegative long adding) {
         // Do nothing
     }
 
     @Override
-    protected void readCheckOffset(long offset, long adding, boolean given) {
+    protected void readCheckOffset(@NonNegative long offset, long adding, boolean given) {
         // Do nothing
     }
 
     @Override
-    void prewriteCheckOffset(long offset, long subtracting) {
+    void prewriteCheckOffset(@NonNegative long offset, long subtracting) {
         // Do nothing
     }
 
     @NotNull
     @Override
-    public Bytes<U> readPosition(long position) {
+    public Bytes<U> readPosition(@NonNegative long position) {
         readPosition = position;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> readLimit(long limit) {
+    public Bytes<U> readLimit(@NonNegative long limit) {
         uncheckedWritePosition(limit);
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> writePosition(long position) {
+    public Bytes<U> writePosition(@NonNegative long position) {
         uncheckedWritePosition(position);
         return this;
     }
@@ -142,7 +143,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLimit(long limit) {
+    public Bytes<U> writeLimit(@NonNegative long limit) {
         writeLimit = limit;
         return this;
     }
@@ -160,21 +161,21 @@ public class UncheckedBytes<U>
     }
 
     @Override
-    protected long readOffsetPositionMoved(long adding) {
+    protected long readOffsetPositionMoved(@NonNegative long adding) {
         long offset = readPosition;
         readPosition += adding;
         return offset;
     }
 
     @Override
-    protected long writeOffsetPositionMoved(long adding, long advance) {
+    protected long writeOffsetPositionMoved(@NonNegative long adding, @NonNegative long advance) {
         long oldPosition = writePosition();
         uncheckedWritePosition(writePosition() + advance);
         return oldPosition;
     }
 
     @Override
-    protected long prewriteOffsetPositionMoved(long subtracting)
+    protected long prewriteOffsetPositionMoved(@NonNegative long subtracting)
             throws BufferOverflowException {
         readPosition -= subtracting;
         return readPosition;
@@ -182,7 +183,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
+    public Bytes<U> write(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException, BufferUnderflowException {
         requireNonNull(bytes);
         if (length == 8) {
@@ -196,7 +197,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull BytesStore bytes, long offset, long length)
+    public Bytes<U> write(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException, BufferUnderflowException {
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
         requireNonNegative(offset);
@@ -234,7 +235,7 @@ public class UncheckedBytes<U>
         return this;
     }
 
-    long rawCopy(@NotNull BytesStore bytes, long offset, long length)
+    long rawCopy(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws BufferOverflowException, IllegalStateException, BufferUnderflowException {
         requireNonNull(bytes);
         long len = Math.min(writeRemaining(), Math.min(bytes.capacity() - offset, length));
@@ -300,7 +301,7 @@ public class UncheckedBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> appendUtf8(char[] chars, int offset, int length)
+    public Bytes<U> appendUtf8(char[] chars, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         requireNonNull(chars);
         long wp = writePosition();

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedNativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedNativeBytes.java
@@ -72,7 +72,7 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public void ensureCapacity(long desiredCapacity)
+    public void ensureCapacity(@NonNegative long desiredCapacity)
             throws IllegalArgumentException, IllegalStateException {
         if (desiredCapacity > realCapacity()) {
             underlyingBytes.ensureCapacity(desiredCapacity);
@@ -98,7 +98,7 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public void move(long from, long to, long length)
+    public void move(@NonNegative long from, @NonNegative long to, @NonNegative long length)
             throws IllegalStateException, BufferUnderflowException {
         bytesStore.move(from - start(), to - start(), length);
     }
@@ -124,21 +124,21 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> readPosition(long position) {
+    public Bytes<U> readPosition(@NonNegative long position) {
         readPosition = position;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> readLimit(long limit) {
+    public Bytes<U> readLimit(@NonNegative long limit) {
         writePosition = limit;
         return this;
     }
 
     @NotNull
     @Override
-    public Bytes<U> writePosition(long position) {
+    public Bytes<U> writePosition(@NonNegative long position) {
         writePosition = requireNonNegative(position);
         return this;
     }
@@ -151,25 +151,25 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public byte readVolatileByte(long offset)
+    public byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException {
         return bytesStore.readVolatileByte(offset);
     }
 
     @Override
-    public short readVolatileShort(long offset)
+    public short readVolatileShort(@NonNegative long offset)
             throws BufferUnderflowException {
         return bytesStore.readVolatileShort(offset);
     }
 
     @Override
-    public int readVolatileInt(long offset)
+    public int readVolatileInt(@NonNegative long offset)
             throws BufferUnderflowException {
         return bytesStore.readVolatileInt(offset);
     }
 
     @Override
-    public long readVolatileLong(long offset)
+    public long readVolatileLong(@NonNegative long offset)
             throws BufferUnderflowException {
         return bytesStore.readVolatileLong(offset);
     }
@@ -193,7 +193,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLimit(long limit) {
+    public Bytes<U> writeLimit(@NonNegative long limit) {
         writeLimit = requireNonNegative(limit);
         return this;
     }
@@ -210,17 +210,17 @@ public class UncheckedNativeBytes<U>
         return false;
     }
 
-    protected long readOffsetPositionMoved(long adding) {
+    protected long readOffsetPositionMoved(@NonNegative long adding) {
         long offset = readPosition;
         readPosition += adding;
         return offset;
     }
 
-    protected long writeOffsetPositionMoved(long adding) {
+    protected long writeOffsetPositionMoved(@NonNegative long adding) {
         return writeOffsetPositionMoved(adding, adding);
     }
 
-    protected long writeOffsetPositionMoved(long adding, long advance) {
+    protected long writeOffsetPositionMoved(@NonNegative long adding, @NonNegative long advance) {
         long oldPosition = writePosition;
         long writeEnd = oldPosition + adding;
         assert writeEnd <= bytesStore.safeLimit();
@@ -228,14 +228,14 @@ public class UncheckedNativeBytes<U>
         return oldPosition;
     }
 
-    protected long prewriteOffsetPositionMoved(long substracting) {
+    protected long prewriteOffsetPositionMoved(@NonNegative long substracting) {
         readPosition -= substracting;
         return readPosition;
     }
 
     @NotNull
     @Override
-    public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
+    public Bytes<U> write(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
         requireNonNegative(offset);
@@ -252,7 +252,7 @@ public class UncheckedNativeBytes<U>
         return this;
     }
 
-    public long rawCopy(@NotNull RandomDataInput bytes, long offset, long length)
+    public long rawCopy(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         long len = Math.min(writeRemaining(), Math.min(bytes.capacity() - offset, length));
         if (len > 0) {
@@ -274,7 +274,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> clearAndPad(long length)
+    public Bytes<U> clearAndPad(@NonNegative long length)
             throws BufferOverflowException {
         if (start() + length > capacity())
             throw new BufferOverflowException();
@@ -294,7 +294,7 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public long realCapacity() {
+    public @NonNegative long realCapacity() {
         return bytesStore.realCapacity();
     }
 
@@ -304,7 +304,7 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public long capacity() {
+    public @NonNegative long capacity() {
         return capacity;
     }
 
@@ -315,31 +315,31 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public long readPosition() {
+    public @NonNegative long readPosition() {
         return readPosition;
     }
 
     @Override
-    public long writePosition() {
+    public @NonNegative long writePosition() {
         return writePosition;
     }
 
     @Override
-    public boolean compareAndSwapInt(long offset, int expected, int value)
+    public boolean compareAndSwapInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         return bytesStore.compareAndSwapInt(offset, expected, value);
     }
 
     @Override
-    public void testAndSetInt(long offset, int expected, int value)
+    public void testAndSetInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.testAndSetInt(offset, expected, value);
     }
 
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value)
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         return bytesStore.compareAndSwapLong(offset, expected, value);
@@ -424,7 +424,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeByte(long offset, byte i)
+    public Bytes<U> writeByte(@NonNegative long offset, byte i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeByte(offset, i);
@@ -433,7 +433,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeShort(long offset, short i)
+    public Bytes<U> writeShort(@NonNegative long offset, short i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeShort(offset, i);
@@ -442,7 +442,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeInt(long offset, int i)
+    public Bytes<U> writeInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeInt(offset, i);
@@ -451,7 +451,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedInt(long offset, int i)
+    public Bytes<U> writeOrderedInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeOrderedInt(offset, i);
@@ -460,7 +460,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLong(long offset, long i)
+    public Bytes<U> writeLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeLong(offset, i);
@@ -469,7 +469,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeOrderedLong(long offset, long i)
+    public Bytes<U> writeOrderedLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeOrderedLong(offset, i);
@@ -478,7 +478,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeFloat(long offset, float d)
+    public Bytes<U> writeFloat(@NonNegative long offset, float d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeFloat(offset, d);
@@ -487,7 +487,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeDouble(long offset, double d)
+    public Bytes<U> writeDouble(@NonNegative long offset, double d)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeDouble(offset, d);
@@ -496,7 +496,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileByte(long offset, byte i8)
+    public Bytes<U> writeVolatileByte(@NonNegative long offset, byte i8)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 1);
         bytesStore.writeVolatileByte(offset, i8);
@@ -505,7 +505,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileShort(long offset, short i16)
+    public Bytes<U> writeVolatileShort(@NonNegative long offset, short i16)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 2);
         bytesStore.writeVolatileShort(offset, i16);
@@ -514,7 +514,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileInt(long offset, int i32)
+    public Bytes<U> writeVolatileInt(@NonNegative long offset, int i32)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 4);
         bytesStore.writeVolatileInt(offset, i32);
@@ -523,7 +523,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeVolatileLong(long offset, long i64)
+    public Bytes<U> writeVolatileLong(@NonNegative long offset, long i64)
             throws BufferOverflowException, IllegalStateException {
         writeCheckOffset(offset, 8);
         bytesStore.writeVolatileLong(offset, i64);
@@ -543,7 +543,7 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public void write(long offsetInRDO, @NotNull ByteBuffer bytes, int offset, int length)
+    public void write(@NonNegative long offsetInRDO, @NotNull ByteBuffer bytes, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException {
         requireNonNull(bytes);
         writeCheckOffset(offsetInRDO, length);
@@ -552,8 +552,8 @@ public class UncheckedNativeBytes<U>
 
     @Override
     @NotNull
-    public Bytes<U> write(long writeOffset,
-                          @NotNull RandomDataInput bytes, long readOffset, long length)
+    public Bytes<U> write(@NonNegative long writeOffset,
+                          @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         writeCheckOffset(writeOffset, length);
         bytesStore.write(writeOffset, bytes, readOffset, length);
@@ -566,42 +566,42 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public byte readByte(long offset) {
+    public byte readByte(@NonNegative long offset) {
         return bytesStore.readByte(offset);
     }
 
     @Override
-    public int readUnsignedByte(long offset) {
+    public int readUnsignedByte(@NonNegative long offset) {
         return bytesStore.readByte(offset) & 0xFF;
     }
 
     @Override
-    public int peekUnsignedByte(long offset) {
+    public int peekUnsignedByte(@NonNegative long offset) {
         return offset >= writePosition ? -1 : readByte(offset);
     }
 
     @Override
-    public short readShort(long offset) {
+    public short readShort(@NonNegative long offset) {
         return bytesStore.readShort(offset);
     }
 
     @Override
-    public int readInt(long offset) {
+    public int readInt(@NonNegative long offset) {
         return bytesStore.readInt(offset);
     }
 
     @Override
-    public long readLong(long offset) {
+    public long readLong(@NonNegative long offset) {
         return bytesStore.readLong(offset);
     }
 
     @Override
-    public float readFloat(long offset) {
+    public float readFloat(@NonNegative long offset) {
         return bytesStore.readFloat(offset);
     }
 
     @Override
-    public double readDouble(long offset) {
+    public double readDouble(@NonNegative long offset) {
         return bytesStore.readDouble(offset);
     }
 
@@ -650,7 +650,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeIntAdv(int i, int advance)
+    public Bytes<U> writeIntAdv(int i, @NonNegative int advance)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(4, advance);
         bytesStore.writeInt(offset, i);
@@ -677,7 +677,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> writeLongAdv(long i64, int advance)
+    public Bytes<U> writeLongAdv(long i64, @NonNegative int advance)
             throws IllegalStateException {
         long offset = writeOffsetPositionMoved(8, advance);
         bytesStore.writeLong(offset, i64);
@@ -785,13 +785,13 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public long addressForRead(long offset)
+    public long addressForRead(@NonNegative long offset)
             throws BufferUnderflowException {
         return bytesStore.addressForRead(offset);
     }
 
     @Override
-    public long addressForWrite(long offset)
+    public long addressForWrite(@NonNegative long offset)
             throws BufferOverflowException {
         return bytesStore.addressForWrite(offset);
     }
@@ -830,13 +830,13 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public void nativeRead(long position, long address, long size)
+    public void nativeRead(@NonNegative long position, long address, @NonNegative long size)
             throws IllegalStateException, BufferUnderflowException {
         bytesStore.nativeRead(position, address, size);
     }
 
     @Override
-    public void nativeWrite(long address, long position, long size)
+    public void nativeWrite(long address, @NonNegative long position, @NonNegative long size)
             throws IllegalStateException, BufferOverflowException {
         bytesStore.nativeWrite(address, position, size);
     }
@@ -883,7 +883,7 @@ public class UncheckedNativeBytes<U>
 
     @NotNull
     @Override
-    public Bytes<U> appendUtf8(char[] chars, int offset, int length)
+    public Bytes<U> appendUtf8(char[] chars, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         long actualUTF8Length = AppendableUtil.findUtf8Length(chars, offset, length);
         ensureCapacity(writePosition + actualUTF8Length);
@@ -927,12 +927,12 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public long write8bit(long position, @NotNull BytesStore bs) {
+    public long write8bit(@NonNegative long position, @NotNull BytesStore bs) {
         return bytesStore.write8bit(position, bs);
     }
 
     @Override
-    public long write8bit(long position, @NotNull String s, int start, int length) {
+    public long write8bit(@NonNegative long position, @NotNull String s, @NonNegative int start, @NonNegative int length) {
         return bytesStore.write8bit(position, s, start, length);
     }
 
@@ -954,7 +954,7 @@ public class UncheckedNativeBytes<U>
     }
 
     @Override
-    public @NotNull Bytes<U> write8bit(final @NotNull String text, final int start, final int length) {
+    public @NotNull Bytes<U> write8bit(final @NotNull String text, final @NonNegative int start, final @NonNegative int length) {
         requireNonNull(text);
         final long toWriteLength = UnsafeMemory.INSTANCE.stopBitLength(length) + (long) length;
         final long position = writeOffsetPositionMoved(toWriteLength, 0);
@@ -971,22 +971,22 @@ public class UncheckedNativeBytes<U>
     private final class UncheckedRandomDataInputHolder implements UncheckedRandomDataInput {
 
         @Override
-        public byte readByte(long offset) {
+        public byte readByte(@NonNegative long offset) {
             return bytesStore.readByte(offset);
         }
 
         @Override
-        public short readShort(long offset) {
+        public short readShort(@NonNegative long offset) {
             return bytesStore.readShort(offset);
         }
 
         @Override
-        public int readInt(long offset) {
+        public int readInt(@NonNegative long offset) {
             return bytesStore.readInt(offset);
         }
 
         @Override
-        public long readLong(long offset) {
+        public long readLong(@NonNegative long offset) {
             return bytesStore.readLong(offset);
         }
     }

--- a/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
@@ -22,6 +22,7 @@
     import net.openhft.chronicle.bytes.internal.NativeBytesStore;
     import net.openhft.chronicle.core.*;
     import net.openhft.chronicle.core.annotation.Java9;
+    import net.openhft.chronicle.core.annotation.NonNegative;
     import net.openhft.chronicle.core.io.IORuntimeException;
     import net.openhft.chronicle.core.util.StringUtils;
     import org.jetbrains.annotations.NotNull;
@@ -121,7 +122,7 @@
             return true;
         }
 
-        private static boolean isEqual1(char[] chars, @NotNull BytesStore bytesStore, long readPosition)
+        private static boolean isEqual1(char[] chars, @NotNull BytesStore bytesStore, @NonNegative long readPosition)
                 throws BufferUnderflowException, IllegalStateException {
             for (int i = 0; i < chars.length; i++) {
                 int b = bytesStore.readByte(readPosition + i) & 0xFF;
@@ -132,7 +133,7 @@
         }
 
         @Java9
-        private static boolean isEqual1(byte[] bytes, byte coder, @NotNull BytesStore bytesStore, long readPosition)
+        private static boolean isEqual1(byte[] bytes, byte coder, @NotNull BytesStore bytesStore, @NonNegative long readPosition)
                 throws BufferUnderflowException, IllegalStateException {
             for (int i = 0; i < bytes.length; i++) {
                 int b = bytesStore.readByte(readPosition + i) & 0xFF;
@@ -152,16 +153,16 @@
         }
 
         @Override
-        public long readVolatileLong(long offset)
+        public long readVolatileLong(@NonNegative long offset)
                 throws BufferUnderflowException, IllegalStateException {
             readCheckOffset(offset, 8, true);
             return bytesStore.readVolatileLong(offset);
         }
 
         @Override
-        public void bytesStore(@NotNull final BytesStore<Bytes<U>, U> byteStore,
-                               final long offset,
-                               final long length)
+        public void bytesStore(final @NotNull BytesStore<Bytes<U>, U> byteStore,
+                               final @NonNegative long offset,
+                               final @NonNegative long length)
                 throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
             requireNonNull(byteStore);
             setBytesStore(byteStore);
@@ -251,7 +252,7 @@
         }
 
         @Override
-        public long realCapacity() {
+        public @NonNegative long realCapacity() {
             return bytesStore.realCapacity();
         }
 
@@ -282,7 +283,7 @@
 
         @NotNull
         @Override
-        public Bytes<U> write(@NotNull RandomDataInput bytes, long offset, long length)
+        public Bytes<U> write(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
             requireNonNull(bytes);
             requireNonNegative(offset);
@@ -292,7 +293,7 @@
             return this;
         }
 
-        protected void optimisedWrite(@NotNull RandomDataInput bytes, long offset, long length)
+        protected void optimisedWrite(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
             requireNonNull(bytes);
             if (length <= safeCopySize() && isDirectMemory() && bytes.isDirectMemory()) {
@@ -311,7 +312,7 @@
             }
         }
 
-        public void write(long position, @NotNull CharSequence str, int offset, int length)
+        public void write(long position, @NotNull CharSequence str, @NonNegative int offset, @NonNegative int length)
                 throws BufferOverflowException, IllegalArgumentException, ArithmeticException, IllegalStateException, BufferUnderflowException {
             requireNonNegative(position);
             requireNonNull(str);
@@ -327,13 +328,13 @@
             }
         }
 
-        private char charAt(@NotNull CharSequence str, int index) {
+        private char charAt(@NotNull CharSequence str, @NonNegative int index) {
             return str.charAt(index);
         }
 
         @Override
         @NotNull
-        public VanillaBytes append(@NotNull CharSequence str, int start, int end)
+        public VanillaBytes append(@NotNull CharSequence str, @NonNegative int start, @NonNegative int end)
                 throws IndexOutOfBoundsException {
             assert end > start : "end=" + end + ",start=" + start;
             requireNonNull(str);
@@ -427,7 +428,7 @@
 
         @NotNull
         @Override
-        public Bytes<U> write(@NotNull BytesStore bytes, long offset, long length)
+        public Bytes<U> write(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
                 throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
             requireNonNull(bytes);
             requireNonNegative(offset);
@@ -593,7 +594,7 @@
             }
         }
 
-        public void read8Bit(char[] chars, int length)
+        public void read8Bit(char[] chars, @NonNegative int length)
                 throws BufferUnderflowException, IllegalStateException {
             ReportUnoptimised.reportOnce();
 
@@ -610,7 +611,7 @@
 
         // TODO: protected?
         @Override
-        public int byteCheckSum(int start, int end)
+        public int byteCheckSum(@NonNegative int start, @NonNegative int end)
                 throws IORuntimeException, BufferUnderflowException {
             byte b = 0;
             // the below cast is safe as should only be called from net.openhft.chronicle.bytes.AbstractBytes.byteCheckSum(long, long)
@@ -634,7 +635,7 @@
 
         @NotNull
         @Override
-        public Bytes<U> appendUtf8(char[] chars, int offset, int length)
+        public Bytes<U> appendUtf8(char[] chars, @NonNegative int offset, @NonNegative int length)
                 throws BufferOverflowException, IllegalStateException, BufferUnderflowException, IllegalArgumentException {
             long actualUTF8Length = AppendableUtil.findUtf8Length(chars, offset, length);
             ensureCapacity(writePosition() + actualUTF8Length);

--- a/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.bytes.algo;
 
 import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.BufferUnderflowException;
@@ -35,7 +36,7 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
                 : VanillaBytesStoreHash.INSTANCE.applyAsLong(b);
     }
 
-    static long hash(@NotNull BytesStore b, long length) throws IllegalStateException, BufferUnderflowException {
+    static long hash(@NotNull BytesStore b, @NonNegative long length) throws IllegalStateException, BufferUnderflowException {
         return b.isDirectMemory()
                 ? OptimisedBytesStoreHash.INSTANCE.applyAsLong(b, length)
                 : VanillaBytesStoreHash.INSTANCE.applyAsLong(b, length);
@@ -46,7 +47,7 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
         return (int) (hash ^ (hash >>> 32));
     }
 
-    static int hash32(@NotNull BytesStore b, int length) throws IllegalStateException, BufferUnderflowException {
+    static int hash32(@NotNull BytesStore b, @NonNegative int length) throws IllegalStateException, BufferUnderflowException {
         long hash = hash(b, length);
         return (int) (hash ^ (hash >>> 32));
     }

--- a/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Memory;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.BufferUnderflowException;
@@ -37,7 +38,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
     public static final boolean IS_LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
     private static final int TOP_BYTES = IS_LITTLE_ENDIAN ? 4 : 0;
 
-    static long applyAsLong1to7(@NotNull BytesStore store, int remaining) throws IllegalStateException, BufferUnderflowException {
+    static long applyAsLong1to7(@NotNull BytesStore store, @NonNegative int remaining) throws IllegalStateException, BufferUnderflowException {
         final long address = store.addressForRead(store.readPosition());
 
         return hash(readIncompleteLong(address, remaining));
@@ -57,7 +58,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
         return agitate(l * K0 + hi * K1);
     }
 
-    static long applyAsLong9to16(@NotNull BytesStore store, int remaining) throws BufferUnderflowException {
+    static long applyAsLong9to16(@NotNull BytesStore store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore bytesStore = store.bytesStore();
         final long address = bytesStore.addressForRead(store.readPosition());
         long h0 = (long) remaining * K0;
@@ -83,7 +84,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
                 ^ agitate(h2) ^ agitate(h3);
     }
 
-    static long applyAsLong17to32(@NotNull BytesStore store, int remaining) throws BufferUnderflowException {
+    static long applyAsLong17to32(@NotNull BytesStore store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore bytesStore = store.bytesStore();
         final long address = bytesStore.addressForRead(store.readPosition());
         long h0 = (long) remaining * K0;
@@ -109,7 +110,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
                 ^ agitate(h2) ^ agitate(h3);
     }
 
-    public static long applyAsLong32bytesMultiple(@NotNull BytesStore store, int remaining) throws BufferUnderflowException {
+    public static long applyAsLong32bytesMultiple(@NotNull BytesStore store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore bytesStore = store.bytesStore();
         final long address = bytesStore.addressForRead(store.readPosition());
         long h0 = (long) remaining * K0;
@@ -145,7 +146,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
                 ^ agitate(h2) ^ agitate(h3);
     }
 
-    public static long applyAsLongAny(@NotNull BytesStore store, long remaining) throws BufferUnderflowException {
+    public static long applyAsLongAny(@NotNull BytesStore store, @NonNegative long remaining) throws BufferUnderflowException {
         @NotNull final BytesStore bytesStore = store.bytesStore();
         final long address = bytesStore.addressForRead(store.readPosition());
         long h0 = remaining * K0;
@@ -222,7 +223,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
                 ^ agitate(h2) ^ agitate(h3);
     }
 
-    static long readIncompleteLong(long address, int len) {
+    static long readIncompleteLong(long address, @NonNegative int len) {
         switch (len) {
             case 1:
                 return MEMORY.readByte(address);
@@ -262,7 +263,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore> {
     }
 
     @Override
-    public long applyAsLong(@NotNull BytesStore store, long remaining) throws IllegalStateException, BufferUnderflowException {
+    public long applyAsLong(@NotNull BytesStore store, @NonNegative long remaining) throws IllegalStateException, BufferUnderflowException {
         if (remaining <= 16) {
             if (remaining == 0) {
                 return 0;

--- a/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.bytes.algo;
 
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.BufferUnderflowException;
@@ -56,7 +57,7 @@ public enum VanillaBytesStoreHash implements BytesStoreHash<BytesStore> {
     }
 
     @Override
-    public long applyAsLong(BytesStore bytes, long length) throws IllegalStateException, BufferUnderflowException {
+    public long applyAsLong(BytesStore bytes, @NonNegative long length) throws IllegalStateException, BufferUnderflowException {
         long start = bytes.readPosition();
         if (length <= 8) {
             if (length == 0)

--- a/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
@@ -18,6 +18,7 @@
 package net.openhft.chronicle.bytes.algo;
 
 import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.core.annotation.NonNegative;
 
 import java.nio.BufferUnderflowException;
 
@@ -46,17 +47,17 @@ public class XxHash implements BytesStoreHash<BytesStore> {
         return hash;
     }
 
-    long fetch64(BytesStore bytes, long off) throws IllegalStateException, BufferUnderflowException {
+    long fetch64(BytesStore bytes, @NonNegative long off) throws IllegalStateException, BufferUnderflowException {
         return bytes.readLong(off);
     }
 
     // long because of unsigned nature of original algorithm
-    long fetch32(BytesStore bytes, long off) throws IllegalStateException, BufferUnderflowException {
+    long fetch32(BytesStore bytes, @NonNegative long off) throws IllegalStateException, BufferUnderflowException {
         return bytes.readUnsignedInt(off);
     }
 
     // int because of unsigned nature of original algorithm
-    long fetch8(BytesStore bytes, long off) throws IllegalStateException, BufferUnderflowException {
+    long fetch8(BytesStore bytes, @NonNegative long off) throws IllegalStateException, BufferUnderflowException {
         return bytes.readUnsignedByte(off);
     }
 
@@ -70,7 +71,7 @@ public class XxHash implements BytesStoreHash<BytesStore> {
     }
 
     @Override
-    public long applyAsLong(BytesStore bytes, long length) throws IllegalStateException, BufferUnderflowException {
+    public long applyAsLong(BytesStore bytes, @NonNegative long length) throws IllegalStateException, BufferUnderflowException {
         long hash;
         long remaining = length;
         long off = bytes.readPosition();

--- a/src/main/java/net/openhft/chronicle/bytes/internal/AbstractBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/AbstractBytesStore.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.bytes.internal;
 
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.algo.BytesStoreHash;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.AbstractReferenceCounted;
 
 import java.nio.BufferUnderflowException;
@@ -43,7 +44,7 @@ public abstract class AbstractBytesStore<B extends BytesStore<B, U>, U>
     }
 
     @Override
-    public int peekUnsignedByte(long offset)
+    public int peekUnsignedByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         return offset >= readLimit() ? -1 : readUnsignedByte(offset);
     }
@@ -60,7 +61,7 @@ public abstract class AbstractBytesStore<B extends BytesStore<B, U>, U>
     }
 
     @Override
-    public long readPosition() {
+    public @NonNegative long readPosition() {
         return 0L;
     }
 
@@ -75,7 +76,7 @@ public abstract class AbstractBytesStore<B extends BytesStore<B, U>, U>
     }
 
     @Override
-    public long start() {
+    public @NonNegative long start() {
         return 0L;
     }
 

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ByteStringReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ByteStringReader.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.bytes.internal;
 
 import net.openhft.chronicle.bytes.ByteStringParser;
+import net.openhft.chronicle.core.annotation.NonNegative;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -61,7 +62,7 @@ public class ByteStringReader extends Reader {
     }
 
     @Override
-    public int read(char[] cbuf, int off, int len)
+    public int read(char[] cbuf, @NonNegative int off, @NonNegative int len)
             throws IOException {
         try {
             return in.read(cbuf, off, len);

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ByteStringWriter.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ByteStringWriter.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.bytes.internal;
 
 import net.openhft.chronicle.bytes.ByteStringAppender;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -57,7 +58,7 @@ public class ByteStringWriter extends Writer {
     }
 
     @Override
-    public void write(@NotNull String str, int off, int len)
+    public void write(@NotNull String str, @NonNegative int off, @NonNegative int len)
             throws IOException {
         out.append(str, off, off + len);
     }
@@ -72,7 +73,7 @@ public class ByteStringWriter extends Writer {
 
     @NotNull
     @Override
-    public Writer append(@NotNull CharSequence csq, int start, int end) {
+    public Writer append(@NotNull CharSequence csq, @NonNegative int start, @NonNegative int end) {
         out.append(csq, start, end);
         return this;
     }
@@ -99,7 +100,7 @@ public class ByteStringWriter extends Writer {
     }
 
     @Override
-    public void write(char[] cbuf, int off, int len)
+    public void write(char[] cbuf, @NonNegative int off, @NonNegative int len)
             throws IOException {
         try {
             for (int i = 0; i < len; i++)

--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -351,7 +351,7 @@ enum BytesInternal {
     }
 
     public static void parseUtf8(
-            @NotNull StreamingDataInput bytes, Appendable appendable, boolean utf, int length)
+            @NotNull StreamingDataInput bytes, Appendable appendable, boolean utf, @NonNegative int length)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, IllegalStateException {
         throwExceptionIfReleased(bytes);
         // Because Bytes implements Appendable, we need to check if it might be closed
@@ -368,7 +368,7 @@ enum BytesInternal {
     }
 
     public static void parseUtf8(
-            @NotNull RandomDataInput input, long offset, Appendable appendable, boolean utf, int length)
+            @NotNull RandomDataInput input, long offset, Appendable appendable, boolean utf, @NonNegative int length)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, IllegalStateException {
 
         assert utf;
@@ -388,7 +388,7 @@ enum BytesInternal {
         parseUtf81(input, offset, appendable, length);
     }
 
-    public static boolean compareUtf8(@NotNull RandomDataInput input, long offset, @Nullable CharSequence other)
+    public static boolean compareUtf8(@NotNull RandomDataInput input, @NonNegative long offset, @Nullable CharSequence other)
             throws IORuntimeException, BufferUnderflowException, IllegalStateException {
         throwExceptionIfReleased(input);
         if (other != null)
@@ -421,7 +421,7 @@ enum BytesInternal {
     }
 
     private static boolean compareUtf8(
-            @NotNull RandomDataInput input, long offset, long utfLen, @NotNull CharSequence other)
+            @NotNull RandomDataInput input, @NonNegative long offset, @NonNegative long utfLen, @NotNull CharSequence other)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, IndexOutOfBoundsException, IllegalStateException {
         throwExceptionIfReleased(input);
         throwExceptionIfReleased(other);
@@ -442,7 +442,7 @@ enum BytesInternal {
     }
 
     private static boolean compareUtf82(
-            @NotNull RandomDataInput input, long offset, int charI, long utfLen, @NotNull CharSequence other)
+            @NotNull RandomDataInput input, @NonNegative long offset, int charI, @NonNegative long utfLen, @NotNull CharSequence other)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, IndexOutOfBoundsException, IllegalStateException {
         throwExceptionIfReleased(input);
         throwExceptionIfReleased(other);
@@ -508,7 +508,7 @@ enum BytesInternal {
         return offset == limit && charI == other.length();
     }
 
-    public static void parse8bit(long offset, @NotNull RandomDataInput bytesStore, Appendable appendable, int utflen)
+    public static void parse8bit(@NonNegative long offset, @NotNull RandomDataInput bytesStore, Appendable appendable, @NonNegative int utflen)
             throws BufferUnderflowException, IOException, IllegalStateException {
         throwExceptionIfReleased(bytesStore);
         throwExceptionIfReleased(appendable);
@@ -521,7 +521,7 @@ enum BytesInternal {
     }
 
     public static void parseUtf81(
-            @NotNull StreamingDataInput bytes, @NotNull Appendable appendable, boolean utf, int length)
+            @NotNull StreamingDataInput bytes, @NotNull Appendable appendable, boolean utf, @NonNegative int length)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, IllegalStateException {
         throwExceptionIfReleased(bytes);
         throwExceptionIfReleased(appendable);
@@ -575,7 +575,7 @@ enum BytesInternal {
         }
     }
 
-    public static void parse8bit1(@NotNull StreamingDataInput bytes, @NotNull StringBuilder sb, int utflen)
+    public static void parse8bit1(@NotNull StreamingDataInput bytes, @NotNull StringBuilder sb, @NonNegative int utflen)
             throws IllegalStateException {
         throwExceptionIfReleased(bytes);
         assert bytes.readRemaining() >= utflen;
@@ -597,7 +597,7 @@ enum BytesInternal {
         StringUtils.setLength(sb, utflen);
     }
 
-    public static void parse8bit1(@NotNull StreamingDataInput bytes, @NotNull Appendable appendable, int utflen)
+    public static void parse8bit1(@NotNull StreamingDataInput bytes, @NotNull Appendable appendable, @NonNegative int utflen)
             throws IllegalStateException, IOException {
         throwExceptionIfReleased(bytes);
         throwExceptionIfReleased(appendable);
@@ -608,7 +608,7 @@ enum BytesInternal {
         }
     }
 
-    public static void parse8bit1(long offset, @NotNull RandomDataInput bytes, @NotNull Appendable appendable, int utflen)
+    public static void parse8bit1(long offset, @NotNull RandomDataInput bytes, @NotNull Appendable appendable, @NonNegative int utflen)
             throws BufferUnderflowException, IllegalStateException, IOException {
         throwExceptionIfReleased(bytes);
         throwExceptionIfReleased(appendable);
@@ -620,7 +620,7 @@ enum BytesInternal {
         }
     }
 
-    public static void parseUtf8_SB1(@NotNull Bytes bytes, @NotNull StringBuilder sb, boolean utf, int utflen)
+    public static void parseUtf8_SB1(@NotNull Bytes bytes, @NotNull StringBuilder sb, boolean utf, @NonNegative int utflen)
             throws UTFDataFormatRuntimeException, BufferUnderflowException {
         throwExceptionIfReleased(bytes);
         try {
@@ -647,7 +647,7 @@ enum BytesInternal {
         }
     }
 
-    private static void parseUtf82Guarded(@NotNull Bytes bytes, @NotNull StringBuilder sb, boolean utf, int utflen, int count, long rp0) throws IOException {
+    private static void parseUtf82Guarded(@NotNull Bytes bytes, @NotNull StringBuilder sb, boolean utf, @NonNegative int utflen, int count, long rp0) throws IOException {
         try {
             parseUtf82(bytes, sb, utf, utflen, count);
         } catch (UTFDataFormatRuntimeException e) {
@@ -656,7 +656,7 @@ enum BytesInternal {
         }
     }
 
-    private static int calculateCount(@NotNull Bytes bytes, @NotNull StringBuilder sb, int utflen, long readPosition) {
+    private static int calculateCount(@NotNull Bytes bytes, @NotNull StringBuilder sb, @NonNegative int utflen, @NonNegative long readPosition) {
         int count = 0;
         if (Jvm.isJava9Plus()) {
             sb.setLength(utflen);
@@ -678,8 +678,8 @@ enum BytesInternal {
         return count;
     }
 
-    public static void parseUtf8_SB1(@NotNull NativeBytesStore bytes, long offset,
-                                     @NotNull StringBuilder sb, int utflen)
+    public static void parseUtf8_SB1(@NotNull NativeBytesStore bytes, @NonNegative long offset,
+                                     @NotNull StringBuilder sb, @NonNegative int utflen)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, IllegalStateException {
         throwExceptionIfReleased(bytes);
         requireNonNull(sb);
@@ -717,7 +717,7 @@ enum BytesInternal {
         }
     }
 
-    public static int parse8bit_SB1(long offset, @NotNull NativeBytesStore nbs, @NotNull StringBuilder sb, int length) {
+    public static int parse8bit_SB1(@NonNegative long offset, @NotNull NativeBytesStore nbs, @NotNull StringBuilder sb, @NonNegative int length) {
         throwExceptionIfReleased(nbs);
         requireNonNull(sb);
         long address = nbs.address + nbs.translate(offset);
@@ -753,7 +753,7 @@ enum BytesInternal {
         return count;
     }
 
-    static void parseUtf82(@NotNull StreamingDataInput bytes, @NotNull Appendable appendable, boolean utf, int length, int count)
+    static void parseUtf82(@NotNull StreamingDataInput bytes, @NotNull Appendable appendable, boolean utf, @NonNegative int length, @NonNegative int count)
             throws IOException, UTFDataFormatRuntimeException, IllegalStateException {
         throwExceptionIfReleased(bytes);
         throwExceptionIfReleased(appendable);
@@ -817,8 +817,8 @@ enum BytesInternal {
         }
     }
 
-    static void parseUtf82(@NotNull RandomDataInput input, long offset, long limit,
-                           @NotNull Appendable appendable, int utflen)
+    static void parseUtf82(@NotNull RandomDataInput input, @NonNegative long offset, @NonNegative long limit,
+                           @NotNull Appendable appendable, @NonNegative int utflen)
             throws IOException, UTFDataFormatRuntimeException, BufferUnderflowException, IllegalStateException {
         throwExceptionIfReleased(input);
         throwExceptionIfReleased(appendable);
@@ -916,7 +916,7 @@ enum BytesInternal {
     }
 
     public static long writeUtf8(@NotNull RandomDataOutput out,
-                                 long writeOffset,
+                                 @NonNegative long writeOffset,
                                  @Nullable CharSequence str)
             throws BufferOverflowException, IllegalStateException, ArithmeticException {
         throwExceptionIfReleased(out);
@@ -983,7 +983,7 @@ enum BytesInternal {
     }
 
     @NotNull
-    public static Bytes asBytes(@NotNull RandomDataOutput bytes, long position, long limit)
+    public static Bytes asBytes(@NotNull RandomDataOutput bytes, @NonNegative long position, @NonNegative long limit)
             throws IllegalStateException, BufferOverflowException, BufferUnderflowException {
         throwExceptionIfReleased(bytes);
         Bytes sbytes = bytes.bytesForWrite();
@@ -994,7 +994,7 @@ enum BytesInternal {
     }
 
     public static void appendUtf8(@NotNull StreamingDataOutput bytes,
-                                  @NotNull CharSequence str, int offset, int length)
+                                  @NotNull CharSequence str, @NonNegative int offset, @NonNegative int length)
             throws IndexOutOfBoundsException {
         throwExceptionIfReleased(bytes);
         throwExceptionIfReleased(str);
@@ -1013,7 +1013,7 @@ enum BytesInternal {
     }
 
     private static void appendUtf82(@NotNull StreamingDataOutput bytes,
-                                    @NotNull CharSequence str, int offset, int length, int i)
+                                    @NotNull CharSequence str, @NonNegative int offset, @NonNegative int length, @NonNegative int i)
             throws IndexOutOfBoundsException, BufferOverflowException, IllegalStateException {
         throwExceptionIfReleased(bytes);
         throwExceptionIfReleased(str);
@@ -1023,8 +1023,8 @@ enum BytesInternal {
         }
     }
 
-    public static long appendUtf8(@NotNull RandomDataOutput out, long outOffset,
-                                  @NotNull CharSequence str, int strOffset, int length)
+    public static long appendUtf8(@NotNull RandomDataOutput out, @NonNegative long outOffset,
+                                  @NotNull CharSequence str, @NonNegative int strOffset, @NonNegative int length)
             throws IndexOutOfBoundsException, BufferOverflowException, IllegalStateException {
         throwExceptionIfReleased(out);
         throwExceptionIfReleased(str);
@@ -1038,8 +1038,8 @@ enum BytesInternal {
         return appendUtf82(out, outOffset, str, strOffset, length, i);
     }
 
-    private static long appendUtf82(@NotNull RandomDataOutput out, long outOffset,
-                                    @NotNull CharSequence str, int strOffset, int length, int i)
+    private static long appendUtf82(@NotNull RandomDataOutput out, @NonNegative long outOffset,
+                                    @NotNull CharSequence str, @NonNegative int strOffset, @NonNegative int length, @NonNegative int i)
             throws IndexOutOfBoundsException, BufferOverflowException, IllegalStateException {
         throwExceptionIfReleased(out);
         throwExceptionIfReleased(str);
@@ -1050,7 +1050,7 @@ enum BytesInternal {
         return outOffset;
     }
 
-    public static void append8bit(long offsetInRDO, RandomDataOutput bytes, @NotNull CharSequence str, int offset, int length)
+    public static void append8bit(@NonNegative long offsetInRDO, RandomDataOutput bytes, @NotNull CharSequence str, @NonNegative int offset, @NonNegative int length)
             throws IllegalArgumentException, BufferOverflowException, BufferUnderflowException,
             IndexOutOfBoundsException, IllegalStateException, ArithmeticException {
         throwExceptionIfReleased(bytes);
@@ -1095,7 +1095,7 @@ enum BytesInternal {
         }
     }
 
-    public static long appendUtf8Char(@NotNull RandomDataOutput out, long offset, int c)
+    public static long appendUtf8Char(@NotNull RandomDataOutput out, @NonNegative long offset, int c)
             throws BufferOverflowException, IllegalStateException {
         if (c <= 0x007F) {
             out.writeByte(offset++, (byte) c);
@@ -1141,7 +1141,7 @@ enum BytesInternal {
         writeStopBit0(out, n);
     }
 
-    public static long writeStopBit(@NotNull final long addr, final long n)
+    public static long writeStopBit(final long addr, final long n)
             throws BufferOverflowException, IllegalStateException {
         if ((n & ~0x7F) == 0) {
             UnsafeMemory.INSTANCE.writeByte(addr, (byte) n);
@@ -1172,7 +1172,7 @@ enum BytesInternal {
         writeStopBit0(out, n);
     }
 
-    public static long writeStopBit(@NotNull RandomDataOutput out, long offset, long n)
+    public static long writeStopBit(@NotNull RandomDataOutput out, @NonNegative long offset, long n)
             throws BufferOverflowException, IllegalStateException {
         if ((n & ~0x7F) == 0) {
             out.writeByte(offset++, (byte) n);
@@ -1258,7 +1258,7 @@ enum BytesInternal {
         return addr + i;
     }
 
-    static long writeStopBit0(@NotNull RandomDataOutput out, long offset, long n)
+    static long writeStopBit0(@NotNull RandomDataOutput out, @NonNegative long offset, long n)
             throws BufferOverflowException, IllegalStateException {
         boolean neg = false;
         if (n < 0) {
@@ -1293,7 +1293,7 @@ enum BytesInternal {
         return len + 1;
     }
 
-    public static String toDebugString(@NotNull RandomDataInput bytes, long maxLength)
+    public static String toDebugString(@NotNull RandomDataInput bytes, @NonNegative long maxLength)
             throws IllegalStateException, ArithmeticException {
         if (bytes.refCount() < 1) {
             // Make sure not to access a released resource
@@ -1325,10 +1325,10 @@ enum BytesInternal {
     }
 
     private static void appendContent(@NotNull final RandomDataInput bytes,
-                                      final long maxLength,
+                                      @NonNegative final long maxLength,
                                       @NotNull final StringBuilder sb,
-                                      final long readPosition,
-                                      final long readLimit) {
+                                      @NonNegative final long readPosition,
+                                      @NonNegative final long readLimit) {
         try {
             final long start = Math.max(bytes.start(), readPosition - 64);
             long end = Math.min(readLimit + 64, start + maxLength);
@@ -1351,7 +1351,7 @@ enum BytesInternal {
     }
 
     @NotNull
-    public static Object asSize(long size) {
+    public static Object asSize(@NonNegative long size) {
         return size == Bytes.MAX_CAPACITY ? "8EiB" : size;
     }
 
@@ -1408,10 +1408,10 @@ enum BytesInternal {
 
     private static void toString(@NotNull RandomDataInput bytes,
                                  @NotNull Appendable sb,
-                                 long start,
-                                 long readPosition,
-                                 long writePosition,
-                                 long end)
+                                 @NonNegative long start,
+                                 @NonNegative long readPosition,
+                                 @NonNegative long writePosition,
+                                 @NonNegative long end)
             throws IllegalStateException {
         throwExceptionIfReleased(bytes);
         throwExceptionIfReleased(sb);
@@ -1441,7 +1441,7 @@ enum BytesInternal {
         }
     }
 
-    private static void toString(@NotNull RandomDataInput bytes, @NotNull Appendable sb, long start, long last)
+    private static void toString(@NotNull RandomDataInput bytes, @NotNull Appendable sb, @NonNegative long start, @NonNegative long last)
             throws IOException, BufferUnderflowException, IllegalStateException {
         throwExceptionIfReleased(bytes);
         throwExceptionIfReleased(sb);
@@ -1642,7 +1642,7 @@ enum BytesInternal {
      * The length of the number must be fixed otherwise short numbers will not overwrite longer
      * numbers
      */
-    public static void append(@NotNull RandomDataOutput out, long offset, long num, int digits)
+    public static void append(@NotNull RandomDataOutput out, @NonNegative long offset, long num, int digits)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         boolean negative = num < 0;
         num = Math.abs(num);
@@ -1668,7 +1668,7 @@ enum BytesInternal {
      *
      * @param width Maximum width. I will be padded with zeros to the left if necessary
      */
-    public static void appendDecimal(@NotNull RandomDataOutput out, long num, long offset, int decimalPlaces, int width)
+    public static void appendDecimal(@NotNull RandomDataOutput out, long num, @NonNegative long offset, int decimalPlaces, int width)
             throws IORuntimeException, IllegalArgumentException, BufferOverflowException, ArithmeticException, IllegalStateException {
         if (decimalPlaces == 0) {
             append(out, offset, num, width);
@@ -2010,7 +2010,7 @@ enum BytesInternal {
     }
 
     @Nullable
-    public static String readUtf8(@NotNull RandomDataInput in, long offset, int maxUtf8Len)
+    public static String readUtf8(@NotNull RandomDataInput in, @NonNegative long offset, @NonNegative int maxUtf8Len)
             throws BufferUnderflowException, IllegalArgumentException,
             IllegalStateException, IORuntimeException {
         throwExceptionIfReleased(in);
@@ -2188,11 +2188,11 @@ enum BytesInternal {
         }
     }
 
-    private static UTFDataFormatException newUTFDataFormatException(final long offset, final String suffix) {
+    private static UTFDataFormatException newUTFDataFormatException(@NonNegative final long offset, final String suffix) {
         return new UTFDataFormatException(MALFORMED_INPUT_AROUND_BYTE + offset + " " + suffix);
     }
 
-    private static UTFDataFormatRuntimeException newUTFDataFormatRuntimeException(final long offset, final String suffix) {
+    private static UTFDataFormatRuntimeException newUTFDataFormatRuntimeException(@NonNegative final long offset, final String suffix) {
         return new UTFDataFormatRuntimeException(MALFORMED_INPUT_AROUND_BYTE + offset + " " + suffix);
     }
 
@@ -2756,7 +2756,7 @@ enum BytesInternal {
         return false;
     }
 
-    public static float addAndGetFloat(@NotNull RandomDataInput in, long offset, float adding)
+    public static float addAndGetFloat(@NotNull RandomDataInput in, @NonNegative long offset, float adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             for (; ; ) {
@@ -2771,7 +2771,7 @@ enum BytesInternal {
         }
     }
 
-    public static double addAndGetDouble(@NotNull RandomDataInput in, long offset, double adding)
+    public static double addAndGetDouble(@NotNull RandomDataInput in, @NonNegative long offset, double adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             for (; ; ) {
@@ -2786,7 +2786,7 @@ enum BytesInternal {
         }
     }
 
-    public static int addAndGetInt(@NotNull RandomDataInput in, long offset, int adding)
+    public static int addAndGetInt(@NotNull RandomDataInput in, @NonNegative long offset, int adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             for (; ; ) {
@@ -2800,7 +2800,7 @@ enum BytesInternal {
         }
     }
 
-    public static long addAndGetLong(@NotNull RandomDataInput in, long offset, long adding)
+    public static long addAndGetLong(@NotNull RandomDataInput in, @NonNegative long offset, long adding)
             throws BufferUnderflowException, IllegalStateException {
         try {
             for (; ; ) {
@@ -2820,7 +2820,7 @@ enum BytesInternal {
      * @param bytes the buffer you wish to toString()
      * @return hex representation of the buffer, from example [0D ,OA, FF]
      */
-    public static String toHexString(@NotNull final Bytes bytes, long offset, long len)
+    public static String toHexString(@NotNull final Bytes bytes, @NonNegative long offset, @NonNegative long len)
             throws BufferUnderflowException, IllegalStateException {
         throwExceptionIfReleased(bytes);
         if (len == 0)
@@ -2919,7 +2919,7 @@ enum BytesInternal {
         b.rawWriteByte((byte) (millis % 10 + '0'));
     }
 
-    public static boolean equalBytesAny(@NotNull BytesStore b1, @NotNull BytesStore b2, long readRemaining)
+    public static boolean equalBytesAny(@NotNull BytesStore b1, @NotNull BytesStore b2, @NonNegative long readRemaining)
             throws BufferUnderflowException, IllegalStateException {
 
         if (b1.readRemaining() < readRemaining)
@@ -3074,7 +3074,7 @@ enum BytesInternal {
     }
 
     @NotNull
-    public static BytesStore subBytes(RandomDataInput from, long start, long length)
+    public static BytesStore subBytes(RandomDataInput from, @NonNegative long start, @NonNegative long length)
             throws BufferUnderflowException, IllegalStateException {
         try {
             @NotNull BytesStore ret;
@@ -3202,7 +3202,7 @@ enum BytesInternal {
         return BytesInternal.SI.intern(sb);
     }
 
-    public static void copy8bit(BytesStore bs, long addressForWrite, long length) {
+    public static void copy8bit(BytesStore bs, long addressForWrite, @NonNegative long length) {
         throwExceptionIfReleased(bs);
         int length0 = Math.toIntExact(length);
         int i = 0;
@@ -3215,7 +3215,6 @@ enum BytesInternal {
     static class DateCache {
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
         private long lastDay = Long.MIN_VALUE;
-        @Nullable
         private byte[] lastDateStr = null;
 
         DateCache() {

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -102,10 +102,10 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public @NotNull ChunkedMappedBytes write(final long writeOffset,
+    public @NotNull ChunkedMappedBytes write(@NonNegative final long writeOffset,
                                              @NotNull final RandomDataInput bytes,
-                                             long readOffset,
-                                             final long length)
+                                             @NonNegative long readOffset,
+                                             @NonNegative final long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         requireNonNegative(writeOffset);
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
@@ -144,14 +144,14 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         return this;
     }
 
-    private long copySize(final long writePosition) {
+    private long copySize(@NonNegative final long writePosition) {
         long size = mappedFile.chunkSize();
         return size - writePosition % size;
     }
 
     @NotNull
     @Override
-    public Bytes<Void> readPositionRemaining(final long position, final long remaining)
+    public Bytes<Void> readPositionRemaining(@NonNegative final long position, @NonNegative final long remaining)
             throws BufferUnderflowException, IllegalStateException {
 
         final long limit = position + remaining;
@@ -174,7 +174,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
     @NotNull
     @Override
-    public Bytes<Void> readPosition(final long position)
+    public Bytes<Void> readPosition(@NonNegative final long position)
             throws BufferUnderflowException, IllegalStateException {
 
         if (bytesStore.inside(position)) {
@@ -197,7 +197,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
      * If manipulating offsets which may reside in the overlap region, always use the 2-argument version below
      */
     @Override
-    public long addressForRead(final long offset)
+    public long addressForRead(@NonNegative final long offset)
             throws BufferUnderflowException, IllegalStateException {
         requireNonNegative(offset);
 
@@ -219,7 +219,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
      * overlap region
      */
     @Override
-    public long addressForRead(final long offset, final int buffer)
+    public long addressForRead(@NonNegative final long offset, @NonNegative final int buffer)
             throws UnsupportedOperationException, BufferUnderflowException, IllegalStateException {
 
         BytesStore bytesStore = this.bytesStore;
@@ -229,7 +229,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public long addressForWrite(final long offset)
+    public long addressForWrite(@NonNegative final long offset)
             throws UnsupportedOperationException, BufferOverflowException, IllegalStateException {
         requireNonNegative(offset);
 
@@ -240,7 +240,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    protected void readCheckOffset(final long offset,
+    protected void readCheckOffset(@NonNegative final long offset,
                                    final long adding,
                                    final boolean given)
             throws BufferUnderflowException, IllegalStateException {
@@ -254,7 +254,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    protected void writeCheckOffset(final long offset, final long adding)
+    protected void writeCheckOffset(final @NonNegative long offset, final @NonNegative long adding)
             throws BufferOverflowException, IllegalStateException {
 
         throwExceptionIfClosed();
@@ -275,7 +275,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public void ensureCapacity(final long desiredCapacity)
+    public void ensureCapacity(@NonNegative final long desiredCapacity)
             throws IllegalArgumentException, IllegalStateException {
         throwExceptionIfClosed();
 
@@ -318,7 +318,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
     // DON'T call this directly.
     // TODO Check whether we need synchronized; original comment; require protection from concurrent mutation to bytesStore field
-    private synchronized @NotNull MappedBytesStore acquireNextByteStore0(final long offset, final boolean set)
+    private synchronized @NotNull MappedBytesStore acquireNextByteStore0(@NonNegative final long offset, final boolean set)
             throws IllegalStateException {
         throwExceptionIfClosed();
 
@@ -407,8 +407,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     @NotNull
     @Override
     public Bytes<Void> write(@NotNull final BytesStore bytes,
-                             final long offset,
-                             final long length)
+                             @NonNegative final long offset,
+                             @NonNegative final long length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         requireNonNull(bytes);
         requireNonNegative(offset);
@@ -436,7 +436,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         return this;
     }
 
-    void rawCopy(final long length, final long fromAddress)
+    void rawCopy(@NonNegative final long length, final long fromAddress)
             throws BufferOverflowException, IllegalStateException {
         this.throwExceptionIfReleased();
         OS.memory().copyMemory(fromAddress, addressForWritePosition(), length);
@@ -445,7 +445,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
     @Override
     @NotNull
-    public Bytes<Void> writeOrderedInt(long offset, int i)
+    public Bytes<Void> writeOrderedInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfClosed();
 
@@ -459,7 +459,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public byte readVolatileByte(long offset)
+    public byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         throwExceptionIfClosed();
 
@@ -471,7 +471,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public short readVolatileShort(long offset)
+    public short readVolatileShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         throwExceptionIfClosed();
 
@@ -483,7 +483,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public int readVolatileInt(long offset)
+    public int readVolatileInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         throwExceptionIfClosed();
 
@@ -495,7 +495,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public long readVolatileLong(long offset)
+    public long readVolatileLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         throwExceptionIfClosed();
 
@@ -523,7 +523,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public int peekUnsignedByte(final long offset)
+    public int peekUnsignedByte(@NonNegative final long offset)
             throws BufferUnderflowException, IllegalStateException {
         throwExceptionIfClosed();
 
@@ -552,7 +552,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
     @NotNull
     @Override
-    public Bytes<Void> appendUtf8(char[] chars, int offset, int length)
+    public Bytes<Void> appendUtf8(char[] chars, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         requireNonNull(chars);
         throwExceptionIfClosed();
@@ -586,7 +586,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
     // used by the Pretoucher, don't change this without considering the impact.
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value)
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfClosed();
 

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.*;
 import net.openhft.chronicle.core.CleaningRandomAccessFile;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.ReferenceOwner;
 import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
@@ -63,9 +64,9 @@ public class ChunkedMappedFile extends MappedFile {
 
     public ChunkedMappedFile(@NotNull final File file,
                              @NotNull final RandomAccessFile raf,
-                             final long chunkSize,
+                             @NonNegative final long chunkSize,
                              final long overlapSize,
-                             final long capacity,
+                             @NonNegative final long capacity,
                              final boolean readOnly)
             throws IORuntimeException {
         super(file, readOnly);
@@ -109,7 +110,7 @@ public class ChunkedMappedFile extends MappedFile {
     private static void warmupChunks(List<IOException> errorsDuringWarmup,
                                      File file,
                                      long mapAlignment,
-                                     int chunks) {
+                                     @NonNegative int chunks) {
         try {
             try (@NotNull RandomAccessFile raf = new CleaningRandomAccessFile(file, "rw")) {
                 try (final ChunkedMappedFile mappedFile = new ChunkedMappedFile(file, raf, mapAlignment, 0, mapAlignment * chunks, false)) {
@@ -123,7 +124,7 @@ public class ChunkedMappedFile extends MappedFile {
     }
 
     private static void warmup0(final long mapAlignment,
-                                final int chunks,
+                                @NonNegative final int chunks,
                                 @NotNull final ChunkedMappedFile mappedFile) {
         try {
             ReferenceOwner warmup = ReferenceOwner.temporary("warmup");
@@ -142,7 +143,7 @@ public class ChunkedMappedFile extends MappedFile {
     @NotNull
     public MappedBytesStore acquireByteStore(
             ReferenceOwner owner,
-            final long position,
+            @NonNegative final long position,
             BytesStore oldByteStore,
             @NotNull final MappedBytesStoreFactory mappedBytesStoreFactory)
             throws IOException,
@@ -215,7 +216,7 @@ public class ChunkedMappedFile extends MappedFile {
         }
     }
 
-    private void resizeRafIfTooSmall(final int chunk)
+    private void resizeRafIfTooSmall(@NonNegative final int chunk)
             throws IOException {
         Jvm.safepoint();
 
@@ -380,14 +381,14 @@ public class ChunkedMappedFile extends MappedFile {
     /**
      * Calls lock on the underlying file channel
      */
-    public FileLock lock(long position, long size, boolean shared) throws IOException {
+    public FileLock lock(long position, @NonNegative long size, boolean shared) throws IOException {
         return fileChannel.lock(position, size, shared);
     }
 
     /**
      * Calls tryLock on the underlying file channel
      */
-    public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+    public FileLock tryLock(@NonNegative long position, @NonNegative long size, boolean shared) throws IOException {
         return fileChannel.tryLock(position, size, shared);
     }
 

--- a/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.*;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Memory;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.ReferenceOwner;
@@ -85,9 +86,9 @@ public abstract class CommonMappedBytes extends MappedBytes {
     }
 
     @Override
-    public @NotNull CommonMappedBytes write(@NotNull final byte[] byteArray,
-                                            final int offset,
-                                            final int length)
+    public @NotNull CommonMappedBytes write(final byte[] byteArray,
+                                            @NonNegative final int offset,
+                                            @NonNegative final int length)
             throws IllegalStateException, BufferOverflowException {
         requireNonNull(byteArray);
         requireNonNegative(offset);
@@ -115,7 +116,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
 
 
     @NotNull
-    public CommonMappedBytes write(final long offsetInRDO, @NotNull final RandomDataInput bytes)
+    public CommonMappedBytes write(@NonNegative final long offsetInRDO, @NotNull final RandomDataInput bytes)
             throws BufferOverflowException, IllegalStateException {
         requireNonNegative(offsetInRDO);
         requireNonNull(bytes);
@@ -141,7 +142,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
     }
 
     @Override
-    public long capacity() {
+    public @NonNegative long capacity() {
         return capacity;
     }
 
@@ -160,7 +161,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
     }
 
     @Override
-    public long realCapacity() {
+    public @NonNegative long realCapacity() {
 
         try {
             lastActualSize = mappedFile.actualSize();
@@ -192,13 +193,13 @@ public abstract class CommonMappedBytes extends MappedBytes {
     }
 
     @Override
-    public long start() {
+    public @NonNegative long start() {
         return 0L;
     }
 
     @NotNull
     @Override
-    public Bytes<Void> writePosition(final long position)
+    public Bytes<Void> writePosition(@NonNegative final long position)
             throws BufferOverflowException {
         //  throwExceptionIfClosed
         if (position > writeLimit)
@@ -234,8 +235,8 @@ public abstract class CommonMappedBytes extends MappedBytes {
     @Override
     @NotNull
     public Bytes<Void> write(@NotNull final RandomDataInput bytes,
-                             final long offset,
-                             final long length)
+                             @NonNegative final long offset,
+                             @NonNegative final long length)
             throws BufferUnderflowException, BufferOverflowException, IllegalStateException {
         requireNonNull(bytes);
         requireNonNegative(offset);
@@ -253,7 +254,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
 
     @NotNull
     @Override
-    public Bytes<Void> append8bit(@NotNull CharSequence text, int start, int end)
+    public Bytes<Void> append8bit(@NotNull CharSequence text, @NonNegative int start, @NonNegative int end)
             throws IllegalArgumentException, BufferOverflowException, BufferUnderflowException,
             IndexOutOfBoundsException, IllegalStateException {
         requireNonNull(text);
@@ -270,7 +271,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
 
     @Override
     @NotNull
-    public CommonMappedBytes write8bit(@NotNull CharSequence text, int start, int length)
+    public CommonMappedBytes write8bit(@NotNull CharSequence text, @NonNegative int start, @NonNegative int length)
             throws IllegalStateException, BufferUnderflowException, BufferOverflowException, ArithmeticException, IndexOutOfBoundsException {
         requireNonNull(text);
         throwExceptionIfClosed();
@@ -290,7 +291,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
     }
 
     @NotNull
-    private CommonMappedBytes append8bit0(@NotNull String s, int start, int length)
+    private CommonMappedBytes append8bit0(@NotNull String s, @NonNegative int start, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException {
 
         requireNonNull(s);
@@ -335,7 +336,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
 
     @NotNull
     @Override
-    public Bytes<Void> appendUtf8(@NotNull CharSequence cs, int start, int length)
+    public Bytes<Void> appendUtf8(@NotNull CharSequence cs, @NonNegative int start, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException, BufferUnderflowException, IndexOutOfBoundsException {
         requireNonNull(cs);
         throwExceptionIfClosed();

--- a/src/main/java/net/openhft/chronicle/bytes/internal/EmbeddedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/EmbeddedBytes.java
@@ -2,6 +2,7 @@ package net.openhft.chronicle.bytes.internal;
 
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.VanillaBytes;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 public class EmbeddedBytes<U> extends VanillaBytes<U> {
@@ -20,13 +21,13 @@ public class EmbeddedBytes<U> extends VanillaBytes<U> {
     }
 
     @Override
-    protected void uncheckedWritePosition(long writePosition) {
+    protected void uncheckedWritePosition(@NonNegative long writePosition) {
         super.uncheckedWritePosition(writePosition);
         bytesStore.writeUnsignedByte(bytesStore.start() - 1, (int) writePosition);
     }
 
     @Override
-    public long writePosition() {
+    public @NonNegative long writePosition() {
         return bytesStore.readUnsignedByte(bytesStore.start() - 1);
     }
 }

--- a/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
@@ -60,7 +60,7 @@ public class HeapBytesStore<U>
         this.capacity = byteBuffer.capacity();
     }
 
-    private HeapBytesStore(@NotNull byte @NotNull [] byteArray) {
+    private HeapBytesStore(byte[] byteArray) {
         super(false);
         //noinspection unchecked
         this.underlyingObject = (U) byteArray;
@@ -102,7 +102,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public void move(long from, long to, long length)
+    public void move(@NonNegative long from, @NonNegative long to, @NonNegative long length)
             throws BufferUnderflowException, ArithmeticException {
         if (from < 0 || to < 0) throw new BufferUnderflowException();
         throwExceptionIfReleased();
@@ -132,7 +132,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public long capacity() {
+    public @NonNegative long capacity() {
         return capacity;
     }
 
@@ -143,7 +143,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public boolean compareAndSwapInt(long offset, int expected, int value) {
+    public boolean compareAndSwapInt(@NonNegative long offset, int expected, int value) {
         try {
             return memory.compareAndSwapInt(realUnderlyingObject, dataOffset + offset, expected, value);
         } catch (NullPointerException ifReleased) {
@@ -153,7 +153,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public void testAndSetInt(long offset, int expected, int value)
+    public void testAndSetInt(@NonNegative long offset, int expected, int value)
             throws IllegalStateException {
         try {
             memory.testAndSetInt(realUnderlyingObject, dataOffset + offset, expected, value);
@@ -164,7 +164,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value) {
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value) {
         try {
             return memory.compareAndSwapLong(
                     realUnderlyingObject, dataOffset + offset, expected, value);
@@ -175,7 +175,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public byte readByte(long offset)
+    public byte readByte(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             return memory.readByte(realUnderlyingObject, dataOffset + offset);
@@ -186,7 +186,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public short readShort(long offset)
+    public short readShort(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             return memory.readShort(realUnderlyingObject, dataOffset + offset);
@@ -197,7 +197,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public int readInt(long offset)
+    public int readInt(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             return memory.readInt(realUnderlyingObject, dataOffset + offset);
@@ -208,7 +208,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public long readLong(long offset)
+    public long readLong(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             return memory.readLong(realUnderlyingObject, dataOffset + offset);
@@ -219,7 +219,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public float readFloat(long offset)
+    public float readFloat(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             return memory.readFloat(realUnderlyingObject, dataOffset + offset);
@@ -230,7 +230,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public double readDouble(long offset)
+    public double readDouble(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             return memory.readDouble(realUnderlyingObject, dataOffset + offset);
@@ -241,7 +241,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public byte readVolatileByte(long offset)
+    public byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             return memory.readVolatileByte(realUnderlyingObject, dataOffset + offset);
@@ -252,7 +252,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public short readVolatileShort(long offset)
+    public short readVolatileShort(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             return memory.readVolatileShort(realUnderlyingObject, dataOffset + offset);
@@ -263,7 +263,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public int readVolatileInt(long offset)
+    public int readVolatileInt(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             throwExceptionIfReleased();
@@ -275,7 +275,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public long readVolatileLong(long offset)
+    public long readVolatileLong(@NonNegative long offset)
             throws BufferUnderflowException {
         try {
             throwExceptionIfReleased();
@@ -287,7 +287,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public long write8bit(long position, @NotNull BytesStore bs) {
+    public long write8bit(@NonNegative long position, @NotNull BytesStore bs) {
         requireNonNull(bs);
         int length0 = Math.toIntExact(bs.readRemaining());
         position = BytesUtil.writeStopBit(this, position, length0);
@@ -300,7 +300,7 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public long write8bit(long position, @NotNull String s, int start, int length) {
+    public long write8bit(@NonNegative long position, @NotNull String s, @NonNegative int start, @NonNegative int length) {
         requireNonNegative(position);
         requireNonNull(s);
         requireNonNegative(start);
@@ -318,7 +318,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeByte(long offset, byte b)
+    public HeapBytesStore<U> writeByte(@NonNegative long offset, byte b)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -332,7 +332,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeShort(long offset, short i16)
+    public HeapBytesStore<U> writeShort(@NonNegative long offset, short i16)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -346,7 +346,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeInt(long offset, int i32)
+    public HeapBytesStore<U> writeInt(@NonNegative long offset, int i32)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -360,7 +360,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeOrderedInt(long offset, int i32)
+    public HeapBytesStore<U> writeOrderedInt(@NonNegative long offset, int i32)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -374,7 +374,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeLong(long offset, long i64)
+    public HeapBytesStore<U> writeLong(@NonNegative long offset, long i64)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -388,7 +388,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeOrderedLong(long offset, long i)
+    public HeapBytesStore<U> writeOrderedLong(@NonNegative long offset, long i)
             throws BufferOverflowException {
         try {
             throwExceptionIfReleased();
@@ -402,7 +402,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeFloat(long offset, float f)
+    public HeapBytesStore<U> writeFloat(@NonNegative long offset, float f)
             throws BufferOverflowException {
         try {
             memory.writeFloat(realUnderlyingObject, dataOffset + offset, f);
@@ -415,7 +415,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeDouble(long offset, double d)
+    public HeapBytesStore<U> writeDouble(@NonNegative long offset, double d)
             throws BufferOverflowException {
         try {
             memory.writeDouble(realUnderlyingObject, dataOffset + offset, d);
@@ -428,7 +428,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeVolatileByte(long offset, byte i8)
+    public HeapBytesStore<U> writeVolatileByte(@NonNegative long offset, byte i8)
             throws BufferOverflowException {
         try {
             memory.writeVolatileByte(realUnderlyingObject, dataOffset + offset, i8);
@@ -441,7 +441,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeVolatileShort(long offset, short i16)
+    public HeapBytesStore<U> writeVolatileShort(@NonNegative long offset, short i16)
             throws BufferOverflowException {
         try {
             memory.writeVolatileShort(realUnderlyingObject, dataOffset + offset, i16);
@@ -454,7 +454,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeVolatileInt(long offset, int i32)
+    public HeapBytesStore<U> writeVolatileInt(@NonNegative long offset, int i32)
             throws BufferOverflowException {
         try {
             memory.writeVolatileInt(realUnderlyingObject, dataOffset + offset, i32);
@@ -467,7 +467,7 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> writeVolatileLong(long offset, long i64)
+    public HeapBytesStore<U> writeVolatileLong(@NonNegative long offset, long i64)
             throws BufferOverflowException {
         try {
             memory.writeVolatileLong(realUnderlyingObject, dataOffset + offset, i64);
@@ -500,7 +500,7 @@ public class HeapBytesStore<U>
 
     @Override
     public void write(
-            long offsetInRDO, @NotNull ByteBuffer bytes, int offset, int length)
+            @NonNegative long offsetInRDO, @NotNull ByteBuffer bytes, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException {
         try {
             assert realUnderlyingObject == null || dataOffset >= (Jvm.is64bit() ? 12 : 8);
@@ -520,8 +520,8 @@ public class HeapBytesStore<U>
 
     @NotNull
     @Override
-    public HeapBytesStore<U> write(long writeOffset,
-                                   @NotNull RandomDataInput bytes, long readOffset, long length)
+    public HeapBytesStore<U> write(@NonNegative long writeOffset,
+                                   @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length)
             throws IllegalStateException, BufferUnderflowException, BufferOverflowException {
         requireNonNegative(writeOffset);
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
@@ -546,8 +546,8 @@ public class HeapBytesStore<U>
         return this;
     }
 
-    private void writeLongLength(long writeOffset,
-                                 @NotNull RandomDataInput bytes, long readOffset, long length)
+    private void writeLongLength(@NonNegative long writeOffset,
+                                 @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length)
             throws IllegalStateException, BufferUnderflowException, BufferOverflowException {
         requireNonNull(bytes);
         long i;
@@ -562,13 +562,13 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public long addressForRead(long offset)
+    public long addressForRead(@NonNegative long offset)
             throws UnsupportedOperationException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public long addressForWrite(long offset)
+    public long addressForWrite(@NonNegative long offset)
             throws UnsupportedOperationException {
         requireNonNegative(offset);
         throw new UnsupportedOperationException();
@@ -581,12 +581,12 @@ public class HeapBytesStore<U>
     }
 
     @Override
-    public void nativeRead(long position, long address, long size) {
+    public void nativeRead(@NonNegative long position, @NonNegative long address, @NonNegative long size) {
         throw new UnsupportedOperationException("todo");
     }
 
     @Override
-    public void nativeWrite(long address, long position, long size) {
+    public void nativeWrite(@NonNegative long address, @NonNegative long position, @NonNegative long size) {
         throw new UnsupportedOperationException("todo");
     }
 

--- a/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
@@ -91,12 +91,12 @@ public class NativeBytesStore<U>
     }
 
     public NativeBytesStore(
-            long address, long limit, @Nullable Runnable deallocator, boolean elastic) {
+            long address, @NonNegative long limit, @Nullable Runnable deallocator, boolean elastic) {
         this(address, limit, deallocator, elastic, false);
     }
 
     protected NativeBytesStore(
-            long address, long limit, @Nullable Runnable deallocator, boolean elastic, boolean monitored) {
+            long address, @NonNegative long limit, @Nullable Runnable deallocator, boolean elastic, boolean monitored) {
         super(monitored);
         setAddress(address);
         this.limit = limit;
@@ -131,13 +131,13 @@ public class NativeBytesStore<U>
      * @param capacity of the buffer.
      */
     @NotNull
-    public static NativeBytesStore<Void> nativeStore(long capacity)
+    public static NativeBytesStore<Void> nativeStore(@NonNegative long capacity)
             throws IllegalArgumentException {
         return of(capacity, true, true);
     }
 
     @NotNull
-    private static NativeBytesStore<Void> of(long capacity, boolean zeroOut, boolean elastic)
+    private static NativeBytesStore<Void> of(@NonNegative long capacity, boolean zeroOut, boolean elastic)
             throws IllegalArgumentException {
         if (capacity <= 0)
             return new NativeBytesStore<>(NoBytesStore.NO_PAGE, 0, null, elastic);
@@ -152,13 +152,13 @@ public class NativeBytesStore<U>
     }
 
     @NotNull
-    public static NativeBytesStore<Void> nativeStoreWithFixedCapacity(long capacity)
+    public static NativeBytesStore<Void> nativeStoreWithFixedCapacity(@NonNegative long capacity)
             throws IllegalArgumentException {
         return of(capacity, true, false);
     }
 
     @NotNull
-    public static NativeBytesStore<Void> lazyNativeBytesStoreWithFixedCapacity(long capacity)
+    public static NativeBytesStore<Void> lazyNativeBytesStoreWithFixedCapacity(@NonNegative long capacity)
             throws IllegalArgumentException {
         return of(capacity, false, false);
     }
@@ -169,7 +169,7 @@ public class NativeBytesStore<U>
     }
 
     @NotNull
-    public static NativeBytesStore<ByteBuffer> elasticByteBuffer(int size, long maxSize) {
+    public static NativeBytesStore<ByteBuffer> elasticByteBuffer(@NonNegative int size, @NonNegative long maxSize) {
         return new NativeBytesStore<>(ByteBuffer.allocateDirect(size), true, Math.toIntExact(maxSize));
     }
 
@@ -179,7 +179,7 @@ public class NativeBytesStore<U>
     }
 
     @NotNull
-    public static NativeBytesStore from(@NotNull byte[] bytes) {
+    public static NativeBytesStore from(byte[] bytes) {
         try {
             @NotNull NativeBytesStore nbs = nativeStoreWithFixedCapacity(bytes.length);
             Bytes<byte[]> bytes2 = Bytes.wrapForRead(bytes);
@@ -197,7 +197,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public boolean canReadDirect(long length) {
+    public boolean canReadDirect(@NonNegative long length) {
         return limit >= length;
     }
 
@@ -219,7 +219,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public void move(long from, long to, long length)
+    public void move(@NonNegative long from, @NonNegative long to, @NonNegative long length)
             throws BufferUnderflowException, IllegalStateException {
         if (from < 0 || to < 0) throw new BufferUnderflowException();
         long addr = this.address;
@@ -227,7 +227,7 @@ public class NativeBytesStore<U>
         memoryCopyMemory(addr + from, addr + to, length);
     }
 
-    private void memoryCopyMemory(long fromAddress, long toAddress, long length)
+    private void memoryCopyMemory(long fromAddress, long toAddress, @NonNegative long length)
             throws IllegalStateException {
         try {
             memory.copyMemory(fromAddress, toAddress, length);
@@ -280,12 +280,12 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public long realCapacity() {
+    public @NonNegative long realCapacity() {
         return limit;
     }
 
     @Override
-    public long capacity() {
+    public @NonNegative long capacity() {
         return maximumLimit;
     }
 
@@ -297,7 +297,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> zeroOut(long start, long end) {
+    public NativeBytesStore<U> zeroOut(@NonNegative long start, @NonNegative long end) {
         if (end <= start)
             return this;
         if (start < start())
@@ -327,100 +327,100 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public boolean compareAndSwapInt(long offset, int expected, int value)
+    public boolean compareAndSwapInt(@NonNegative long offset, int expected, int value)
             throws IllegalStateException {
         return memory.compareAndSwapInt(address + translate(offset), expected, value);
     }
 
     @Override
-    public void testAndSetInt(long offset, int expected, int value)
+    public void testAndSetInt(@NonNegative long offset, int expected, int value)
             throws IllegalStateException {
         memory.testAndSetInt(address + translate(offset), offset, expected, value);
     }
 
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value)
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws IllegalStateException {
         return memory.compareAndSwapLong(address + translate(offset), expected, value);
     }
 
     @Override
-    public long addAndGetLong(long offset, long adding)
+    public long addAndGetLong(@NonNegative long offset, long adding)
             throws BufferUnderflowException {
         return memory.addLong(address + translate(offset), adding);
     }
 
     @Override
-    public int addAndGetInt(long offset, int adding)
+    public int addAndGetInt(@NonNegative long offset, int adding)
             throws BufferUnderflowException {
         return memory.addInt(address + translate(offset), adding);
     }
 
-    public long translate(long offset) {
+    public long translate(@NonNegative long offset) {
         return offset;
     }
 
     @Override
-    public byte readByte(long offset) {
+    public byte readByte(@NonNegative long offset) {
         return memory.readByte(address + translate(offset));
     }
 
     @Override
-    public int readUnsignedByte(long offset)
+    public int readUnsignedByte(@NonNegative long offset)
             throws BufferUnderflowException {
         return readByte(offset) & 0xFF;
     }
 
     @Override
-    public short readShort(long offset) {
+    public short readShort(@NonNegative long offset) {
         return memory.readShort(address + translate(offset));
     }
 
     @Override
-    public int readInt(long offset) {
+    public int readInt(@NonNegative long offset) {
         return memory.readInt(address + translate(offset));
     }
 
     @Override
-    public long readLong(long offset) {
+    public long readLong(@NonNegative long offset) {
         long addr = this.address;
         assert addr != 0;
         return memory.readLong(addr + translate(offset));
     }
 
     @Override
-    public float readFloat(long offset) {
+    public float readFloat(@NonNegative long offset) {
         return memory.readFloat(address + translate(offset));
     }
 
     @Override
-    public double readDouble(long offset) {
+    public double readDouble(@NonNegative long offset) {
         return memory.readDouble(address + translate(offset));
     }
 
     @Override
-    public byte readVolatileByte(long offset) {
+    public byte readVolatileByte(@NonNegative long offset) {
         return memory.readVolatileByte(address + translate(offset));
     }
 
     @Override
-    public short readVolatileShort(long offset) {
+    public short readVolatileShort(@NonNegative long offset) {
         return memory.readVolatileShort(address + translate(offset));
     }
 
     @Override
-    public int readVolatileInt(long offset) {
+    public int readVolatileInt(@NonNegative long offset) {
         return memory.readVolatileInt(address + translate(offset));
     }
 
     @Override
-    public long readVolatileLong(long offset) {
+    public long readVolatileLong(@NonNegative long offset) {
         return memory.readVolatileLong(address + translate(offset));
     }
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeByte(long offset, byte i8)
+    public NativeBytesStore<U> writeByte(@NonNegative long offset, byte i8)
             throws IllegalStateException {
         memory.writeByte(address + translate(offset), i8);
         return this;
@@ -428,7 +428,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeShort(long offset, short i16)
+    public NativeBytesStore<U> writeShort(@NonNegative long offset, short i16)
             throws IllegalStateException {
         memory.writeShort(address + translate(offset), i16);
         return this;
@@ -436,7 +436,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeInt(long offset, int i32)
+    public NativeBytesStore<U> writeInt(@NonNegative long offset, int i32)
             throws IllegalStateException {
         try {
             memory.writeInt(address + translate(offset), i32);
@@ -449,7 +449,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeOrderedInt(long offset, int i)
+    public NativeBytesStore<U> writeOrderedInt(@NonNegative long offset, int i)
             throws IllegalStateException {
         memory.writeOrderedInt(address + translate(offset), i);
         return this;
@@ -457,7 +457,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeLong(long offset, long i64)
+    public NativeBytesStore<U> writeLong(@NonNegative long offset, long i64)
             throws IllegalStateException {
         memory.writeLong(address + translate(offset), i64);
         return this;
@@ -465,7 +465,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeOrderedLong(long offset, long i)
+    public NativeBytesStore<U> writeOrderedLong(@NonNegative long offset, long i)
             throws IllegalStateException {
         memory.writeOrderedLong(address + translate(offset), i);
         return this;
@@ -473,7 +473,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeFloat(long offset, float f)
+    public NativeBytesStore<U> writeFloat(@NonNegative long offset, float f)
             throws IllegalStateException {
         memory.writeFloat(address + translate(offset), f);
         return this;
@@ -481,7 +481,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeDouble(long offset, double d)
+    public NativeBytesStore<U> writeDouble(@NonNegative long offset, double d)
             throws IllegalStateException {
         memory.writeDouble(address + translate(offset), d);
         return this;
@@ -489,7 +489,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeVolatileByte(long offset, byte i8)
+    public NativeBytesStore<U> writeVolatileByte(@NonNegative long offset, byte i8)
             throws IllegalStateException {
         memory.writeVolatileByte(address + translate(offset), i8);
         return this;
@@ -497,7 +497,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeVolatileShort(long offset, short i16)
+    public NativeBytesStore<U> writeVolatileShort(@NonNegative long offset, short i16)
             throws IllegalStateException {
         memory.writeVolatileShort(address + translate(offset), i16);
         return this;
@@ -505,7 +505,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeVolatileInt(long offset, int i32)
+    public NativeBytesStore<U> writeVolatileInt(@NonNegative long offset, int i32)
             throws IllegalStateException {
         memory.writeVolatileInt(address + translate(offset), i32);
         return this;
@@ -513,7 +513,7 @@ public class NativeBytesStore<U>
 
     @NotNull
     @Override
-    public NativeBytesStore<U> writeVolatileLong(long offset, long i64)
+    public NativeBytesStore<U> writeVolatileLong(@NonNegative long offset, long i64)
             throws IllegalStateException {
         memory.writeVolatileLong(address + translate(offset), i64);
         return this;
@@ -535,7 +535,7 @@ public class NativeBytesStore<U>
 
     @Override
     public void write(
-            long offsetInRDO, @NotNull ByteBuffer bytes, int offset, int length)
+            @NonNegative long offsetInRDO, @NotNull ByteBuffer bytes, @NonNegative int offset, @NonNegative int length)
             throws IllegalStateException {
         if (bytes.isDirect()) {
             memoryCopyMemory(Jvm.address(bytes) + offset, address + translate(offsetInRDO), length);
@@ -548,7 +548,7 @@ public class NativeBytesStore<U>
     @NotNull
     @Override
     public NativeBytesStore<U> write(
-            long writeOffset, @NotNull RandomDataInput bytes, long readOffset, long length)
+            @NonNegative long writeOffset, @NotNull RandomDataInput bytes, @NonNegative long readOffset, @NonNegative long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         requireNonNegative(writeOffset);
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
@@ -563,7 +563,7 @@ public class NativeBytesStore<U>
         return this;
     }
 
-    public void write0(long offsetInRDO, @NotNull RandomDataInput bytes, long offset, long length)
+    public void write0(@NonNegative long offsetInRDO, @NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
             throws BufferUnderflowException, IllegalStateException {
         long i = 0;
         for (; i < length - 7; i += 8) {
@@ -575,7 +575,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public long addressForRead(long offset)
+    public long addressForRead(@NonNegative long offset)
             throws BufferUnderflowException {
         if (offset < start() || offset > realCapacity())
             throw new BufferUnderflowException();
@@ -583,7 +583,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public long addressForWrite(long offset)
+    public long addressForWrite(@NonNegative long offset)
             throws BufferOverflowException {
         if (offset < start() || offset > realCapacity())
             throw new BufferOverflowException();
@@ -623,20 +623,20 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public void nativeRead(long position, long address, long size)
+    public void nativeRead(@NonNegative long position, long address, @NonNegative long size)
             throws BufferUnderflowException, IllegalStateException {
         // TODO add bounds checking.
         memoryCopyMemory(addressForRead(position), address, size);
     }
 
     @Override
-    public void nativeWrite(long address, long position, long size)
+    public void nativeWrite(long address, @NonNegative long position, @NonNegative long size)
             throws BufferOverflowException, IllegalStateException {
         // TODO add bounds checking.
         memoryCopyMemory(address, addressForWrite(position), size);
     }
 
-    void write8bit(long position, char[] chars, int offset, int length)
+    void write8bit(@NonNegative long position, char[] chars, @NonNegative int offset, @NonNegative int length)
             throws IllegalStateException {
         long addr = address + translate(position);
         @Nullable Memory mem = this.memory;
@@ -645,7 +645,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public long write8bit(long position, @NotNull BytesStore bs) {
+    public long write8bit(@NonNegative long position, @NotNull BytesStore bs) {
         requireNonNegative(position);
         final long length = bs.readRemaining();
         long addressForWrite = addressForWrite(position);
@@ -665,7 +665,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public long write8bit(long position, @NotNull String s, int start, int length) {
+    public long write8bit(@NonNegative long position, @NotNull String s, @NonNegative int start, @NonNegative int length) {
         requireNonNegative(position);
         requireNonNull(s);
         requireNonNegative(start);
@@ -675,18 +675,18 @@ public class NativeBytesStore<U>
         return position + length;
     }
 
-    private void copy8bit(byte[] arr, long readPosition, long addressForWrite, long readRemaining) {
+    private void copy8bit(byte[] arr, @NonNegative long readPosition, long addressForWrite, @NonNegative long readRemaining) {
         requireNonNull(arr);
         int readOffset = Math.toIntExact(readPosition);
         int length = Math.toIntExact(readRemaining);
         MEMORY.copyMemory(arr, readOffset, addressForWrite, length);
     }
 
-    private void copy8bit(long addressForRead, long addressForWrite, long length) {
+    private void copy8bit(long addressForRead, long addressForWrite, @NonNegative long length) {
         OS.memory().copyMemory(addressForRead, addressForWrite, length);
     }
 
-    public void read8bit(long position, char[] chars, int length) {
+    public void read8bit(@NonNegative long position, char[] chars, @NonNegative int length) {
         long addr = address + translate(position);
         Memory mem = this.memory;
         for (int i = 0; i < length; i++)
@@ -694,7 +694,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public long readIncompleteLong(long offset) {
+    public long readIncompleteLong(@NonNegative long offset) {
         int remaining = (int) Math.min(8, readRemaining() - offset);
         long l = 0;
         for (int i = 0; i < remaining; i++) {
@@ -710,7 +710,7 @@ public class NativeBytesStore<U>
         this.address = address;
     }
 
-    public long appendUtf8(long pos, char[] chars, int offset, int length)
+    public long appendUtf8(@NonNegative long pos, char[] chars, @NonNegative int offset, @NonNegative int length)
             throws BufferOverflowException, IllegalStateException {
         requireNonNull(chars);
         if (pos + length > realCapacity())
@@ -746,7 +746,7 @@ public class NativeBytesStore<U>
         return appendUtf8a(pos, chars, offset, length, i);
     }
 
-    private long appendUtf8a(long pos, char[] chars, int offset, int length, int i)
+    private long appendUtf8a(@NonNegative long pos, char[] chars, @NonNegative int offset, @NonNegative int length, int i)
             throws IllegalStateException {
         for (; i < length; i++) {
             char c = chars[offset + i];
@@ -812,7 +812,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public int byteCheckSum(long position, long limit) {
+    public int byteCheckSum(@NonNegative long position, @NonNegative long limit) {
         @Nullable Memory mem = this.memory;
         assert mem != null;
         int b = 0;
@@ -840,7 +840,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public long read(long offsetInRDI, byte[] bytes, int offset, int length) {
+    public long read(@NonNegative long offsetInRDI, byte[] bytes, @NonNegative int offset, @NonNegative int length) {
         requireNonNull(bytes);
         int len = (int) Math.min(length, readLimit() - offsetInRDI);
 
@@ -849,7 +849,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public int peekUnsignedByte(long offset) {
+    public int peekUnsignedByte(@NonNegative long offset) {
         final long addr = this.address;
         @Nullable final Memory mem = this.memory;
         final long translate = translate(offset);
@@ -860,7 +860,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public int fastHash(long offset, int length)
+    public int fastHash(@NonNegative long offset, @NonNegative int length)
             throws BufferUnderflowException, IllegalStateException {
         long ret;
         switch (length) {
@@ -891,7 +891,7 @@ public class NativeBytesStore<U>
     }
 
     @Override
-    public boolean isEqual(long start, long length, String s) {
+    public boolean isEqual(@NonNegative long start, @NonNegative long length, String s) {
         if (s == null || s.length() != length)
             return false;
         return MEMORY.isEqual(addressForRead(start), s, (int) length);
@@ -916,7 +916,7 @@ public class NativeBytesStore<U>
         private final long size;
         private volatile long address;
 
-        Deallocator(long address, long size) {
+        Deallocator(long address, @NonNegative long size) {
             assert address != 0;
             this.address = address;
             this.size = size;

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedBytes.java
@@ -105,10 +105,10 @@ public class SingleMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    public @NotNull SingleMappedBytes write(final long writeOffset,
+    public @NotNull SingleMappedBytes write(@NonNegative final long writeOffset,
                                             @NotNull final RandomDataInput bytes,
-                                            long readOffset,
-                                            final long length)
+                                            @NonNegative long readOffset,
+                                            @NonNegative final long length)
             throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
         requireNonNegative(writeOffset);
         ReferenceCountedUtil.throwExceptionIfReleased(bytes);
@@ -142,14 +142,14 @@ public class SingleMappedBytes extends CommonMappedBytes {
         return this;
     }
 
-    private long copySize(final long writePosition) {
+    private long copySize(@NonNegative final long writePosition) {
         long size = mappedFile.chunkSize();
         return size - writePosition % size;
     }
 
     @NotNull
     @Override
-    public Bytes<Void> readPositionRemaining(final long position, final long remaining)
+    public Bytes<Void> readPositionRemaining(@NonNegative final long position, @NonNegative final long remaining)
             throws BufferUnderflowException, IllegalStateException {
         //  throwExceptionIfClosed
 
@@ -181,7 +181,7 @@ public class SingleMappedBytes extends CommonMappedBytes {
     }
 
     @NotNull
-    private BufferOverflowException newBufferOverflowException(final long offset) {
+    private BufferOverflowException newBufferOverflowException(@NonNegative final long offset) {
         BufferOverflowException exception = new BufferOverflowException();
         exception.initCause(new IllegalArgumentException("Offset out of bound " + offset));
         return exception;
@@ -219,7 +219,7 @@ public class SingleMappedBytes extends CommonMappedBytes {
 
     // used by the Pretoucher, don't change this without considering the impact.
     @Override
-    public boolean compareAndSwapLong(long offset, long expected, long value)
+    public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfClosed();
 

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.bytes.internal;
 import net.openhft.chronicle.bytes.*;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.ReferenceOwner;
 import org.jetbrains.annotations.NotNull;
@@ -53,7 +54,7 @@ public class SingleMappedFile extends MappedFile {
 
     public SingleMappedFile(@NotNull final File file,
                             @NotNull final RandomAccessFile raf,
-                            final long capacity,
+                            @NonNegative final long capacity,
                             final boolean readOnly)
             throws IORuntimeException {
         super(file, readOnly);
@@ -95,7 +96,7 @@ public class SingleMappedFile extends MappedFile {
     @NotNull
     public MappedBytesStore acquireByteStore(
             ReferenceOwner owner,
-            final long position,
+            @NonNegative final long position,
             BytesStore oldByteStore,
             @NotNull final MappedBytesStoreFactory mappedBytesStoreFactory)
             throws IllegalArgumentException {
@@ -106,7 +107,7 @@ public class SingleMappedFile extends MappedFile {
         return store;
     }
 
-    private void resizeRafIfTooSmall(final long minSize)
+    private void resizeRafIfTooSmall(@NonNegative final long minSize)
             throws IOException {
         Jvm.safepoint();
 
@@ -258,14 +259,14 @@ public class SingleMappedFile extends MappedFile {
     /**
      * Calls lock on the underlying file channel
      */
-    public FileLock lock(long position, long size, boolean shared) throws IOException {
+    public FileLock lock(@NonNegative long position, @NonNegative long size, boolean shared) throws IOException {
         return fileChannel.lock(position, size, shared);
     }
 
     /**
      * Calls tryLock on the underlying file channel
      */
-    public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+    public FileLock tryLock(@NonNegative long position, @NonNegative long size, boolean shared) throws IOException {
         return fileChannel.tryLock(position, size, shared);
     }
 

--- a/src/main/java/net/openhft/chronicle/bytes/internal/UncheckedRandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/UncheckedRandomDataInput.java
@@ -1,5 +1,7 @@
 package net.openhft.chronicle.bytes.internal;
 
+import net.openhft.chronicle.core.annotation.NonNegative;
+
 import java.nio.BufferUnderflowException;
 
 public interface UncheckedRandomDataInput {
@@ -15,7 +17,7 @@ public interface UncheckedRandomDataInput {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    byte readByte(long offset);
+    byte readByte(@NonNegative long offset);
 
     /**
      * Read a short at an offset possibly not checking memory bounds.
@@ -28,7 +30,7 @@ public interface UncheckedRandomDataInput {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    short readShort(long offset);
+    short readShort(@NonNegative long offset);
 
     /**
      * Read an int at an offset possibly not checking memory bounds.
@@ -41,7 +43,7 @@ public interface UncheckedRandomDataInput {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    int readInt(long offset);
+    int readInt(@NonNegative long offset);
 
     /**
      * Read a long at an offset possibly not checking memory bounds.
@@ -54,6 +56,6 @@ public interface UncheckedRandomDataInput {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
-    long readLong(long offset);
+    long readLong(@NonNegative long offset);
 
 }

--- a/src/main/java/net/openhft/chronicle/bytes/internal/migration/HashCodeEqualsUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/migration/HashCodeEqualsUtil.java
@@ -3,13 +3,14 @@ package net.openhft.chronicle.bytes.internal.migration;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.algo.BytesStoreHash;
 import net.openhft.chronicle.core.io.ReferenceOwner;
+import org.jetbrains.annotations.NotNull;
 
 public final class HashCodeEqualsUtil {
 
     private HashCodeEqualsUtil() {
     }
 
-    public static int hashCode(final BytesStore<?, ?> bytes) {
+    public static int hashCode(final @NotNull BytesStore<?, ?> bytes) {
         // Reserving prevents illegal access to this Bytes object if released by another thread
         final ReferenceOwner owner = ReferenceOwner.temporary("hashCode");
         bytes.reserve(owner);

--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.bytes.ref;
 import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.MappedBytesStore;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.Closeable;
 import org.jetbrains.annotations.NotNull;
@@ -43,7 +44,7 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     }
 
     @Override
-    public void bytesStore(@NotNull final BytesStore bytes, final long offset, final long length)
+    public void bytesStore(final @NotNull BytesStore bytes, @NonNegative final long offset, @NonNegative final long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException {
         throwExceptionIfClosedInSetter();
         // trigger it to move to this

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
@@ -2,6 +2,7 @@ package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.HexDumpBytes;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.values.BooleanValue;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,7 @@ public class BinaryBooleanReference extends AbstractReference implements Boolean
 
     @SuppressWarnings("rawtypes")
     @Override
-    public void bytesStore(@NotNull final BytesStore bytes, long offset, final long length)
+    public void bytesStore(final @NotNull BytesStore bytes, @NonNegative long offset, @NonNegative final long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException {
         throwExceptionIfClosedInSetter();
 

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
@@ -18,6 +18,7 @@
 package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.*;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.values.IntValue;
 import org.jetbrains.annotations.NotNull;
@@ -74,7 +75,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
         binaryIntArrayReferences = null;
     }
 
-    public static void write(@NotNull Bytes bytes, long capacity)
+    public static void write(@NotNull Bytes bytes, @NonNegative long capacity)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         assert (bytes.writePosition() & 0x7) == 0;
 
@@ -85,7 +86,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
         bytes.writeSkip(capacity << SHIFT);
     }
 
-    public static void lazyWrite(@NotNull Bytes bytes, long capacity)
+    public static void lazyWrite(@NotNull Bytes bytes, @NonNegative long capacity)
             throws BufferOverflowException, IllegalStateException {
         assert (bytes.writePosition() & 0x7) == 0;
 
@@ -94,7 +95,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
         bytes.writeSkip(capacity << SHIFT);
     }
 
-    public static long peakLength(@NotNull BytesStore bytes, long offset)
+    public static long peakLength(@NotNull BytesStore bytes, @NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         final long capacity = bytes.readLong(offset + CAPACITY);
         assert capacity > 0 : "capacity too small " + capacity;
@@ -136,7 +137,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @Override
-    public int getValueAt(long index)
+    public int getValueAt(@NonNegative long index)
             throws IllegalStateException, BufferUnderflowException {
         throwExceptionIfClosed();
 
@@ -144,7 +145,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @Override
-    public void setValueAt(long index, int value)
+    public void setValueAt(@NonNegative long index, int value)
             throws IllegalStateException, BufferOverflowException {
         throwExceptionIfClosedInSetter();
 
@@ -152,7 +153,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @Override
-    public int getVolatileValueAt(long index)
+    public int getVolatileValueAt(@NonNegative long index)
             throws IllegalStateException, BufferUnderflowException {
         throwExceptionIfClosed();
 
@@ -160,7 +161,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @Override
-    public void bindValueAt(long index, @NotNull IntValue value)
+    public void bindValueAt(@NonNegative long index, @NotNull IntValue value)
             throws IllegalStateException, BufferOverflowException, IllegalArgumentException {
         throwExceptionIfClosed();
 
@@ -168,7 +169,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @Override
-    public void setOrderedValueAt(long index, int value)
+    public void setOrderedValueAt(@NonNegative long index, int value)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfClosedInSetter();
 
@@ -176,7 +177,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @Override
-    public void bytesStore(@NotNull BytesStore bytes, long offset, long length)
+    public void bytesStore(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws IllegalArgumentException, IllegalStateException, BufferOverflowException {
         throwExceptionIfClosed();
 
@@ -318,7 +319,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @Override
-    public long sizeInBytes(long capacity)
+    public long sizeInBytes(@NonNegative long capacity)
             throws IllegalStateException {
         throwExceptionIfClosed();
 
@@ -341,7 +342,7 @@ public class BinaryIntArrayReference extends AbstractReference implements Byteab
     }
 
     @Override
-    public boolean compareAndSet(long index, int expected, int value)
+    public boolean compareAndSet(@NonNegative long index, int expected, int value)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfClosed();
 

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -19,6 +19,7 @@ package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.HexDumpBytes;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.values.IntValue;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,7 +36,7 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public void bytesStore(@NotNull final BytesStore bytes, long offset, final long length)
+    public void bytesStore(final @NotNull BytesStore bytes, @NonNegative long offset, @NonNegative final long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException {
         throwExceptionIfClosedInSetter();
 

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
@@ -19,6 +19,7 @@ package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.*;
 import net.openhft.chronicle.bytes.util.DecoratedBufferOverflowException;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.values.LongValue;
 import org.jetbrains.annotations.NotNull;
@@ -52,7 +53,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
         this(0);
     }
 
-    public BinaryLongArrayReference(long defaultCapacity) {
+    public BinaryLongArrayReference(@NonNegative long defaultCapacity) {
         this.length = (defaultCapacity << SHIFT) + VALUES;
         disableThreadSafetyCheck(true);
     }
@@ -85,7 +86,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
         this.bytes.reserve(this);
     }
 
-    public static void write(@NotNull Bytes bytes, long capacity)
+    public static void write(@NotNull Bytes bytes, @NonNegative long capacity)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         assert (bytes.writePosition() & 0x7) == 0;
 
@@ -96,7 +97,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
         bytes.writeSkip(capacity << SHIFT);
     }
 
-    public static void lazyWrite(@NotNull Bytes bytes, long capacity)
+    public static void lazyWrite(@NotNull Bytes bytes, @NonNegative long capacity)
             throws BufferOverflowException, IllegalStateException {
         assert (bytes.writePosition() & 0x7) == 0;
 
@@ -105,14 +106,14 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
         bytes.writeSkip(capacity << SHIFT);
     }
 
-    public static long peakLength(@NotNull BytesStore bytes, long offset)
+    public static long peakLength(@NotNull BytesStore bytes, @NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         long capacity = bytes.readLong(offset + CAPACITY);
         assert capacity > 0 : "capacity too small " + capacity;
         return (capacity << SHIFT) + VALUES;
     }
 
-    public static long peakLength(@NotNull BytesStore bytes, long offset, long capacityHint)
+    public static long peakLength(@NotNull BytesStore bytes, @NonNegative long offset, long capacityHint)
             throws BufferUnderflowException, IllegalStateException {
         long capacity = bytes.readLong(offset + CAPACITY);
         if (capacity == 0) {
@@ -157,7 +158,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @Override
-    public long getValueAt(long index)
+    public long getValueAt(@NonNegative long index)
             throws BufferUnderflowException, IllegalStateException {
         throwExceptionIfClosed();
 
@@ -165,7 +166,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @Override
-    public void setValueAt(long index, long value)
+    public void setValueAt(@NonNegative long index, long value)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfClosedInSetter();
 
@@ -181,7 +182,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @Override
-    public void bindValueAt(long index, @NotNull LongValue value)
+    public void bindValueAt(@NonNegative long index, @NotNull LongValue value)
             throws IllegalStateException, BufferOverflowException {
         throwExceptionIfClosed();
 
@@ -193,7 +194,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @Override
-    public void setOrderedValueAt(long index, long value)
+    public void setOrderedValueAt(@NonNegative long index, long value)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfClosedInSetter();
 
@@ -201,7 +202,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @Override
-    public void bytesStore(@NotNull BytesStore bytes, long offset, long length)
+    public void bytesStore(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws IllegalArgumentException, IllegalStateException, BufferOverflowException {
         throwExceptionIfClosed();
 
@@ -335,7 +336,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @Override
-    public long sizeInBytes(long capacity)
+    public long sizeInBytes(@NonNegative long capacity)
             throws IllegalStateException {
         throwExceptionIfClosed();
 
@@ -343,7 +344,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @Override
-    public ByteableLongArrayValues capacity(long arrayLength)
+    public ByteableLongArrayValues capacity(@NonNegative long arrayLength)
             throws IllegalStateException {
         throwExceptionIfClosedInSetter();
 
@@ -358,7 +359,7 @@ public class BinaryLongArrayReference extends AbstractReference implements Bytea
     }
 
     @Override
-    public boolean compareAndSet(long index, long expected, long value)
+    public boolean compareAndSet(@NonNegative long index, long expected, long value)
             throws BufferOverflowException, IllegalStateException {
         throwExceptionIfClosed();
 

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -19,6 +19,7 @@ package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.HexDumpBytes;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.BufferOverflowException;
@@ -31,7 +32,7 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
 
     @SuppressWarnings("rawtypes")
     @Override
-    public void bytesStore(@NotNull final BytesStore bytes, long offset, final long length)
+    public void bytesStore(final @NotNull BytesStore bytes, @NonNegative long offset, @NonNegative final long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException {
         throwExceptionIfClosed();
 

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
@@ -20,14 +20,15 @@ package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.DynamicallySized;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.values.IntArrayValues;
 
 @SuppressWarnings("rawtypes")
 public interface ByteableIntArrayValues extends IntArrayValues, Byteable, DynamicallySized {
     @Override
-    long sizeInBytes(long sizeInBytes)
+    long sizeInBytes(@NonNegative long sizeInBytes)
             throws IllegalStateException;
 
-    ByteableIntArrayValues capacity(long arrayLength)
+    ByteableIntArrayValues capacity(@NonNegative long arrayLength)
             throws IllegalStateException;
 }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
@@ -20,14 +20,15 @@ package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.bytes.DynamicallySized;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.values.LongArrayValues;
 
 @SuppressWarnings("rawtypes")
 public interface ByteableLongArrayValues extends LongArrayValues, Byteable, DynamicallySized {
     @Override
-    long sizeInBytes(long sizeInBytes)
+    long sizeInBytes(@NonNegative long sizeInBytes)
             throws IllegalStateException;
 
-    ByteableLongArrayValues capacity(long arrayLength)
+    ByteableLongArrayValues capacity(@NonNegative long arrayLength)
             throws IllegalStateException;
 }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
@@ -18,6 +18,7 @@
 package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.values.BooleanValue;
 import org.jetbrains.annotations.NotNull;
 
@@ -33,7 +34,7 @@ public class TextBooleanReference extends AbstractReference implements BooleanVa
     private static final int TRUE = ' ' | ('t' << 8) | ('r' << 16) | ('u' << 24);
 
     @SuppressWarnings("rawtypes")
-    public static void write(final boolean value, final BytesStore bytes, long offset)
+    public static void write(final boolean value, final BytesStore bytes, @NonNegative long offset)
             throws IllegalStateException, BufferOverflowException {
         bytes.writeVolatileInt(offset, value ? TRUE : FALSE);
         bytes.writeByte(offset + 4, (byte) 'e');

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.bytes.ref;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.values.IntValue;
 import org.jetbrains.annotations.NotNull;
 
@@ -52,7 +53,7 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
 
     private long length = VALUES;
 
-    public static void write(@NotNull Bytes bytes, long capacity)
+    public static void write(@NotNull Bytes bytes, @NonNegative long capacity)
             throws IllegalStateException, BufferOverflowException {
         long start = bytes.writePosition();
         bytes.write(SECTION1);
@@ -80,7 +81,7 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
         bytes.write(SECTION4);
     }
 
-    public static long peakLength(@NotNull BytesStore bytes, long offset)
+    public static long peakLength(@NotNull BytesStore bytes, @NonNegative long offset)
             throws IllegalStateException {
         //todo check this, I think there could be a bug here
         try {
@@ -146,7 +147,7 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
     }
 
     @Override
-    public ByteableIntArrayValues capacity(long arrayLength) {
+    public ByteableIntArrayValues capacity(@NonNegative long arrayLength) {
         BytesStore bytesStore = bytesStore();
         long len = sizeInBytes(arrayLength);
         if (bytesStore == null) {
@@ -158,7 +159,7 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
     }
 
     @Override
-    public int getValueAt(long index)
+    public int getValueAt(@NonNegative long index)
             throws IllegalStateException {
         try {
             return (int) bytes.parseLong(VALUES + offset + index * VALUE_SIZE);
@@ -172,7 +173,7 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
     }
 
     @Override
-    public void setValueAt(long index, int value)
+    public void setValueAt(@NonNegative long index, int value)
             throws IllegalStateException {
         try {
             bytes.append(VALUES + offset + index * VALUE_SIZE, value, DIGITS);
@@ -185,26 +186,26 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
     }
 
     @Override
-    public void bindValueAt(long index, IntValue value) {
+    public void bindValueAt(@NonNegative long index, IntValue value) {
         throw new UnsupportedOperationException("todo");
     }
 
     @Override
-    public int getVolatileValueAt(long index)
+    public int getVolatileValueAt(@NonNegative long index)
             throws IllegalStateException {
         OS.memory().loadFence();
         return getValueAt(index);
     }
 
     @Override
-    public void setOrderedValueAt(long index, int value)
+    public void setOrderedValueAt(@NonNegative long index, int value)
             throws IllegalStateException {
         setValueAt(index, value);
         OS.memory().storeFence();
     }
 
     @Override
-    public boolean compareAndSet(long index, int expected, int value)
+    public boolean compareAndSet(@NonNegative long index, int expected, int value)
             throws IllegalStateException {
         try {
             if (!bytes.compareAndSwapInt(LOCK_OFFSET + offset, FALS, TRU))
@@ -229,7 +230,7 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
     }
 
     @Override
-    public void bytesStore(@NotNull final BytesStore bytes, long offset, long length)
+    public void bytesStore(final @NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException {
         throwExceptionIfClosedInSetter();
 
@@ -278,7 +279,7 @@ public class TextIntArrayReference extends AbstractReference implements Byteable
     }
 
     @Override
-    public long sizeInBytes(long capacity) {
+    public long sizeInBytes(@NonNegative long capacity) {
         return (capacity * VALUE_SIZE) + VALUES + SECTION3.length - SEP.length;
     }
 }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
@@ -19,6 +19,7 @@ package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.util.ThrowingIntSupplier;
 import net.openhft.chronicle.core.values.IntValue;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +45,7 @@ public class TextIntReference extends AbstractReference implements IntValue {
     private static final int DIGITS = 10;
 
     @SuppressWarnings("rawtypes")
-    public static void write(@NotNull Bytes bytes, int value)
+    public static void write(@NotNull Bytes bytes, @NonNegative int value)
             throws BufferOverflowException, IllegalStateException {
         long position = bytes.writePosition();
         bytes.write(template);
@@ -148,7 +149,7 @@ public class TextIntReference extends AbstractReference implements IntValue {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public void bytesStore(@NotNull final BytesStore bytes, long offset, long length)
+    public void bytesStore(final @NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws IllegalStateException, IllegalArgumentException, BufferOverflowException {
         throwExceptionIfClosedInSetter();
 

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -21,6 +21,7 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.util.DecoratedBufferOverflowException;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.values.LongValue;
 import org.jetbrains.annotations.NotNull;
 
@@ -53,7 +54,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
 
     private long length = VALUES;
 
-    public static void write(@NotNull Bytes bytes, long capacity)
+    public static void write(@NotNull Bytes bytes, @NonNegative long capacity)
             throws IllegalArgumentException, IllegalStateException, BufferOverflowException, ArithmeticException, BufferUnderflowException {
         long start = bytes.writePosition();
         bytes.write(SECTION1);
@@ -72,7 +73,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
         bytes.write(SECTION4);
     }
 
-    public static long peakLength(@NotNull BytesStore bytes, long offset)
+    public static long peakLength(@NotNull BytesStore bytes, @NonNegative long offset)
             throws IllegalStateException, BufferUnderflowException {
         //todo check this, I think there could be a bug here
         return (bytes.parseLong(offset + CAPACITY) * VALUE_SIZE) - SEP.length
@@ -134,7 +135,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
     }
 
     @Override
-    public ByteableLongArrayValues capacity(long arrayLength) {
+    public ByteableLongArrayValues capacity(@NonNegative long arrayLength) {
         BytesStore bytesStore = bytesStore();
         long len = sizeInBytes(arrayLength);
         if (bytesStore == null) {
@@ -146,7 +147,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
     }
 
     @Override
-    public long getValueAt(long index)
+    public long getValueAt(@NonNegative long index)
             throws IllegalStateException {
         try {
             return bytes.parseLong(VALUES + offset + index * VALUE_SIZE);
@@ -160,7 +161,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
     }
 
     @Override
-    public void setValueAt(long index, long value)
+    public void setValueAt(@NonNegative long index, long value)
             throws IllegalStateException {
         try {
             bytes.append(VALUES + offset + index * VALUE_SIZE, value, DIGITS);
@@ -173,26 +174,26 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
     }
 
     @Override
-    public void bindValueAt(long index, LongValue value) {
+    public void bindValueAt(@NonNegative long index, LongValue value) {
         throw new UnsupportedOperationException("todo");
     }
 
     @Override
-    public long getVolatileValueAt(long index)
+    public long getVolatileValueAt(@NonNegative long index)
             throws IllegalStateException {
         OS.memory().loadFence();
         return getValueAt(index);
     }
 
     @Override
-    public void setOrderedValueAt(long index, long value)
+    public void setOrderedValueAt(@NonNegative long index, long value)
             throws IllegalStateException {
         setValueAt(index, value);
         OS.memory().storeFence();
     }
 
     @Override
-    public boolean compareAndSet(long index, long expected, long value)
+    public boolean compareAndSet(@NonNegative long index, long expected, long value)
             throws IllegalStateException {
         try {
             if (!bytes.compareAndSwapInt(LOCK_OFFSET + offset, FALS, TRU))
@@ -217,7 +218,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
     }
 
     @Override
-    public void bytesStore(@NotNull final BytesStore bytes, long offset, long length)
+    public void bytesStore(final @NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws IllegalStateException, BufferOverflowException, IllegalArgumentException {
         throwExceptionIfClosedInSetter();
 
@@ -272,7 +273,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
     }
 
     @Override
-    public long sizeInBytes(long capacity) {
+    public long sizeInBytes(@NonNegative long capacity) {
         return (capacity * VALUE_SIZE) + VALUES + SECTION3.length - SEP.length;
     }
 }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.bytes.ref;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.BytesUtil;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.util.ThrowingLongSupplier;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,7 +45,7 @@ public class TextLongReference extends AbstractReference implements LongReferenc
     private static final int DIGITS = 20;
 
     @SuppressWarnings("rawtypes")
-    public static void write(@NotNull Bytes bytes, long value)
+    public static void write(@NotNull Bytes bytes, @NonNegative long value)
             throws BufferOverflowException, IllegalArgumentException, IllegalStateException {
         long position = bytes.writePosition();
         bytes.write(template);
@@ -76,7 +77,7 @@ public class TextLongReference extends AbstractReference implements LongReferenc
 
     @SuppressWarnings("rawtypes")
     @Override
-    public void bytesStore(@NotNull final BytesStore bytes, long offset, long length)
+    public void bytesStore(final @NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws IllegalArgumentException, IllegalStateException, BufferOverflowException {
         if (length != template.length)
             throw new IllegalArgumentException();

--- a/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
@@ -19,6 +19,7 @@ package net.openhft.chronicle.bytes.ref;
 
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.ReferenceOwner;
 import net.openhft.chronicle.core.io.UnsafeCloseable;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +32,7 @@ public class UncheckedLongReference extends UnsafeCloseable implements LongRefer
     private BytesStore bytes;
 
     @NotNull
-    public static LongReference create(BytesStore bytesStore, long offset, int size)
+    public static LongReference create(@NotNull BytesStore bytesStore, @NonNegative long offset, @NonNegative int size)
             throws IllegalArgumentException, BufferOverflowException, BufferUnderflowException, IllegalStateException {
         @NotNull LongReference ref = Jvm.isDebug() ? new BinaryLongReference() : new UncheckedLongReference();
         ref.bytesStore(bytesStore, offset, size);
@@ -39,7 +40,7 @@ public class UncheckedLongReference extends UnsafeCloseable implements LongRefer
     }
 
     @Override
-    public void bytesStore(@NotNull BytesStore bytes, long offset, long length)
+    public void bytesStore(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
             throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
         throwExceptionIfClosedInSetter();
 

--- a/src/main/java/net/openhft/chronicle/bytes/util/AbstractInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/AbstractInterner.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.bytes.util;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.core.Maths;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.IOTools;
 import org.jetbrains.annotations.NotNull;
@@ -47,7 +48,7 @@ public abstract class AbstractInterner<T> {
     protected final int shift;
     protected boolean toggle = false;
 
-    protected AbstractInterner(int capacity)
+    protected AbstractInterner(@NonNegative int capacity)
             throws IllegalArgumentException {
         int n = Maths.nextPower2(capacity, 128);
         shift = Maths.intLog2(n);
@@ -55,7 +56,7 @@ public abstract class AbstractInterner<T> {
         mask = n - 1;
     }
 
-    private static int hash32(@NotNull BytesStore bs, int length) throws IllegalStateException, BufferUnderflowException {
+    private static int hash32(@NotNull BytesStore bs, @NonNegative int length) throws IllegalStateException, BufferUnderflowException {
         return bs.fastHash(bs.readPosition(), length);
     }
 
@@ -69,12 +70,12 @@ public abstract class AbstractInterner<T> {
         return intern(cs, (int) cs.readRemaining());
     }
 
-    public T intern(@NotNull Bytes cs, int length)
+    public T intern(@NotNull Bytes cs, @NonNegative int length)
             throws IORuntimeException, BufferUnderflowException, IllegalStateException {
         return intern((BytesStore) cs, length);
     }
 
-    public T intern(@NotNull BytesStore cs, int length)
+    public T intern(@NotNull BytesStore cs, @NonNegative int length)
             throws IORuntimeException, BufferUnderflowException, IllegalStateException {
         if (length > entries.length)
             return getValue(cs, length);
@@ -99,7 +100,7 @@ public abstract class AbstractInterner<T> {
     }
 
     @NotNull
-    protected abstract T getValue(BytesStore bs, int length)
+    protected abstract T getValue(BytesStore bs, @NonNegative int length)
             throws IORuntimeException, IllegalStateException, BufferUnderflowException;
 
     protected boolean toggle() {

--- a/src/main/java/net/openhft/chronicle/bytes/util/BinaryLengthLength.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/BinaryLengthLength.java
@@ -3,6 +3,7 @@ package net.openhft.chronicle.bytes.util;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesOut;
 import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 public enum BinaryLengthLength {
@@ -21,7 +22,7 @@ public enum BinaryLengthLength {
         }
 
         @Override
-        public void writeLength(@NotNull Bytes<?> bytes, long positionReturnedFromInitialise, long end) {
+        public void writeLength(@NotNull Bytes<?> bytes, @NonNegative long positionReturnedFromInitialise, @NonNegative long end) {
             long length = (end - positionReturnedFromInitialise - 1) & MASK;
             if (length >= 1 << 8)
                 throw invalidLength(length);
@@ -44,7 +45,7 @@ public enum BinaryLengthLength {
         }
 
         @Override
-        public void writeLength(@NotNull Bytes<?> bytes, long positionReturnedFromInitialise, long end) {
+        public void writeLength(@NotNull Bytes<?> bytes, @NonNegative long positionReturnedFromInitialise, @NonNegative long end) {
             final long length = (end - positionReturnedFromInitialise - 2) & MASK;
             if (length >= 1 << 16)
                 throw invalidLength(length);
@@ -67,7 +68,7 @@ public enum BinaryLengthLength {
         }
 
         @Override
-        public void writeLength(@NotNull Bytes<?> bytes, long positionReturnedFromInitialise, long end) {
+        public void writeLength(@NotNull Bytes<?> bytes, @NonNegative long positionReturnedFromInitialise, @NonNegative long end) {
             final long length = (end - positionReturnedFromInitialise - 4) & MASK;
             if (length >= 1L << 31)
                 throw invalidLength(length);
@@ -77,7 +78,7 @@ public enum BinaryLengthLength {
 
     static final long MASK = 0xFFFFFFFFL;
 
-    IllegalStateException invalidLength(final long length) {
+    IllegalStateException invalidLength(@NonNegative final long length) {
         return new IllegalStateException("length: " + length);
     }
 
@@ -86,6 +87,6 @@ public enum BinaryLengthLength {
     public abstract long initialise(@NotNull BytesOut<?> bytes);
 
     public abstract void writeLength(@NotNull Bytes<?> bytes,
-                                     long positionReturnedFromInitialise,
-                                     long end);
+                                     @NonNegative long positionReturnedFromInitialise,
+                                     @NonNegative long end);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/util/Bit8StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Bit8StringInterner.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.bytes.util;
 
 import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.pool.StringBuilderPool;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,7 +37,7 @@ public class Bit8StringInterner extends AbstractInterner<String> {
     @SuppressWarnings("rawtypes")
     @Override
     @NotNull
-    protected String getValue(@NotNull BytesStore cs, int length) throws IllegalStateException, BufferUnderflowException {
+    protected String getValue(@NotNull BytesStore cs, @NonNegative int length) throws IllegalStateException, BufferUnderflowException {
         StringBuilder sb = SBP.acquireStringBuilder();
         for (int i = 0; i < length; i++)
             sb.append((char) cs.readUnsignedByte(cs.readPosition() + i));

--- a/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.bytes.util;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.algo.BytesStoreHash;
 import net.openhft.chronicle.core.Maths;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.pool.StringInterner;
 import net.openhft.chronicle.core.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +32,7 @@ import static net.openhft.chronicle.bytes.BytesUtil.toCharArray;
 
 public class StringInternerBytes extends StringInterner {
 
-    public StringInternerBytes(int capacity)
+    public StringInternerBytes(@NonNegative int capacity)
             throws IllegalArgumentException {
         super(capacity);
     }
@@ -53,7 +54,7 @@ public class StringInternerBytes extends StringInterner {
      * @return the string made from bytes only ( rather than chars )
      */
     @SuppressWarnings("rawtypes")
-    public String intern(@NotNull final Bytes bytes, int length)
+    public String intern(@NotNull final Bytes bytes, @NonNegative int length)
             throws IllegalStateException, BufferUnderflowException {
         try {
 

--- a/src/main/java/net/openhft/chronicle/bytes/util/UTF8StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/UTF8StringInterner.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.bytes.util;
 import net.openhft.chronicle.bytes.AppendableUtil;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.UTFDataFormatRuntimeException;
+import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.pool.StringBuilderPool;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,7 +31,7 @@ public class UTF8StringInterner extends AbstractInterner<String> {
 
     private static final StringBuilderPool SBP = new StringBuilderPool();
 
-    public UTF8StringInterner(int capacity)
+    public UTF8StringInterner(@NonNegative int capacity)
             throws IllegalArgumentException {
         super(capacity);
     }
@@ -38,7 +39,7 @@ public class UTF8StringInterner extends AbstractInterner<String> {
     @SuppressWarnings("rawtypes")
     @Override
     @NotNull
-    protected String getValue(@NotNull BytesStore cs, int length)
+    protected String getValue(@NotNull BytesStore cs, @NonNegative int length)
             throws UTFDataFormatRuntimeException, IllegalStateException, BufferUnderflowException {
         StringBuilder sb = SBP.acquireStringBuilder();
         AppendableUtil.parseUtf8(cs, sb, true, length);


### PR DESCRIPTION
This PR introduces `@NonNegative` annotations on methods and parameters. In the next step, these parameter values can be asserted (zero cost or `requireNonNegative()`)

Unfortunately, many classes and methods are affected.

Addresses can be negative (e.g. if a mapped file is used) and some skip parameters can be negative. Otherwise, most parameters (int and long) are affected.