### PR TITLE
deprecating mutating methods from readonly interfaces #967

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -55,7 +55,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
         extends RandomDataInput, RandomDataOutput<B>, ReferenceCounted, CharSequence {
 
     /**
-     * Returns a BytesStore using the bytes in a specified CharSequence. This chars are encoded
+     * Returns a BytesStore using the bytes in a specified CharSequence. These chars are encoded
      * using ISO_8859_1
      *
      * @param cs a CharSequence to convert

--- a/src/main/java/net/openhft/chronicle/bytes/RandomCommon.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomCommon.java
@@ -215,9 +215,11 @@ interface RandomCommon extends ReferenceCounted {
      * @param value    to set
      * @return true, if successful.
      */
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.25 */)
     boolean compareAndSwapInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException;
 
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.25 */)
     void testAndSetInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException;
 
@@ -229,6 +231,7 @@ interface RandomCommon extends ReferenceCounted {
      * @param value    to set
      * @return true, if successful.
      */
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.25 */)
     boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws BufferOverflowException, IllegalStateException;
 
@@ -240,6 +243,7 @@ interface RandomCommon extends ReferenceCounted {
      * @param value    to set
      * @return true, if successful.
      */
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.25 */)
     default boolean compareAndSwapFloat(@NonNegative long offset, float expected, float value)
             throws BufferOverflowException, IllegalStateException {
         return compareAndSwapInt(offset, Float.floatToRawIntBits(expected), Float.floatToRawIntBits(value));
@@ -253,6 +257,7 @@ interface RandomCommon extends ReferenceCounted {
      * @param value    to set
      * @return true, if successful.
      */
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.25 */)
     default boolean compareAndSwapDouble(@NonNegative long offset, double expected, double value)
             throws BufferOverflowException, IllegalStateException {
         return compareAndSwapLong(offset, Double.doubleToRawLongBits(expected), Double.doubleToRawLongBits(value));

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
@@ -387,6 +387,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.26 */)
     default int addAndGetInt(@NonNegative long offset, int adding)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.addAndGetInt(this, offset, adding);
@@ -401,6 +402,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.26 */)
     default long addAndGetLong(@NonNegative long offset, long adding)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.addAndGetLong(this, offset, adding);
@@ -414,6 +416,7 @@ public interface RandomDataInput extends RandomCommon {
      * @return the sum
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      */
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.26 */)
     default float addAndGetFloat(@NonNegative long offset, float adding)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.addAndGetFloat(this, offset, adding);
@@ -428,6 +431,7 @@ public interface RandomDataInput extends RandomCommon {
      * @throws BufferUnderflowException if the offset is outside the limits of the Bytes
      * @throws IllegalStateException    if released
      */
+    @Deprecated(/* Use RandomDataOutput instead, to be removed in x.26 */)
     default double addAndGetDouble(@NonNegative long offset, double adding)
             throws BufferUnderflowException, IllegalStateException {
         return BytesInternal.addAndGetDouble(this, offset, adding);


### PR DESCRIPTION
This is an alternative version of interface change, we keep writers write only and readers read only
however we will have to do type casts whenever we need to read while having Writer interface (this is how deprecations would get applied https://github.com/OpenHFT/Chronicle-Bytes/commit/8d224d85c7f0e660f1961debe56741f605d3b993)

