### PR TITLE
uncomment commented-out test params

### DIFF
--- a/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
@@ -60,12 +60,12 @@ public class BytesTest extends BytesTestCommon {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-//                {"Native Unchecked", NATIVE_UNCHECKED},
-//                {"Native", NATIVE},
-//                {"Heap", HEAP},
-//                {"Heap ByteBuffer", BYTE_BUFFER},
-//                {"Heap Unchecked", HEAP_UNCHECKED},
-//                {"Heap Embedded", HEAP_EMBEDDED},
+                {"Native Unchecked", NATIVE_UNCHECKED},
+                {"Native", NATIVE},
+                {"Heap", HEAP},
+                {"Heap ByteBuffer", BYTE_BUFFER},
+                {"Heap Unchecked", HEAP_UNCHECKED},
+                {"Heap Embedded", HEAP_EMBEDDED},
                 {"Hex Dump", HEX_DUMP}
         });
     }


### PR DESCRIPTION
these were commented out (in error I assume) in https://github.com/OpenHFT/Chronicle-Bytes/commit/1943908c91c75dc676f70b4f01228fb27591c42e