### PR TITLE
Consolidate mapped bytes fixes 2

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -951,7 +951,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(1, 1);
+        long offset = writeOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
         return this;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -916,7 +916,7 @@ public interface Bytes<U> extends
 
     /**
      * Grows the buffer if the buffer is elastic, if the buffer is not elastic and there is not
-     * enough capacity then this method will throw an {@link IllegalArgumentException}
+     * enough capacity then this method will throw an {@link DecoratedBufferOverflowException}
      *
      * @param desiredCapacity the capacity that you required
      * @throws IllegalStateException if closed and it needs a resize

--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -316,7 +316,8 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
     /**
      * Returns if a specified offset is inside this BytesStore limits.
      * <p>
-     * Use this test to determine if an offset is considered safe.
+     * Use this test to determine if an offset is considered safe for reading from. Note that it checks we are
+     * inside the BytesStore limits *without* including the overlap
      *
      * @param offset the specified offset to check
      * @return <code>true</code> if offset is safe
@@ -327,6 +328,11 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
 
     /**
      * Returns if a number of bytes starting from an offset are inside this ByteStore limits.
+     * If you are going to write n bytes starting at offset, you need to call this method with buffer=n-1,
+     * as the 1st byte is written at offset, and the last at offset+n-1
+     * <p>
+     * Use this test to determine if an offset is considered safe to write to. Note that it checks we are
+     * inside the BytesStore limits *including* the overlap
      *
      * @param offset the starting index to check
      * @param buffer the number of bytes after the offset to check

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
@@ -111,8 +111,8 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
 
     @Override
     public boolean inside(@NonNegative long offset, @NonNegative long buffer) {
-        // this is correct that it uses the maximumLimit, yes it is different than the method above.
-        return start <= offset && offset + buffer <= limit;
+        // yes this is different than the method above
+        return start <= offset && offset + buffer < limit;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
@@ -388,7 +388,7 @@ public class NativeBytes<U>
     @Override
     public Bytes<U> writeByte(final byte i8)
             throws BufferOverflowException, IllegalStateException {
-        final long offset = writeOffsetPositionMoved(1, 1);
+        final long offset = writeOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
         return this;
     }
@@ -397,7 +397,7 @@ public class NativeBytes<U>
     @Override
     public Bytes<U> writeLong(final long i64)
             throws BufferOverflowException, IllegalStateException {
-        final long offset = writeOffsetPositionMoved(8L, 8L);
+        final long offset = writeOffsetPositionMoved(8L);
         bytesStore.writeLong(offset, i64);
         return this;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
@@ -251,7 +251,7 @@ public class UncheckedBytes<U>
     @Override
     public Bytes<U> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(1, 1);
+        long offset = writeOffsetPositionMoved(1);
         bytesStore.writeByte(offset, i8);
         return this;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -223,7 +223,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
 
         BytesStore bytesStore = this.bytesStore;
         if (!bytesStore.inside(offset, buffer))
-            bytesStore = acquireNextByteStore0(offset, true);
+            bytesStore = acquireNextByteStore0(offset,  true);
         return bytesStore.addressForRead(offset);
     }
 
@@ -260,9 +260,9 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         if (offset + adding < start() || offset > mappedFile.capacity() - adding)
             throw writeBufferOverflowException0(offset);
         BytesStore bytesStore = this.bytesStore;
-        if (adding > 0 && !bytesStore.inside(offset, checkSize0(adding))) {
-            acquireNextByteStore0(offset, false);
-            if (!this.bytesStore.inside(offset, checkSize0(adding)))
+        if (adding > 0 && !bytesStore.inside(offset, checkSize0(adding - 1))) {
+            acquireNextByteStore0(offset + adding - 1, false);
+            if (!this.bytesStore.inside(offset, checkSize0(adding - 1)))
                 throw new DecoratedBufferUnderflowException(String.format("Acquired the next BytesStore, but still not room to add %d when realCapacity %d", adding, this.bytesStore.realCapacity()));
         }
     }
@@ -277,10 +277,17 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     public void ensureCapacity(@NonNegative final long desiredCapacity)
             throws IllegalArgumentException, IllegalStateException {
         throwExceptionIfClosed();
-
+        // TODO: should not accept desiredCapacity == 0
         BytesStore<?, ?> bytesStore = this.bytesStore;
-        if (!bytesStore.inside(writePosition(), checkSize0(desiredCapacity))) {
-            acquireNextByteStore0(writePosition(), false);
+        if (desiredCapacity > capacity())
+            throw new DecoratedBufferOverflowException("Cannot extend capacity beyond " + capacity());
+        // we deliberately check writePosition here - the javadoc of this method explicitly references
+        // growing an elastic Bytes and it feels like the least surprising behaviour is to do this
+        if (desiredCapacity > writePosition()) {
+            long adding = desiredCapacity - writePosition();
+            if (!bytesStore.inside(writePosition(), checkSize0(adding))) {
+                acquireNextByteStore0(writePosition() + adding, false);
+            }
         }
     }
 
@@ -379,25 +386,6 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         return this;
     }
 
-    @NotNull
-    @Override
-    public Bytes<Void> writeByte(final byte i8)
-            throws BufferOverflowException, IllegalStateException {
-        throwExceptionIfClosed();
-
-        final long oldPosition = writePosition();
-        if (writePosition() < 0 || writePosition() > capacity() - 1)
-            throw writeBufferOverflowException0(writePosition());
-        BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(writePosition(), 1)) {
-            // already determined we need it
-            bytesStore = acquireNextByteStore0(writePosition(), false);
-        }
-        uncheckedWritePosition(writePosition() + 1);
-        bytesStore.writeByte(oldPosition, i8);
-        return this;
-    }
-
     @Override
     public boolean isElastic() {
         return true;
@@ -443,27 +431,12 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     @Override
-    @NotNull
-    public Bytes<Void> writeOrderedInt(@NonNegative long offset, int i)
-            throws BufferOverflowException, IllegalStateException {
-        throwExceptionIfClosed();
-
-        writeCheckOffset(offset, 4);
-        BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 4)) {
-            bytesStore = acquireNextByteStore0(offset, false);
-        }
-        bytesStore.writeOrderedInt(offset, i);
-        return this;
-    }
-
-    @Override
     public byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 1)) {
+        if (!bytesStore.inside(offset, 0)) {
             bytesStore = acquireNextByteStore0(offset, false);
         }
         return bytesStore.readVolatileByte(offset);
@@ -475,8 +448,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 2)) {
-            bytesStore = acquireNextByteStore0(offset, false);
+        if (!bytesStore.inside(offset, 1)) {
+            bytesStore = acquireNextByteStore0(offset + 1, false);
         }
         return bytesStore.readVolatileShort(offset);
     }
@@ -487,8 +460,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 4)) {
-            bytesStore = acquireNextByteStore0(offset, false);
+        if (!bytesStore.inside(offset, 3)) {
+            bytesStore = acquireNextByteStore0(offset + 3, false);
         }
         return bytesStore.readVolatileInt(offset);
     }
@@ -499,8 +472,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 8)) {
-            bytesStore = acquireNextByteStore0(offset, false);
+        if (!bytesStore.inside(offset, 7)) {
+            bytesStore = acquireNextByteStore0(offset + 7, false);
         }
         return bytesStore.readVolatileLong(offset);
     }
@@ -511,7 +484,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(readPosition, 1)) {
+        if (!bytesStore.inside(readPosition, 0)) {
             bytesStore = acquireNextByteStore0(readPosition, false);
         }
         try {
@@ -527,8 +500,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 1)) {
-            bytesStore = acquireNextByteStore0(offset, false);
+        if (!bytesStore.inside(offset, 0)) {
+            bytesStore = acquireNextByteStore0(offset + 0, false);
         }
         return offset < start() || readLimit() <= offset ? -1 : bytesStore.peekUnsignedByte(offset);
     }
@@ -539,8 +512,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
             throws IllegalStateException {
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(readPosition, 4)) {
-            bytesStore = acquireNextByteStore0(readPosition, true);
+        if (!bytesStore.inside(readPosition, 3)) {
+            bytesStore = acquireNextByteStore0(readPosition + 3, true);
         }
         MappedBytesStore mbs = (MappedBytesStore) bytesStore;
         long address = mbs.address + mbs.translate(readPosition);

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class MappedBytesEdgeTest extends BytesTestCommon {
+    private final int size;
+    private final ReadWrite rw;
+    private final Consumer<Bytes<?>> doit;
+
+    public MappedBytesEdgeTest(int size, ReadWrite rw, Consumer<Bytes<?>> doit) {
+        this.size = size;
+        this.rw = rw;
+        this.doit = doit;
+    }
+
+    @Parameterized.Parameters(name = "size {0} rw {1} lambda {2}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {1, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::peekUnsignedByte) },
+                {4, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::readInt) },
+                {4, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::readVolatileInt) },
+                {4, ReadWrite.READ, (Consumer<Bytes<?>>)(b -> b.peekVolatileInt()) },
+                {8, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::readLong) },
+                {8, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::readDouble) },
+
+                {1, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeByte((byte) 99)) },
+                {2, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeShort((short) 123)) },
+                {4, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeInt(1234)) },
+                {4, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeOrderedInt(1234)) },
+                {8, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeLong(1234)) },
+                {8, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeDouble(1234)) },
+                {6, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.write8bit("hello")) },
+                {7, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.appendUtf8("doggie")) },
+                {10, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.write(Bytes.from("armadillo"))) },
+
+        });
+    }
+
+    @Test
+    public void testCorrectChunkResolved() throws IOException {
+        final File tempMBFile = File.createTempFile("mapped", "bytes");
+        int chunk = 262144;
+        int overlap = 65536;
+        try (final MappedBytes bytes = MappedBytes.mappedBytes(tempMBFile, chunk, overlap)) {
+            // map in the real file
+            bytes.writePosition(0).writeByte((byte) 0);
+            assertEquals(0, bytes.bytesStore().start());
+
+            if (rw == ReadWrite.WRITE) {
+                checkWritePosition(bytes, chunk + overlap - size, 0);
+                checkWritePosition(bytes, chunk + overlap, chunk);
+                checkWritePosition(bytes, chunk + overlap + size, chunk);
+                // go back to just before the overlap - will still be in second chunk
+                checkWritePosition(bytes, chunk + overlap - size, chunk);
+                checkWritePosition(bytes, chunk - size, 0);
+                if (size > 1) {
+                    // now try and write over the end of the chunk
+                    bytes.writePosition(chunk - 1);
+                    doit.accept(bytes);
+                    // and end of chunk plus offset
+                    bytes.writePosition(chunk + overlap - 1);
+                    doit.accept(bytes);
+                }
+            } else {
+                // ensure WP is far ahead as Bytes generally won't allow a read past the WP
+                bytes.writePosition(chunk + 1_000);
+                checkReadPosition(bytes, chunk - size, 0);
+                checkReadPosition(bytes, chunk, chunk);
+                checkReadPosition(bytes, chunk + size, chunk);
+                checkReadPosition(bytes, chunk - size, 0);
+                // read over the end should work as we have the overlap
+                if (size > 1) {
+                    bytes.readPosition(chunk - 1);
+                    doit.accept(bytes);
+                }
+            }
+        }
+    }
+
+    private void checkWritePosition(MappedBytes bytes, int writePosition, int expectedStart) {
+        bytes.writePosition(writePosition);
+        doit.accept(bytes);
+        assertEquals(expectedStart, bytes.bytesStore().start());
+    }
+
+    private void checkReadPosition(MappedBytes bytes, int readPosition, int expectedStart) {
+        bytes.readPosition(readPosition);
+        doit.accept(bytes);
+        assertEquals(expectedStart, bytes.bytesStore().start());
+    }
+
+    private enum ReadWrite {
+        READ,
+        WRITE
+    }
+}


### PR DESCRIPTION
undo <= change from previous commit and add test. Add MappedBytesEdgeTest and address off-by-ones. Closes #412. Fix ChunkedMappedBytes.ensureCapacity. Make acquireNextByteStore0 use 3 args. Closes #417. Clean up use of API