### PR TITLE
Fixed wrong writePosition being used for EmbeddedBytes

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -64,7 +64,8 @@ public abstract class AbstractBytes<U>
     @NotNull
     protected BytesStore<Bytes<U>, U> bytesStore;
     protected long readPosition;
-    private long writePosition; // May be overridden in subclasses - use writePosition() getter to access it
+    // Make private in x.24 - can be overridden in subclasses, should be accessed via writePosition() getter
+    protected long writePosition;
     protected long writeLimit;
     protected boolean isPresent;
     private int lastDecimalPlaces = 0;

--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -64,7 +64,7 @@ public abstract class AbstractBytes<U>
     @NotNull
     protected BytesStore<Bytes<U>, U> bytesStore;
     protected long readPosition;
-    protected long writePosition;
+    private long writePosition; // May be overridden in subclasses - use writePosition() getter to access it
     protected long writeLimit;
     protected boolean isPresent;
     private int lastDecimalPlaces = 0;

--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -133,7 +133,7 @@ public abstract class AbstractBytes<U>
             throws IllegalStateException {
         final long start = start();
         final long capacity = capacity();
-        if (readPosition == start && writePosition == start && writeLimit == capacity)
+        if (readPosition == start && writePosition() == start && writeLimit == capacity)
             return this;
         assert DISABLE_THREAD_SAFETY || threadSafetyCheck(true);
         readPosition = start;
@@ -274,7 +274,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> readLimit(@NonNegative long limit)
             throws BufferUnderflowException {
-        if (this.writePosition == limit)
+        if (writePosition() == limit)
             return this;
 
         assert DISABLE_THREAD_SAFETY || threadSafetyCheck(true);
@@ -300,7 +300,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writePosition(@NonNegative long position)
             throws BufferOverflowException {
-        if (writePosition == position)
+        if (writePosition() == position)
             return this;
 
         if (position > writeLimit())

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
@@ -368,7 +368,7 @@ public class NativeBytes<U>
     protected long writeOffsetPositionMoved(final @NonNegative long adding, final @NonNegative long advance)
             throws BufferOverflowException, IllegalStateException {
         final long oldPosition = writePosition();
-        if (writePosition < bytesStore.start())
+        if (writePosition() < bytesStore.start())
             throw new BufferOverflowException();
         final long writeEnd = writePosition() + adding;
         if (writeEnd > writeLimit)

--- a/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
@@ -300,7 +300,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
             throws BufferOverflowException, IllegalStateException {
 
         requireNonNull(s);
-        ensureCapacity(writePosition + length);
+        ensureCapacity(writePosition() + length);
         long address = addressForWritePosition();
         Memory memory = ((MappedBytesStore) bytesStore()).memory;
         if (Jvm.isJava9Plus()) {

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedBytes.java
@@ -233,7 +233,7 @@ public class SingleMappedBytes extends CommonMappedBytes {
         assert bytes != this : "you should not write to yourself !";
 
         long length = bytes.readRemaining();
-        bytesStore.write(writePosition, bytes);
+        bytesStore.write(writePosition(), bytes);
         writeSkip(length);
         return this;
     }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
@@ -150,8 +150,8 @@ public class MappedBytesTest extends BytesTestCommon {
             // write
             Bytes<?> from = Bytes.from(text);
             bytesW.write(from);
-            long wp = bytesW.writePosition;
-            Assert.assertEquals(text.length(), bytesW.writePosition);
+            long wp = bytesW.writePosition();
+            Assert.assertEquals(text.length(), bytesW.writePosition());
 
             // read
             bytesR.readLimit(wp);
@@ -191,7 +191,7 @@ public class MappedBytesTest extends BytesTestCommon {
             Bytes<?> from = Bytes.from(text);
             bytesW.write(offset, from);
             long wp = text.length() + offset;
-            Assert.assertEquals(0, bytesW.writePosition);
+            Assert.assertEquals(0, bytesW.writePosition());
 
             // read
             bytesR.readLimit(wp);
@@ -214,7 +214,7 @@ public class MappedBytesTest extends BytesTestCommon {
             Bytes<?> from = Bytes.from(text);
             bytesW.write(offset, from);
             long wp = text.length() + offset;
-            Assert.assertEquals(0, bytesW.writePosition);
+            Assert.assertEquals(0, bytesW.writePosition());
 
             // read
             bytesR.readLimit(wp);
@@ -236,7 +236,7 @@ public class MappedBytesTest extends BytesTestCommon {
             //write
             Bytes<?> from = Bytes.from(text);
             bytesW.write(offset, from, shift, text.length() - shift);
-            Assert.assertEquals(0, bytesW.writePosition);
+            Assert.assertEquals(0, bytesW.writePosition());
 
             // read
             bytesR.readLimit(offset + (text.length() - shift));
@@ -259,7 +259,7 @@ public class MappedBytesTest extends BytesTestCommon {
             //write
             Bytes<?> from = Bytes.from(text);
             bytesW.write(offset, from, shift, text.length() - shift);
-            Assert.assertEquals(0, bytesW.writePosition);
+            Assert.assertEquals(0, bytesW.writePosition());
 
             // read
             bytesR.readLimit(offset + (text.length() - shift));


### PR DESCRIPTION
See also https://github.com/OpenHFT/Chronicle-Wire/pull/549 - reproducing test