### PR TITLE
Issue/426 read out of range

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
@@ -24,6 +24,7 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.UnsafeMemory;
 import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
@@ -58,7 +59,7 @@ public class HeapBytesStore<U>
         this.capacity = byteBuffer.capacity();
     }
 
-    private HeapBytesStore(byte[] byteArray) {
+    private HeapBytesStore(@Nullable byte[] byteArray) {
         super(false);
         //noinspection unchecked
         this.underlyingObject = (U) byteArray;
@@ -139,7 +140,6 @@ public class HeapBytesStore<U>
         return capacity;
     }
 
-    @NotNull
     @Override
     public U underlyingObject() {
         return underlyingObject;

--- a/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
@@ -839,8 +839,7 @@ public class NativeBytesStore<U>
     @Override
     public long read(@NonNegative long offsetInRDI, byte[] bytes, @NonNegative int offset, @NonNegative int length) {
         requireNonNull(bytes);
-        // length is non-neg and an int
-        int len = (int) Math.min(length, readLimit() - offsetInRDI);
+        int len = Math.min(length, Maths.toUInt31(readLimit() - offsetInRDI));
 
         memory.readBytes(this.address + translate(offsetInRDI), bytes, offset, len);
         return len;

--- a/src/test/java/net/openhft/chronicle/bytes/Allocator.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Allocator.java
@@ -163,6 +163,17 @@ public enum Allocator {
         Bytes<?> fixedBytes(int capacity) {
             return new HexDumpBytes();
         }
+    },
+    HEAP_BYTES_BACKING_BYTES {
+        @Override
+        @NotNull Bytes<?> elasticBytes(int capacity) {
+            return new OnHeapBytes(HEAP.elasticBytes(capacity), true);
+        }
+
+        @Override
+        @NotNull ByteBuffer byteBuffer(int capacity) {
+            return HEAP.byteBuffer(capacity);
+        }
     };
 
     @NotNull

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
@@ -39,7 +39,6 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Locale;
 import java.util.Scanner;
 
@@ -55,22 +54,13 @@ public class BytesTest extends BytesTestCommon {
 
     private final Allocator alloc1;
 
-    public BytesTest(String ignored, Allocator alloc1) {
+    public BytesTest(Allocator alloc1) {
         this.alloc1 = alloc1;
     }
 
     @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"Native Unchecked", NATIVE_UNCHECKED},
-                {"Native Wrapped", NATIVE},
-                {"Native Address", NATIVE_ADDRESS},
-                {"Heap", HEAP},
-                {"Heap ByteBuffer", BYTE_BUFFER},
-                {"Heap Unchecked", HEAP_UNCHECKED},
-                {"Heap Embedded", HEAP_EMBEDDED},
-                {"Hex Dump", HEX_DUMP}
-        });
+    public static Object[] data() {
+        return Arrays.stream(Allocator.values()).toArray();
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/bytes/StreamingDataInputTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StreamingDataInputTest.java
@@ -48,6 +48,17 @@ public class StreamingDataInputTest extends BytesTestCommon {
         Bytes<?> b = bytesType.createBuffer();
         b.append("0123456789");
         byte[] byteArr = "ABCDEFGHIJKLMNOP".getBytes();
+        b.readPosition(3);
+        b.read(byteArr);
+        assertEquals("3456789HIJKLMNOP", new String(byteArr, StandardCharsets.ISO_8859_1));
+        b.releaseLast();
+    }
+
+    @Test
+    public void readOffset() {
+        Bytes<?> b = bytesType.createBuffer();
+        b.append("0123456789");
+        byte[] byteArr = "ABCDEFGHIJKLMNOP".getBytes();
         b.read(byteArr, 2, 6);
         assertEquals("AB012345IJKLMNOP", new String(byteArr, StandardCharsets.ISO_8859_1));
         assertEquals('6', b.readByte());

--- a/src/test/java/net/openhft/chronicle/bytes/StreamingDataInputTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StreamingDataInputTest.java
@@ -32,20 +32,20 @@ import static org.junit.Assume.assumeFalse;
 @RunWith(Parameterized.class)
 public class StreamingDataInputTest extends BytesTestCommon {
 
-    private BytesType bytesType;
+    private Allocator allocator;
 
-    public StreamingDataInputTest(BytesType bytesType) {
-        this.bytesType = bytesType;
+    public StreamingDataInputTest(Allocator allocator) {
+        this.allocator = allocator;
     }
 
-    @Parameterized.Parameters(name = "bytesType={0}")
+    @Parameterized.Parameters(name = "allocator={0}")
     public static Object[] params() {
-        return Arrays.stream(BytesType.values()).toArray();
+        return Arrays.stream(Allocator.values()).toArray();
     }
 
     @Test
     public void read() {
-        Bytes<?> b = bytesType.createBuffer();
+        Bytes<?> b = allocator.elasticBytes(32);
         b.append("0123456789");
         byte[] byteArr = "ABCDEFGHIJKLMNOP".getBytes();
         b.readPosition(3);
@@ -56,7 +56,7 @@ public class StreamingDataInputTest extends BytesTestCommon {
 
     @Test
     public void readOffset() {
-        Bytes<?> b = bytesType.createBuffer();
+        Bytes<?> b = allocator.elasticBytes(32);
         b.append("0123456789");
         byte[] byteArr = "ABCDEFGHIJKLMNOP".getBytes();
         b.read(byteArr, 2, 6);
@@ -68,7 +68,7 @@ public class StreamingDataInputTest extends BytesTestCommon {
     @Test
     public void roundTripWorksOnHeap() {
         assumeFalse(Jvm.isAzulZing());
-        Bytes<?> b = bytesType.createBuffer();
+        Bytes<?> b = allocator.elasticBytes(32);
         TestObject source = new TestObject(123L, 123, false);
         b.unsafeWriteObject(source, 13);
         TestObject dest = new TestObject();
@@ -90,25 +90,6 @@ public class StreamingDataInputTest extends BytesTestCommon {
             bytes.readWithLength(to);
             assertEquals(len, to.readRemaining());
         }
-    }
-
-    private enum BytesType implements BytesFactory {
-        DIRECT {
-            @Override
-            public Bytes<?> createBuffer() {
-                return Bytes.allocateElasticDirect();
-            }
-        },
-        ON_HEAP {
-            @Override
-            public Bytes<?> createBuffer() {
-                return Bytes.allocateElasticOnHeap();
-            }
-        }
-    }
-
-    interface BytesFactory {
-        Bytes<?> createBuffer();
     }
 
     static class TestObject {


### PR DESCRIPTION
DO NOT MERGE

This cleans up a few things and adds some tests but does not fix the problem exposed by `Allocator.HEAP_BYTES_BYTESSTORE` - see #426 