### PR TITLE
Ensure canonical path is not randomized so it can be used to synchronize on across classloaders. Fixes #443

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/CanonicalPathUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/CanonicalPathUtil.java
@@ -22,25 +22,20 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.SecureRandom;
 
 public final class CanonicalPathUtil {
-
-    // This is unlikely to collide with other internalized strings and is seldom the same across JVMs
-    private static final String PREFIX = CanonicalPathUtil.class.getName() + Math.abs(new SecureRandom().nextInt(1 << 30)) + "::";
 
     private CanonicalPathUtil() {}
 
     /**
-     * Returns an internalized String that is unlikely to collide with other internalized strings in the JVM.
+     * Returns an internalized String that can be used to synchronize on across classloaders
      *
      * @param file to use
      * @return internalized String
      */
     public static String of(@NotNull final File file) {
         try {
-            return (PREFIX + file.getCanonicalPath())
-                    .intern();
+            return file.getCanonicalPath().intern();
         } catch (IOException ioe) {
             throw new IORuntimeException("Unable to obtain the canonical path for " + file.getAbsolutePath(), ioe);
         }


### PR DESCRIPTION


Co-authored-by: Rob Austin <rob.austin@chronicle.software>