### PR TITLE
A test for issue #454 (fails)

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -3404,7 +3404,8 @@ enum BytesInternal {
     }
 
     public static <B extends BytesStore<B, U>, U> BytesStore<B, U> failIfBytesOnBytes(BytesStore<B, U> bytesStore) {
-        if (bytesStore instanceof Bytes) {
+        // MappedBytes don't have a backing BytesStore so we have to allow them to be used this way
+        if (bytesStore instanceof Bytes && ! (bytesStore instanceof MappedBytes)) {
             throw new IllegalArgumentException("A BytesStore is required as backing but a Bytes has been provided: " +
                     bytesStore.getClass().getSimpleName());
         }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
@@ -33,6 +33,7 @@ import java.io.RandomAccessFile;
 import java.nio.BufferOverflowException;
 import java.util.Arrays;
 import java.util.Queue;
+import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
@@ -605,6 +606,41 @@ public class MappedBytesTest extends BytesTestCommon {
         try (MappedBytes mb = MappedBytes.mappedBytes(file, chunkSize, chunkSize / 4)) {
             final long capacity = mb.capacity();
             mb.ensureCapacity(capacity + 1);
+        }
+    }
+
+    @Test
+    public void testBoundaryUnderflow() throws FileNotFoundException {
+        File file = IOTools.createTempFile("boundary-underflow");
+
+        Bytes slice = null;
+        try (MappedBytes mf = MappedBytes.mappedBytes(file, 256L * OS.pageSize(), OS.pageSize())) {
+            slice = mf.bytesForWrite();
+
+            mf.writePosition(0);
+            mf.readPositionRemaining(0, 0);
+            slice.writeLimit(slice.capacity());
+
+            Random rnd = new Random(123456L);
+            for (int i = 0; i < 320000; i++) {
+                int size = 10 + rnd.nextInt(100);
+                byte[] msg = new byte[size];
+                rnd.nextBytes(msg);
+
+                long start = mf.readLimit() + Short.BYTES;
+                long wLim = mf.writeLimit();
+
+                slice.writeLimit(wLim);
+                slice.writePosition(start);
+                slice.readPosition(start);
+                slice.write(msg);
+
+                short msgSize = (short) slice.readRemaining();
+                mf.writeShort(msgSize);
+                mf.writeSkip(msgSize);
+            }
+        } finally {
+            slice.releaseLast();
         }
     }
 }


### PR DESCRIPTION
The issue rears its ugly head - we have a regression where the user scenario no longer works since bytesForWrite() now returns a view of empty heap bytes store (MappedChunkedBytes having no store of its own).

@JerryShea can you please take a look?

See also #457 and #456 