### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
@@ -85,7 +85,7 @@ public class ChunkedMappedFile extends MappedFile {
 
             final Path path = Files.createTempDirectory("warmup");
 
-            final File file = File.createTempFile("delete_warming_up", "me", path.toFile());
+            final File file = Files.createTempFile(path.toFile().toPath(), "delete_warming_up", "me").toFile();
             file.deleteOnExit();
             final long mapAlignment = OS.mapAlignment();
             final int chunks = 64;

--- a/src/test/java/net/openhft/chronicle/bytes/CopyBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CopyBytesTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.BufferOverflowException;
+import java.nio.file.Files;
 
 import static org.junit.Assert.assertEquals;
 
@@ -62,7 +63,7 @@ public class CopyBytesTest extends BytesTestCommon {
     @Test
     public void testCanCopyBytesFromMappedBytes1()
             throws Exception {
-        File bytes = File.createTempFile("mapped-test", "bytes");
+        File bytes = Files.createTempFile("mapped-test", "bytes").toFile();
         bytes.deleteOnExit();
         doTest(MappedBytes.mappedBytes(bytes, 64 << 10, 0), 0);
     }
@@ -70,7 +71,7 @@ public class CopyBytesTest extends BytesTestCommon {
     @Test
     public void testCanCopyBytesFromMappedBytesSingle1()
             throws Exception {
-        File bytes = File.createTempFile("mapped-test", "bytes");
+        File bytes = Files.createTempFile("mapped-test", "bytes").toFile();
         bytes.deleteOnExit();
         doTest(MappedBytes.singleMappedBytes(bytes, 64 << 10), 0);
     }
@@ -78,7 +79,7 @@ public class CopyBytesTest extends BytesTestCommon {
     @Test
     public void testCanCopyBytesFromMappedBytes2()
             throws Exception {
-        File bytes = File.createTempFile("mapped-test", "bytes");
+        File bytes = Files.createTempFile("mapped-test", "bytes").toFile();
         bytes.deleteOnExit();
         doTest(MappedBytes.mappedBytes(bytes, 64 << 10, 0), (64 << 10) - 8);
     }
@@ -86,7 +87,7 @@ public class CopyBytesTest extends BytesTestCommon {
     @Test
     public void testCanCopyBytesFromMappedBytesSingle2()
             throws Exception {
-        File bytes = File.createTempFile("mapped-test", "bytes");
+        File bytes = Files.createTempFile("mapped-test", "bytes").toFile();
         bytes.deleteOnExit();
         doTest(MappedBytes.singleMappedBytes(bytes, 128 << 10), (64 << 10) - 8);
     }
@@ -94,7 +95,7 @@ public class CopyBytesTest extends BytesTestCommon {
     @Test
     public void testCanCopyBytesFromMappedBytes3()
             throws Exception {
-        File bytes = File.createTempFile("mapped-test", "bytes");
+        File bytes = Files.createTempFile("mapped-test", "bytes").toFile();
         bytes.deleteOnExit();
         doTest(MappedBytes.mappedBytes(bytes, 16 << 10, 16 << 10), (64 << 10) - 8);
     }
@@ -102,7 +103,7 @@ public class CopyBytesTest extends BytesTestCommon {
     @Test(expected = BufferOverflowException.class)
     public void testCanCopyBytesFromMappedBytesSingle3()
             throws Exception {
-        File bytes = File.createTempFile("mapped-test", "bytes");
+        File bytes = Files.createTempFile("mapped-test", "bytes").toFile();
         bytes.deleteOnExit();
         doTest(MappedBytes.singleMappedBytes(bytes, 32 << 10), (64 << 10) - 8);
     }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
@@ -23,6 +23,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Consumer;
@@ -66,7 +67,7 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
 
     @Test
     public void testCorrectChunkResolved() throws IOException {
-        final File tempMBFile = File.createTempFile("mapped", "bytes");
+        final File tempMBFile = Files.createTempFile("mapped", "bytes").toFile();
         int chunk = 262144;
         int overlap = 65536;
         try (final MappedBytes bytes = MappedBytes.mappedBytes(tempMBFile, chunk, overlap)) {

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
@@ -31,6 +31,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.BufferOverflowException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Queue;
 import java.util.Random;
@@ -76,7 +77,7 @@ public class MappedBytesTest extends BytesTestCommon {
         byte[] data = new byte[arraySize];
         Arrays.fill(data, (byte) 'x');
 
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 50_000, 40_000);
              MappedBytes bytesR = MappedBytes.mappedBytes(tempFile1, 50_000, 40_000)) {
 
@@ -97,7 +98,7 @@ public class MappedBytesTest extends BytesTestCommon {
     public void testAcquireNextByteStoreShiftingBackwards() throws IOException {
         final long chunkSize = OS.mapAlign(40_000);
 
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, chunkSize, chunkSize)) {
 
             for (int i = 0; i < chunkSize / 4; i++)
@@ -124,7 +125,7 @@ public class MappedBytesTest extends BytesTestCommon {
         byte[] data = new byte[arraySize];
         Arrays.fill(data, (byte) 'x');
 
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 50_000, 30_000);
              MappedBytes bytesR = MappedBytes.mappedBytes(tempFile1, 50_000, 30_000)) {
 
@@ -144,7 +145,7 @@ public class MappedBytesTest extends BytesTestCommon {
     @Test
     public void testWriteBytes()
             throws IOException {
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 4, 4);
              MappedBytes bytesR = MappedBytes.mappedBytes(tempFile1, 200 << 10, 200 << 10)) {
 
@@ -167,7 +168,7 @@ public class MappedBytesTest extends BytesTestCommon {
     @Test
     public void testWriteReadBytes()
             throws IOException {
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 64 << 10, 16 << 10);
              MappedBytes bytesR = MappedBytes.mappedBytes(tempFile1, 64 << 10, 16 << 10)) {
 
@@ -188,7 +189,7 @@ public class MappedBytesTest extends BytesTestCommon {
     @Test
     public void testWriteReadWriteSkipBytes()
             throws IOException {
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 64 << 10, 16 << 10)) {
 
             String hello = "hello";
@@ -205,7 +206,7 @@ public class MappedBytesTest extends BytesTestCommon {
     @Test
     public void testWriteBytesWithOffset()
             throws IOException {
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 4, 4);
              MappedBytes bytesR = MappedBytes.mappedBytes(tempFile1, 200 << 10, 200 << 10)) {
 
@@ -228,7 +229,7 @@ public class MappedBytesTest extends BytesTestCommon {
     @Test
     public void testWriteReadBytesWithOffset()
             throws IOException {
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 64 << 10, 16 << 10);
              MappedBytes bytesR = MappedBytes.mappedBytes(tempFile1, 64 << 10, 16 << 10)) {
 
@@ -251,7 +252,7 @@ public class MappedBytesTest extends BytesTestCommon {
     @Test
     public void testWriteBytesWithOffsetAndTextShift()
             throws IOException {
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 4, 4);
              MappedBytes bytesR = MappedBytes.mappedBytes(tempFile1, 200 << 10, 200 << 10)) {
             int offset = 10;
@@ -274,7 +275,7 @@ public class MappedBytesTest extends BytesTestCommon {
     @Test
     public void testWriteReadBytesWithOffsetAndTextShift()
             throws IOException {
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytesW = MappedBytes.mappedBytes(tempFile1, 64 << 10, 16 << 10);
              MappedBytes bytesR = MappedBytes.mappedBytes(tempFile1, 64 << 10, 16 << 10)) {
             int offset = 10;
@@ -296,7 +297,7 @@ public class MappedBytesTest extends BytesTestCommon {
 
     @Test
     public void testWriteLarge8Bit() throws IOException {
-        File tempFile1 = File.createTempFile("mapped", "bytes");
+        File tempFile1 = Files.createTempFile("mapped", "bytes").toFile();
         try (MappedBytes bytes = MappedBytes.mappedBytes(tempFile1, 64 << 10)) {
             testWrite8Bit(bytes);
         }
@@ -393,7 +394,7 @@ public class MappedBytesTest extends BytesTestCommon {
     @Test
     public void shouldBeReadOnly()
             throws Exception {
-        final File tempFile = File.createTempFile("mapped", "bytes");
+        final File tempFile = Files.createTempFile("mapped", "bytes").toFile();
         try (final RandomAccessFile raf = new RandomAccessFile(tempFile, "rw")) {
             raf.setLength(4096);
             assertTrue(tempFile.setWritable(false));

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.*;
 import java.nio.BufferUnderflowException;
+import java.nio.file.Files;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
@@ -148,7 +149,7 @@ public class MappedFileTest extends BytesTestCommon {
             throws IOException {
         assumeFalse(Runtime.getRuntime().maxMemory() < Integer.MAX_VALUE || OS.isWindows());
 
-        final File file = File.createTempFile("largeReadOnlyFile", "deleteme");
+        final File file = Files.createTempFile("largeReadOnlyFile", "deleteme").toFile();
         file.deleteOnExit();
         try (MappedBytes bytes = MappedBytes.mappedBytes(file, 1 << 30, OS.pageSize())) {
             bytes.writeLong(3L << 30, 0x12345678); // make the file 3 GB.
@@ -165,7 +166,7 @@ public class MappedFileTest extends BytesTestCommon {
         if (Runtime.getRuntime().maxMemory() < Integer.MAX_VALUE || OS.isWindows())
             return;
 
-        final File file = File.createTempFile("largeReadOnlyFile", "deleteme");
+        final File file = Files.createTempFile("largeReadOnlyFile", "deleteme").toFile();
         file.deleteOnExit();
         try (MappedBytes bytes = MappedBytes.singleMappedBytes(file, 4L << 30)) {
             bytes.writeLong(3L << 30, 0x12345678); // make the file 3 GB.
@@ -210,7 +211,7 @@ public class MappedFileTest extends BytesTestCommon {
 
         String text = "Some text to put in this file. yay!\n";
 
-        @NotNull File file = File.createTempFile("readOnlyOpenFile", "deleteme");
+        @NotNull File file = Files.createTempFile("readOnlyOpenFile", "deleteme").toFile();
 
         // write some stuff to a file so it exits using stock java APIs
         @NotNull OutputStreamWriter outWrite = new OutputStreamWriter(new FileOutputStream(file));

--- a/src/test/java/net/openhft/chronicle/bytes/MappedMemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedMemoryTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import static net.openhft.chronicle.bytes.MappedBytes.mappedBytes;
@@ -45,7 +46,7 @@ public class MappedMemoryTest extends BytesTestCommon {
 
         final ReferenceOwner test = ReferenceOwner.temporary("test");
         for (int t = 0; t < 5; t++) {
-            final File tempFile = File.createTempFile("chronicle", "q");
+            final File tempFile = Files.createTempFile("chronicle", "q").toFile();
             try {
 
                 final long startTime = System.nanoTime();
@@ -77,7 +78,7 @@ public class MappedMemoryTest extends BytesTestCommon {
             throws IOException {
 
         for (int t = 0; t < 3; t++) {
-            final File tempFile = File.createTempFile("chronicle", "q");
+            final File tempFile = Files.createTempFile("chronicle", "q").toFile();
             try {
 
                 final long startTime = System.nanoTime();
@@ -102,7 +103,7 @@ public class MappedMemoryTest extends BytesTestCommon {
         final ReferenceOwner test = ReferenceOwner.temporary("test");
 
         for (int t = 0; t < 3; t++) {
-            final File tempFile = File.createTempFile("chronicle", "q");
+            final File tempFile = Files.createTempFile("chronicle", "q").toFile();
             try {
 
                 final long startTime = System.nanoTime();
@@ -134,7 +135,7 @@ public class MappedMemoryTest extends BytesTestCommon {
     public void mappedMemoryTest()
             throws IOException, IORuntimeException {
 
-        final File tempFile = File.createTempFile("chronicle", "q");
+        final File tempFile = Files.createTempFile("chronicle", "q").toFile();
         Bytes<?> bytes0;
         try {
             try (MappedBytes bytes = mappedBytes(tempFile, OS.pageSize())) {
@@ -174,7 +175,7 @@ public class MappedMemoryTest extends BytesTestCommon {
     public void mappedMemoryTestSingle()
             throws IOException, IORuntimeException {
 
-        final File tempFile = File.createTempFile("chronicle", "q");
+        final File tempFile = Files.createTempFile("chronicle", "q").toFile();
         Bytes<?> bytes0;
         try {
             try (MappedBytes bytes = singleMappedBytes(tempFile, OS.pageSize() * 8)) {

--- a/src/test/java/net/openhft/chronicle/bytes/UTF8BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UTF8BytesTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.junit.Assert.assertEquals;
 
@@ -31,7 +32,7 @@ public class UTF8BytesTest extends BytesTestCommon {
     @Test
     public void testUtfEncoding()
             throws IOException {
-        File f = File.createTempFile("testUtfEncoding", "data");
+        File f = Files.createTempFile("testUtfEncoding", "data").toFile();
         f.deleteOnExit();
         final MappedBytes bytes = MappedBytes.mappedBytes(f, 256);
         int len = (int) AppendableUtil.findUtf8Length(MESSAGE);


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
