### PR TITLE
fix BytesStore.copyTo(store) when store has a writePosition != 0

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -370,7 +370,7 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
         throwExceptionIfReleased(store);
         long readPos = readPosition();
         long writePos = store.writePosition();
-        long copy = min(readRemaining(), store.capacity());
+        long copy = min(readRemaining(), store.writeRemaining());
         long i = 0;
         try {
             for (; i < copy - 7; i += 8)

--- a/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
@@ -645,6 +645,30 @@ public class ByteStoreTest extends BytesTestCommon {
     }
 
     @Test
+    public void testCopyToDestOffset() {
+        final BytesStore<?, ?> bytesStoreOriginal = BytesStore.wrap(new byte[SIZE]);
+        try {
+            for (int i = 0; i < SIZE; i++) {
+                final byte randomByte = (byte) i;
+                bytesStoreOriginal.writeByte(i, randomByte);
+            }
+            int destOffset = 2;
+            final Bytes<?> bytesStoreCopy = Bytes.wrapForWrite(new byte[SIZE]);
+            bytesStoreCopy.writePosition(destOffset);
+            try {
+                long bytesCopied = bytesStoreOriginal.copyTo(bytesStoreCopy);
+                assertEquals("Unexpected number of bytes copied", SIZE - destOffset, bytesCopied);
+                for (int i = 0; i < bytesCopied; i++)
+                    assertEquals(bytesStoreOriginal.readByte(i), bytesStoreCopy.readByte(i + destOffset));
+            } finally {
+                bytesStoreCopy.releaseLast();
+            }
+        } finally {
+            bytesStoreOriginal.releaseLast();
+        }
+    }
+
+    @Test
     public void testEmpty() {
         assertEquals(0, BytesStore.empty().realCapacity());
     }


### PR DESCRIPTION
BytesStore.copy(BytesStore) calculated the amount of bytes to copy incorrectly when writePosition != 0