### PR TITLE
Implement ReentrantThreadScopedFileLock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
             <artifactId>jlbh</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>chronicle-test-framework</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/net/openhft/chronicle/bytes/ReentrantThreadScopedFileLock.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ReentrantThreadScopedFileLock.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes;
+
+import net.openhft.chronicle.bytes.internal.CanonicalPathUtil;
+import net.openhft.chronicle.core.Jvm;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A way of acquiring exclusive locks on files in a re-entrant fashion.
+ * <p>
+ * It will avoid {@link OverlappingFileLockException} for threads that share a class-loader, but
+ * they can still occur if there are threads in multiple class loaders taking locks.
+ * <p>
+ * All the usual caveats around file locks apply, shared locks and locks for specific ranges are
+ * not supported.
+ */
+public final class ReentrantThreadScopedFileLock implements AutoCloseable {
+
+    private static final ConcurrentHashMap<String, LockHolder> lockHolders = new ConcurrentHashMap<>();
+
+    private final LockHolder lockHolder;
+
+    private ReentrantThreadScopedFileLock(LockHolder lockHolder) {
+        this.lockHolder = lockHolder;
+    }
+
+    @Override
+    public void close() throws IOException {
+        unlock(lockHolder);
+    }
+
+    /**
+     * Try and take an exclusive lock on the entire file, non-blocking
+     *
+     * @param file        The file to lock
+     * @param fileChannel An open {@link FileChannel to the file}
+     * @return the lock if it was acquired, or null if it could not be acquired
+     * @throws IOException
+     */
+    @Nullable
+    public static ReentrantThreadScopedFileLock tryLock(File file, FileChannel fileChannel) throws IOException {
+        final LockHolder lockHolderForFile = lockHolders.computeIfAbsent(CanonicalPathUtil.of(file), LockHolder::new);
+        final boolean acquired = lockHolderForFile.lock.tryLock();
+        if (acquired) {
+            // If this is the first acquisition for the thread, try and acquire the file lock
+            if (lockHolderForFile.lock.getHoldCount() == 1) {
+                try {
+                    final FileLock fileLock = fileChannel.tryLock();
+                    if (fileLock != null) {
+                        lockHolderForFile.fileLock = fileLock;
+                    } else {
+                        // another process has the file lock, unlock our local lock and return null
+                        lockHolderForFile.lock.unlock();
+                        return null;
+                    }
+                } catch (OverlappingFileLockException e) {
+                    Jvm.warn().on(ReentrantThreadScopedFileLock.class, "Another thread holds a lock on this file directly");
+                    lockHolderForFile.lock.unlock();
+                    return null;
+                } catch (Exception e) {
+                    lockHolderForFile.lock.unlock();
+                    throw e;
+                }
+                return new ReentrantThreadScopedFileLock(lockHolderForFile);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Take an exclusive lock on the entire file, blocks until lock is acquired
+     *
+     * @param file        The file to lock
+     * @param fileChannel An open {@link FileChannel to the file}
+     * @return the lock if it was acquired, or null if it could not be acquired
+     * @throws IOException
+     */
+    public static ReentrantThreadScopedFileLock lock(File file, FileChannel fileChannel) throws IOException {
+        final LockHolder lockHolderForFile = lockHolders.computeIfAbsent(CanonicalPathUtil.of(file), LockHolder::new);
+        lockHolderForFile.lock.lock();
+        // If this is the first entry for the thread, try and acquire the file lock
+        if (lockHolderForFile.lock.getHoldCount() == 1) {
+            try {
+                lockHolderForFile.fileLock = fileChannel.lock();
+            } catch (Exception e) {
+                lockHolderForFile.lock.unlock();
+                throw e;
+            }
+        }
+        return new ReentrantThreadScopedFileLock(lockHolderForFile);
+    }
+
+    public static boolean isLocked(File file) {
+        return lockHolders.computeIfAbsent(CanonicalPathUtil.of(file), LockHolder::new).lock.isLocked();
+    }
+
+    public static boolean isHeldByCurrentThread(File file) {
+        return lockHolders.computeIfAbsent(CanonicalPathUtil.of(file), LockHolder::new).lock.isHeldByCurrentThread();
+    }
+
+    private static void unlock(LockHolder lockHolder) throws IOException {
+        if (!lockHolder.lock.isHeldByCurrentThread()) {
+            Jvm.error().on(ReentrantThreadScopedFileLock.class, "Attempted to unlock a lock not held by us, this is a bug");
+            return;
+        }
+        final int holdCount = lockHolder.lock.getHoldCount();
+        if (holdCount == 1) {
+            try {
+                lockHolder.fileLock.release();
+            } catch (ClosedChannelException e) {
+                Jvm.error().on(ReentrantThreadScopedFileLock.class, "Channel closed while unlocking " + lockHolder.canonicalPath, e);
+            } catch (IOException e) {
+                Jvm.error().on(ReentrantThreadScopedFileLock.class, "Error releasing lock from " + lockHolder.canonicalPath, e);
+                lockHolder.lock.unlock();   // still unlock the process-scoped lock?
+                throw e;
+            }
+        }
+        lockHolder.lock.unlock();
+    }
+
+    private static class LockHolder {
+        private final String canonicalPath;
+        @NotNull
+        private final ReentrantLock lock = new ReentrantLock();
+        @Nullable
+        private FileLock fileLock;
+
+        public LockHolder(String canonicalPath) {
+            this.canonicalPath = canonicalPath;
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/ReentrantThreadScopedFileLockTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ReentrantThreadScopedFileLockTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReentrantThreadScopedFileLockTest extends BytesTestCommon {
+
+    private static final int NUM_THREADS = 4;
+    private static final int NUM_ITERATIONS = 300;
+
+    @Test
+    public void willAcquireLockOnFileWhenAvailable() throws IOException {
+        final File fileToLock = IOTools.createTempFile("fileToLock");
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            final ReentrantThreadScopedFileLock lock = ReentrantThreadScopedFileLock.lock(fileToLock, channel);
+            final ReentrantThreadScopedFileLock secondLock = ReentrantThreadScopedFileLock.lock(fileToLock, channel);
+            assertTrue(ReentrantThreadScopedFileLock.isLocked(fileToLock));
+            assertTrue(ReentrantThreadScopedFileLock.isHeldByCurrentThread(fileToLock));
+            Closeable.closeQuietly(lock);
+            assertTrue(ReentrantThreadScopedFileLock.isLocked(fileToLock));
+            assertTrue(ReentrantThreadScopedFileLock.isHeldByCurrentThread(fileToLock));
+            Closeable.closeQuietly(secondLock);
+            assertFalse(ReentrantThreadScopedFileLock.isLocked(fileToLock));
+            assertFalse(ReentrantThreadScopedFileLock.isHeldByCurrentThread(fileToLock));
+        }
+    }
+
+    @Test
+    public void lockWillThrowOverlappingFileLockExceptionWhenAnOverlappingLockIsHeldDirectly() throws IOException {
+        final File fileToLock = IOTools.createTempFile("fileToLock");
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            final FileLock lock = channel.lock();
+            assertThrows(OverlappingFileLockException.class, () -> ReentrantThreadScopedFileLock.lock(fileToLock, channel));
+            assertFalse(ReentrantThreadScopedFileLock.isLocked(fileToLock));
+        }
+    }
+
+    @Test
+    public void tryLockWillReturnNullWhenAnOverlappingLockIsHeldDirectly() throws IOException {
+        expectException("Another thread holds a lock on this file directly");
+        final File fileToLock = IOTools.createTempFile("fileToLock");
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            final FileLock lock = channel.lock();
+            assertNull(ReentrantThreadScopedFileLock.tryLock(fileToLock, channel));
+            assertFalse(ReentrantThreadScopedFileLock.isLocked(fileToLock));
+        }
+    }
+
+    @Test
+    public void lockWillPropagateOtherExceptionsOnAcquire() throws IOException {
+        final File fileToLock = IOTools.createTempFile("fileToLock");
+        FileChannel closedChannel;
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            closedChannel = channel;
+        }
+        assertThrows(ClosedChannelException.class, () -> ReentrantThreadScopedFileLock.lock(fileToLock, closedChannel));
+        assertFalse(ReentrantThreadScopedFileLock.isLocked(fileToLock));
+    }
+
+    @Test
+    public void tryLockWillPropagateOtherExceptionsOnAcquire() throws IOException {
+        final File fileToLock = IOTools.createTempFile("fileToLock");
+        FileChannel closedChannel;
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            closedChannel = channel;
+        }
+        assertThrows(ClosedChannelException.class, () -> ReentrantThreadScopedFileLock.tryLock(fileToLock, closedChannel));
+        assertFalse(ReentrantThreadScopedFileLock.isLocked(fileToLock));
+    }
+
+    @Test
+    public void unlockWillLogAndUnlockProcessScopedLockOnChannelClosedException() throws IOException {
+        expectException("Channel closed while unlocking");
+        final File fileToLock = IOTools.createTempFile("fileToLock");
+        final ReentrantThreadScopedFileLock rtsfl;
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            rtsfl = ReentrantThreadScopedFileLock.lock(fileToLock, channel);
+        }
+        rtsfl.close();
+        assertFalse(ReentrantThreadScopedFileLock.isLocked(fileToLock));
+    }
+
+    @Test
+    public void providesMutualExclusionBetweenThreadsInAProcess_Lock() throws IOException, InterruptedException {
+        providesMutualExclusionBetweenThreadsInAProcess(false);
+    }
+
+    @Test
+    public void providesMutualExclusionBetweenThreadsInAProcess_TryLock() throws IOException, InterruptedException {
+        providesMutualExclusionBetweenThreadsInAProcess(true);
+    }
+
+    @Test
+    public void providesMutualExclusionBetweenProcesses_Lock() throws IOException {
+        providesMutualExclusionBetweenProcesses(false);
+    }
+
+    @Test
+    public void providesMutualExclusionBetweenProcesses_TryLock() throws IOException {
+        providesMutualExclusionBetweenProcesses(true);
+    }
+
+    private void providesMutualExclusionBetweenThreadsInAProcess(boolean useTryLock) throws IOException, InterruptedException {
+        final File fileToLock = IOTools.createTempFile("fileToLock");
+        ExecutorService executorService = Executors.newFixedThreadPool(NUM_THREADS);
+        List<Future<?>> futures = new ArrayList<>();
+        try {
+            for (int i = 0; i < NUM_THREADS; i++) {
+                futures.add(executorService.submit(new LockerThread(fileToLock.getCanonicalPath(), i, useTryLock)));
+            }
+            futures.forEach(future -> {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    fail(e);
+                }
+            });
+        } finally {
+            executorService.shutdown();
+            assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    private void providesMutualExclusionBetweenProcesses(boolean useTryLock) throws IOException {
+        final File fileToLock = IOTools.createTempFile("fileToLock");
+        List<Process> processes = new ArrayList<>();
+        for (int i = 0; i < NUM_THREADS; i++) {
+            processes.add(JavaProcessBuilder.create(LockerThread.class)
+                    .withProgramArguments(fileToLock.getCanonicalPath(), String.valueOf(i), String.valueOf(useTryLock))
+                    .start());
+        }
+        processes.forEach(future -> {
+            try {
+                int exitValue = future.waitFor();
+                if (exitValue != 0) {
+                    JavaProcessBuilder.printProcessOutput("locker", future);
+                    fail();
+                }
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    private static final class LockerThread implements Runnable {
+
+        private final String filePath;
+        private final int identifier;
+        private final boolean useTryLock;
+        private final ByteBuffer buffer = ByteBuffer.allocate(NUM_THREADS);
+
+        public static void main(String[] args) {
+            new LockerThread(args[0], Integer.parseInt(args[1]), Boolean.parseBoolean(args[2])).run();
+        }
+
+        public LockerThread(String filePath, int identifier, boolean useTryLock) {
+            this.filePath = filePath;
+            this.identifier = identifier;
+            this.useTryLock = useTryLock;
+        }
+
+        @Override
+        public void run() {
+            final File fileToLock = new File(filePath);
+            try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+                int acquiredCount = 0;
+                while (acquiredCount < NUM_ITERATIONS) {
+                    try (final ReentrantThreadScopedFileLock lock = acquireLock(fileToLock, channel)) {
+                        if (lock != null) {
+                            writeIdentifier(channel);
+                            Jvm.pause(ThreadLocalRandom.current().nextInt(5));
+                            final int identifierInFile = readIdentifier(channel);
+                            if (identifierInFile != identifier) {
+                                throw new RuntimeException("Expected " + identifier + " got " + identifierInFile);
+                            }
+                            acquiredCount++;
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private ReentrantThreadScopedFileLock acquireLock(File file, FileChannel fileChannel) throws IOException {
+            if (useTryLock) {
+                return ReentrantThreadScopedFileLock.tryLock(file, fileChannel);
+            } else {
+                return ReentrantThreadScopedFileLock.lock(file, fileChannel);
+            }
+        }
+
+        private int readIdentifier(FileChannel channel) {
+            try {
+                buffer.clear();
+                channel.read(buffer, 0);
+                buffer.flip();
+                return buffer.getInt();
+            } catch (IOException e) {
+                throw new RuntimeException("Couldn't read ID", e);
+            }
+        }
+
+        private void writeIdentifier(FileChannel channel) {
+            try {
+                buffer.clear();
+                buffer.putInt(identifier);
+                buffer.flip();
+                channel.write(buffer, 0);
+            } catch (IOException e) {
+                throw new RuntimeException("Couldn't write ID", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
An approach to fixing https://github.com/OpenHFT/Chronicle-Queue/issues/1291 (see also #488)

This approach attempts to prevent threads from the same VM taking overlapping file locks. Here if two threads attempt to lock the file using `ReentrantThreadScopedLock` the second thread will block until the first thread releases the lock.

This could be dangerous, one example is in `resizeRafIfTooSmall`; there used to be two locks acquired to do a resizeRaf..:

a. The file lock
b. The monitor on the canonical path string

In one execution path in Chronicle-Queue we acquire (a), then (b), then (a) again. This is the cause of https://github.com/OpenHFT/Chronicle-Queue/issues/1291. If two different processes did that it wouldn't introduce a deadlock because the thread holding (b) would throw an `OverlappingFileLockException` when it tried to acquire (a), but with `ReentrantThreadScopedLock` it could result in a deadlock if thread 1 holds (a) and is waiting on (b) while thread 2 holds (b) and is waiting on (a).

I removed the synchronization on the monitor to remove that possiblity. The `ReentrantThreadScopedLock` should provide the same level of safety.

## Limitation
A limitation to this approach is the set of current locks is kept in a static variable in `ReentrantThreadScopedLock` so it won't work for two threads that have loaded `ReentrantThreadScopedLock` from different class loaders. In this scenario, OverlappingFileLockExceptions will still be thrown.

It would have been nicer to use the canonical path string to mutex across class loaders, but there's no way for Java 9+ to do a tryLock on a mutex ([Unsafe.tryMonitorEnter is deprecated in Java 8](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8069302))