### PR TITLE
Implement ReentrantFileLock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
             <artifactId>jlbh</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>chronicle-test-framework</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLock.java
+++ b/src/main/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLock.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes.domestic;
+
+import net.openhft.chronicle.bytes.internal.CanonicalPathUtil;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.threads.CleaningThreadLocal;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.Channel;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.util.HashMap;
+
+import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
+
+/**
+ * A way of acquiring exclusive locks on files in a re-entrant fashion.
+ * <p>
+ * It will prevent a single thread that uses this interface to acquire locks from causing
+ * an {@link OverlappingFileLockException}. Separate threads will not be prevented from taking
+ * overlapping file locks.
+ * <p>
+ * All the usual caveats around file locks apply, shared locks and locks for specific ranges are
+ * not supported.
+ */
+public final class ReentrantFileLock extends FileLock {
+
+    private static final ThreadLocal<HashMap<String, ReentrantFileLock>> heldLocks =
+            CleaningThreadLocal.withCleanup(HashMap::new, h -> closeQuietly(h.values()));
+
+    private final String canonicalPath;
+    private final FileLock delegate;
+    private final long owningThreadId;
+    private int counter;
+
+    public ReentrantFileLock(String canonicalPath, FileLock fileLock) {
+        super(fileLock.channel(), fileLock.position(), fileLock.size(), fileLock.isShared());
+        this.canonicalPath = canonicalPath;
+        this.delegate = fileLock;
+        this.owningThreadId = Thread.currentThread().getId();
+        this.counter = 1;
+    }
+
+    @Override
+    public Channel acquiredBy() {
+        checkThreadAccess();
+        return delegate.acquiredBy();
+    }
+
+    @Override
+    public boolean isValid() {
+        checkThreadAccess();
+        return delegate.isValid();
+    }
+
+    @Override
+    public void release() throws IOException {
+        checkThreadAccess();
+        if (--counter == 0) {
+            try {
+                delegate.release();
+            } finally {
+                heldLocks.get().remove(canonicalPath);
+            }
+        }
+    }
+
+    private ReentrantFileLock incrementCounter() {
+        checkThreadAccess();
+        counter++;
+        return this;
+    }
+
+    /**
+     * Try and take an exclusive lock on the entire file, non-blocking
+     *
+     * @param file        The file to lock
+     * @param fileChannel An open {@link FileChannel to the file}
+     * @return the lock if it was acquired, or null if it could not be acquired
+     * @throws IOException
+     */
+    @Nullable
+    public static ReentrantFileLock tryLock(File file, FileChannel fileChannel) throws IOException {
+        final String canonicalPath = CanonicalPathUtil.of(file);
+        final ReentrantFileLock reentrantFileLock = heldLocks.get().get(canonicalPath);
+        if (reentrantFileLock != null) {
+            return reentrantFileLock.incrementCounter();
+        }
+
+        final FileLock lock = fileChannel.tryLock();
+        if (lock != null) {
+            ReentrantFileLock refl = new ReentrantFileLock(canonicalPath, lock);
+            heldLocks.get().put(canonicalPath, refl);
+            return refl;
+        }
+        return null;
+    }
+
+    /**
+     * Take an exclusive lock on the entire file, blocks until lock is acquired
+     *
+     * @param file        The file to lock
+     * @param fileChannel An open {@link FileChannel to the file}
+     * @return the lock if it was acquired, or null if it could not be acquired
+     * @throws IOException
+     */
+    public static ReentrantFileLock lock(File file, FileChannel fileChannel) throws IOException {
+        final String canonicalPath = CanonicalPathUtil.of(file);
+        final ReentrantFileLock reentrantFileLock = heldLocks.get().get(canonicalPath);
+        if (reentrantFileLock != null) {
+            return reentrantFileLock.incrementCounter();
+        }
+
+        final FileLock lock = fileChannel.lock();
+        ReentrantFileLock refl = new ReentrantFileLock(canonicalPath, lock);
+        heldLocks.get().put(canonicalPath, refl);
+        return refl;
+    }
+
+    /**
+     * Is there a cached FileLock held by the current thread for the specified file
+     *
+     * @param file The file to check
+     * @return true if there is a cached file lock, false otherwise
+     */
+    public static boolean isHeldByCurrentThread(File file) {
+        return heldLocks.get().containsKey(CanonicalPathUtil.of(file));
+    }
+
+    /**
+     * Log an error if someone is passing around ReentrantFileLocks between threads
+     */
+    private void checkThreadAccess() {
+        final long currentThreadId = Thread.currentThread().getId();
+        if (currentThreadId != owningThreadId) {
+            Jvm.error().on(ReentrantFileLock.class, "You're accessing a ReentrantFileLock created by thread " + owningThreadId + " on thread " + currentThreadId + " this can have unexpected results, don't do it.");
+        }
+    }
+}

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
@@ -18,6 +18,7 @@
 package net.openhft.chronicle.bytes.internal;
 
 import net.openhft.chronicle.bytes.*;
+import net.openhft.chronicle.bytes.domestic.ReentrantFileLock;
 import net.openhft.chronicle.core.CleaningRandomAccessFile;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
@@ -25,7 +26,6 @@ import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.ReferenceOwner;
 import net.openhft.chronicle.core.onoes.ExceptionHandler;
-import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import net.openhft.chronicle.core.onoes.ThreadLocalisedExceptionHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -255,7 +255,7 @@ public class ChunkedMappedFile extends MappedFile {
                 size = fileChannel.size();
                 if (size < minSize) {
                     final long beginNs = System.nanoTime();
-                    try (FileLock ignore = fileChannel.lock()) {
+                    try (FileLock ignore = ReentrantFileLock.lock(file(), fileChannel)) {
                         size = fileChannel.size();
                         if (size < minSize) {
                             Jvm.safepoint();

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
@@ -18,6 +18,7 @@
 package net.openhft.chronicle.bytes.internal;
 
 import net.openhft.chronicle.bytes.*;
+import net.openhft.chronicle.bytes.domestic.ReentrantFileLock;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.annotation.NonNegative;
@@ -133,7 +134,7 @@ public class SingleMappedFile extends MappedFile {
                 size = fileChannel.size();
                 if (size < minSize) {
                     final long beginNs = System.nanoTime();
-                    try (FileLock ignore = fileChannel.lock()) {
+                    try (FileLock ignore = ReentrantFileLock.lock(file(), fileChannel)) {
                         size = fileChannel.size();
                         if (size < minSize) {
                             Jvm.safepoint();

--- a/src/test/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLockTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLockTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes.domestic;
+
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReentrantFileLockTest extends BytesTestCommon {
+
+    private static final int NUM_THREADS = 4;
+    private static final int NUM_ITERATIONS = 300;
+    private File fileToLock;
+
+    @BeforeEach
+    public void setUp() {
+        fileToLock = IOTools.createTempFile("fileToLock");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        fileToLock.delete();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void willAcquireLockOnFileWhenAvailableAndReleaseOnLastRelease(boolean useTryLock) throws IOException {
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            final ReentrantFileLock lock = acquireLock(useTryLock, fileToLock, channel);
+            final ReentrantFileLock secondLock = acquireLock(useTryLock, fileToLock, channel);
+            assertTrue(ReentrantFileLock.isHeldByCurrentThread(fileToLock));
+            Closeable.closeQuietly(lock);
+            assertTrue(ReentrantFileLock.isHeldByCurrentThread(fileToLock));
+            Closeable.closeQuietly(secondLock);
+            assertFalse(ReentrantFileLock.isHeldByCurrentThread(fileToLock));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void willThrowOverlappingFileLockExceptionWhenAnOverlappingLockIsHeldDirectly(boolean useTryLock) throws IOException {
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            final FileLock lock = channel.lock();
+            assertThrows(OverlappingFileLockException.class, () -> acquireLock(useTryLock, fileToLock, channel));
+            assertFalse(ReentrantFileLock.isHeldByCurrentThread(fileToLock));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void willPropagateOtherExceptionsOnAcquire(boolean useTryLock) throws IOException {
+        FileChannel closedChannel;
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            closedChannel = channel;
+        }
+        assertThrows(ClosedChannelException.class, () -> acquireLock(useTryLock, fileToLock, closedChannel));
+        assertFalse(ReentrantFileLock.isHeldByCurrentThread(fileToLock));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void unlockWillPropagateChannelClosedExceptionOnUnlock(boolean useTryLock) throws IOException {
+        final ReentrantFileLock rtsfl;
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            rtsfl = acquireLock(useTryLock, fileToLock, channel);
+        }
+        assertThrows(ClosedChannelException.class, rtsfl::close);
+        assertFalse(ReentrantFileLock.isHeldByCurrentThread(fileToLock));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void errorIsLoggedWhenLocksArePassedBetweenThreads(boolean useTryLock) throws IOException, ExecutionException, InterruptedException {
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            final ReentrantFileLock lock = acquireLock(useTryLock, fileToLock, channel);
+            final AtomicLong spawnedThreadId = new AtomicLong();
+            Executors.newSingleThreadExecutor().submit(() -> {
+                spawnedThreadId.set(Thread.currentThread().getId());
+                assertTrue(lock.isValid());
+            }).get();
+            expectException("You're accessing a ReentrantFileLock created by thread " + Thread.currentThread().getId() + " on thread " + spawnedThreadId.get() + " this can have unexpected results, don't do it.");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void providesMutualExclusionBetweenProcesses(boolean useTryLock) throws IOException {
+        List<Process> processes = new ArrayList<>();
+        for (int i = 0; i < NUM_THREADS; i++) {
+            processes.add(JavaProcessBuilder.create(LockerThread.class)
+                    .withProgramArguments(fileToLock.getCanonicalPath(), String.valueOf(i), String.valueOf(useTryLock))
+                    .start());
+        }
+        processes.forEach(future -> {
+            try {
+                int exitValue = future.waitFor();
+                if (exitValue != 0) {
+                    JavaProcessBuilder.printProcessOutput("locker", future);
+                    fail();
+                }
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    @Test
+    public void noLockIsCachedOnFailedTryLock() throws IOException, InterruptedException {
+        final Process processHoldingLock = JavaProcessBuilder.create(LockUntilInterruptedThread.class)
+                .withProgramArguments(fileToLock.getCanonicalPath())
+                .start();
+        try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            while (true) {
+                try (final ReentrantFileLock reentrantFileLock = ReentrantFileLock.tryLock(fileToLock, channel)) {
+                    if (reentrantFileLock == null) {
+                        break;
+                    }
+                }
+            }
+            assertFalse(ReentrantFileLock.isHeldByCurrentThread(fileToLock));
+        } finally {
+            processHoldingLock.destroy();
+            assertTrue(processHoldingLock.waitFor(5, TimeUnit.SECONDS));
+        }
+    }
+
+    private static ReentrantFileLock acquireLock(boolean useTryLock, File file, FileChannel fileChannel) throws IOException {
+        if (useTryLock) {
+            return ReentrantFileLock.tryLock(file, fileChannel);
+        } else {
+            return ReentrantFileLock.lock(file, fileChannel);
+        }
+    }
+
+    private static final class LockUntilInterruptedThread implements Runnable {
+
+        private final String filePath;
+
+        public static void main(String[] args) {
+            new LockUntilInterruptedThread(args[0]).run();
+        }
+
+        public LockUntilInterruptedThread(String filePath) {
+            this.filePath = filePath;
+        }
+
+        @Override
+        public void run() {
+            final File fileToLock = new File(filePath);
+            try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+                int acquiredCount = 0;
+                while (acquiredCount < NUM_ITERATIONS) {
+                    try (final ReentrantFileLock lock = ReentrantFileLock.lock(fileToLock, channel)) {
+                        while (!Thread.currentThread().isInterrupted()) {
+                            Jvm.pause(1);
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static final class LockerThread implements Runnable {
+
+        private final String filePath;
+        private final int identifier;
+        private final boolean useTryLock;
+        private final ByteBuffer buffer = ByteBuffer.allocate(NUM_THREADS);
+
+        public static void main(String[] args) {
+            new LockerThread(args[0], Integer.parseInt(args[1]), Boolean.parseBoolean(args[2])).run();
+        }
+
+        public LockerThread(String filePath, int identifier, boolean useTryLock) {
+            this.filePath = filePath;
+            this.identifier = identifier;
+            this.useTryLock = useTryLock;
+        }
+
+        @Override
+        public void run() {
+            final File fileToLock = new File(filePath);
+            try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+                int acquiredCount = 0;
+                while (acquiredCount < NUM_ITERATIONS) {
+                    try (final ReentrantFileLock lock = acquireLock(useTryLock, fileToLock, channel)) {
+                        if (lock != null) {
+                            writeIdentifier(channel);
+                            Jvm.pause(ThreadLocalRandom.current().nextInt(5));
+                            final int identifierInFile = readIdentifier(channel);
+                            if (identifierInFile != identifier) {
+                                throw new RuntimeException("Expected " + identifier + " got " + identifierInFile);
+                            }
+                            acquiredCount++;
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private int readIdentifier(FileChannel channel) {
+            try {
+                buffer.clear();
+                channel.read(buffer, 0);
+                buffer.flip();
+                return buffer.getInt();
+            } catch (IOException e) {
+                throw new RuntimeException("Couldn't read ID", e);
+            }
+        }
+
+        private void writeIdentifier(FileChannel channel) {
+            try {
+                buffer.clear();
+                buffer.putInt(identifier);
+                buffer.flip();
+                channel.write(buffer, 0);
+            } catch (IOException e) {
+                throw new RuntimeException("Couldn't write ID", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Another approach at fixing https://github.com/OpenHFT/Chronicle-Queue/issues/1291 (See also #487)

This approach doesn't try to prevent you taking OverlappingFileLocks across threads, it merely caches locks you hold in a thread local to prevent a single thread taking an OverlappingFileLock.

It would need to be used with care because if a thread other than the thread that acquired it gets passed the FileLock it will not release the underlying lock correctly on close. So this is not something we want to use by default anywhere, only where we know the lock is opened and closed by the same thread.