### PR TITLE
Fix offset in acquire, inside() method

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1098,7 +1098,7 @@ NOTE: Creating and maintain such tests can be an overhead you don't need. In thi
 == Memory mapped files
 
 Memory mapped files act as Bytes, growing as needed.
-A chunk size is set to determine how much to grwo by as more of the Bytes are used.
+A chunk size is set to determine how much to grow by as more of the Bytes are used.
 A `syncMode` can be set to flush data as each chunk is released.
 
 .Open two MappedBytes for the same region of memory

--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -54,7 +54,6 @@ public abstract class AbstractBytes<U>
         HasUncheckedRandomDataInput {
     @Deprecated(/* remove in x.25 */)
     protected static final boolean DISABLE_THREAD_SAFETY = SingleThreadedChecked.DISABLE_SINGLE_THREADED_CHECK;
-    private static final byte[] EMPTY_ARRAY = new byte[0];
     private static final boolean BYTES_BOUNDS_UNCHECKED = Jvm.getBoolean("bytes.bounds.unchecked", false);
 
     // used for debugging
@@ -218,21 +217,21 @@ public abstract class AbstractBytes<U>
     @Override
     public boolean compareAndSwapInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 4);
+        writeCheckOffset(offset, Integer.BYTES);
         return bytesStore.compareAndSwapInt(offset, expected, value);
     }
 
     @Override
     public void testAndSetInt(@NonNegative long offset, int expected, int value)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 4);
+        writeCheckOffset(offset, Integer.BYTES);
         bytesStore.testAndSetInt(offset, expected, value);
     }
 
     @Override
     public boolean compareAndSwapLong(@NonNegative long offset, long expected, long value)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 8);
+        writeCheckOffset(offset, Long.BYTES);
         return bytesStore.compareAndSwapLong(offset, expected, value);
     }
 
@@ -410,7 +409,7 @@ public abstract class AbstractBytes<U>
     public int readUnsignedByte()
             throws IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(1);
+            long offset = readOffsetPositionMoved(Byte.BYTES);
             return bytesStore.readUnsignedByte(offset);
 
         } catch (BufferUnderflowException e) {
@@ -439,7 +438,7 @@ public abstract class AbstractBytes<U>
     public byte readByte()
             throws IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(1);
+            long offset = readOffsetPositionMoved(Byte.BYTES);
             return bytesStore.readByte(offset);
 
         } catch (BufferUnderflowException e) {
@@ -464,7 +463,7 @@ public abstract class AbstractBytes<U>
     public short readShort()
             throws BufferUnderflowException, IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(2);
+            long offset = readOffsetPositionMoved(Short.BYTES);
             return bytesStore.readShort(offset);
         } catch (BufferUnderflowException e) {
             if (lenient) {
@@ -478,7 +477,7 @@ public abstract class AbstractBytes<U>
     public int readInt()
             throws BufferUnderflowException, IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(4);
+            long offset = readOffsetPositionMoved(Integer.BYTES);
             return bytesStore.readInt(offset);
         } catch (BufferUnderflowException e) {
             if (lenient) {
@@ -491,28 +490,28 @@ public abstract class AbstractBytes<U>
     @Override
     public byte readVolatileByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 1, true);
+        readCheckOffset(offset, Byte.BYTES, true);
         return bytesStore.readVolatileByte(offset);
     }
 
     @Override
     public short readVolatileShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 2, true);
+        readCheckOffset(offset, Short.BYTES, true);
         return bytesStore.readVolatileShort(offset);
     }
 
     @Override
     public int readVolatileInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 4, true);
+        readCheckOffset(offset, Integer.BYTES, true);
         return bytesStore.readVolatileInt(offset);
     }
 
     @Override
     public long readVolatileLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 8, true);
+        readCheckOffset(offset, Long.BYTES, true);
         return bytesStore.readVolatileLong(offset);
     }
 
@@ -520,7 +519,7 @@ public abstract class AbstractBytes<U>
     public long readLong()
             throws BufferUnderflowException, IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(8);
+            long offset = readOffsetPositionMoved(Long.BYTES);
             return bytesStore.readLong(offset);
         } catch (BufferUnderflowException e) {
             if (lenient) {
@@ -534,7 +533,7 @@ public abstract class AbstractBytes<U>
     public float readFloat()
             throws BufferUnderflowException, IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(4);
+            long offset = readOffsetPositionMoved(Float.BYTES);
             return bytesStore.readFloat(offset);
         } catch (BufferUnderflowException e) {
             if (lenient) {
@@ -548,7 +547,7 @@ public abstract class AbstractBytes<U>
     public double readDouble()
             throws BufferUnderflowException, IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(8);
+            long offset = readOffsetPositionMoved(Double.BYTES);
             return bytesStore.readDouble(offset);
         } catch (BufferUnderflowException e) {
             if (lenient) {
@@ -562,7 +561,7 @@ public abstract class AbstractBytes<U>
     public int readVolatileInt()
             throws BufferUnderflowException, IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(4);
+            long offset = readOffsetPositionMoved(Integer.BYTES);
             return bytesStore.readVolatileInt(offset);
         } catch (BufferUnderflowException e) {
             if (lenient) {
@@ -576,7 +575,7 @@ public abstract class AbstractBytes<U>
     public long readVolatileLong()
             throws BufferUnderflowException, IllegalStateException {
         try {
-            long offset = readOffsetPositionMoved(8);
+            long offset = readOffsetPositionMoved(Long.BYTES);
             return bytesStore.readVolatileLong(offset);
         } catch (BufferUnderflowException e) {
             if (lenient) {
@@ -600,7 +599,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeByte(@NonNegative long offset, byte i)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 1);
+        writeCheckOffset(offset, Byte.BYTES);
         bytesStore.writeByte(offset, i);
         return this;
     }
@@ -609,7 +608,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeShort(@NonNegative long offset, short i)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 2);
+        writeCheckOffset(offset, Short.BYTES);
         bytesStore.writeShort(offset, i);
         return this;
     }
@@ -618,7 +617,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 4);
+        writeCheckOffset(offset, Integer.BYTES);
         bytesStore.writeInt(offset, i);
         return this;
     }
@@ -627,7 +626,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeOrderedInt(@NonNegative long offset, int i)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 4);
+        writeCheckOffset(offset, Integer.BYTES);
         bytesStore.writeOrderedInt(offset, i);
         return this;
     }
@@ -636,7 +635,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 8);
+        writeCheckOffset(offset, Long.BYTES);
         bytesStore.writeLong(offset, i);
         return this;
     }
@@ -645,7 +644,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeOrderedLong(@NonNegative long offset, long i)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 8);
+        writeCheckOffset(offset, Long.BYTES);
         bytesStore.writeOrderedLong(offset, i);
         return this;
     }
@@ -654,7 +653,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeFloat(@NonNegative long offset, float d)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 4);
+        writeCheckOffset(offset, Float.BYTES);
         bytesStore.writeFloat(offset, d);
         return this;
     }
@@ -663,7 +662,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeDouble(@NonNegative long offset, double d)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 8);
+        writeCheckOffset(offset, Double.BYTES);
         bytesStore.writeDouble(offset, d);
         return this;
     }
@@ -672,7 +671,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeVolatileByte(@NonNegative long offset, byte i8)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 1);
+        writeCheckOffset(offset, Byte.BYTES);
         bytesStore.writeVolatileByte(offset, i8);
         return this;
     }
@@ -681,7 +680,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeVolatileShort(@NonNegative long offset, short i16)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 2);
+        writeCheckOffset(offset, Short.BYTES);
         bytesStore.writeVolatileShort(offset, i16);
         return this;
     }
@@ -690,7 +689,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeVolatileInt(@NonNegative long offset, int i32)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 4);
+        writeCheckOffset(offset, Integer.BYTES);
         bytesStore.writeVolatileInt(offset, i32);
         return this;
     }
@@ -699,7 +698,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeVolatileLong(@NonNegative long offset, long i64)
             throws BufferOverflowException, IllegalStateException {
-        writeCheckOffset(offset, 8);
+        writeCheckOffset(offset, Long.BYTES);
         bytesStore.writeVolatileLong(offset, i64);
         return this;
     }
@@ -766,10 +765,10 @@ public abstract class AbstractBytes<U>
 
             int i = 0;
             if (bytes.order() == ByteOrder.nativeOrder()) {
-                for (; i < length - 7; i += 8)
+                for (; i < length - 7; i += Long.BYTES)
                     writeLong(offsetInRDO + i, bytes.getLong(offset + i));
             } else {
-                for (; i < length - 7; i += 8)
+                for (; i < length - 7; i += Long.BYTES)
                     writeLong(offsetInRDO + i, Long.reverseBytes(bytes.getLong(offset + i)));
             }
             for (; i < length; i++)
@@ -884,7 +883,7 @@ public abstract class AbstractBytes<U>
     @Override
     public byte readByte(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 1, true);
+        readCheckOffset(offset, Byte.BYTES, true);
         return bytesStore.readByte(offset);
     }
 
@@ -897,35 +896,35 @@ public abstract class AbstractBytes<U>
     @Override
     public short readShort(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 2, true);
+        readCheckOffset(offset, Short.BYTES, true);
         return bytesStore.readShort(offset);
     }
 
     @Override
     public int readInt(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 4, true);
+        readCheckOffset(offset, Integer.BYTES, true);
         return bytesStore.readInt(offset);
     }
 
     @Override
     public long readLong(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 8, true);
+        readCheckOffset(offset, Long.BYTES, true);
         return bytesStore.readLong(offset);
     }
 
     @Override
     public float readFloat(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 4, true);
+        readCheckOffset(offset, Float.BYTES, true);
         return bytesStore.readFloat(offset);
     }
 
     @Override
     public double readDouble(@NonNegative long offset)
             throws BufferUnderflowException, IllegalStateException {
-        readCheckOffset(offset, 8, true);
+        readCheckOffset(offset, Double.BYTES, true);
         return bytesStore.readDouble(offset);
     }
 
@@ -986,7 +985,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(1);
+        long offset = writeOffsetPositionMoved(Byte.BYTES);
         bytesStore.writeByte(offset, i8);
         return this;
     }
@@ -1013,7 +1012,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> prewriteByte(byte i8)
             throws BufferOverflowException, IllegalStateException {
-        long offset = prewriteOffsetPositionMoved(1);
+        long offset = prewriteOffsetPositionMoved(Byte.BYTES);
         bytesStore.writeByte(offset, i8);
         return this;
     }
@@ -1022,7 +1021,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> prewriteInt(int i)
             throws BufferOverflowException, IllegalStateException {
-        long offset = prewriteOffsetPositionMoved(4);
+        long offset = prewriteOffsetPositionMoved(Integer.BYTES);
         bytesStore.writeInt(offset, i);
         return this;
     }
@@ -1031,7 +1030,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> prewriteShort(short i)
             throws BufferOverflowException, IllegalStateException {
-        long offset = prewriteOffsetPositionMoved(2);
+        long offset = prewriteOffsetPositionMoved(Short.BYTES);
         bytesStore.writeShort(offset, i);
         return this;
     }
@@ -1040,7 +1039,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> prewriteLong(long l)
             throws BufferOverflowException, IllegalStateException {
-        long offset = prewriteOffsetPositionMoved(8);
+        long offset = prewriteOffsetPositionMoved(Long.BYTES);
         bytesStore.writeLong(offset, l);
         return this;
     }
@@ -1074,7 +1073,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeShort(short i16)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(2);
+        long offset = writeOffsetPositionMoved(Short.BYTES);
         bytesStore.writeShort(offset, i16);
         return this;
     }
@@ -1083,7 +1082,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeInt(int i)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(4);
+        long offset = writeOffsetPositionMoved(Integer.BYTES);
         bytesStore.writeInt(offset, i);
         return this;
     }
@@ -1092,7 +1091,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeIntAdv(int i, @NonNegative int advance)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(4, advance);
+        long offset = writeOffsetPositionMoved(Integer.BYTES, advance);
         bytesStore.writeInt(offset, i);
         return this;
     }
@@ -1101,7 +1100,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeLong(long i64)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(8);
+        long offset = writeOffsetPositionMoved(Long.BYTES);
         bytesStore.writeLong(offset, i64);
         return this;
     }
@@ -1110,7 +1109,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeLongAdv(long i64, @NonNegative int advance)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(8, advance);
+        long offset = writeOffsetPositionMoved(Long.BYTES, advance);
         bytesStore.writeLong(offset, i64);
         return this;
     }
@@ -1119,7 +1118,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeFloat(float f)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(4);
+        long offset = writeOffsetPositionMoved(Float.BYTES);
         bytesStore.writeFloat(offset, f);
         return this;
     }
@@ -1128,7 +1127,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeDouble(double d)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(8);
+        long offset = writeOffsetPositionMoved(Double.BYTES);
         bytesStore.writeDouble(offset, d);
         return this;
     }
@@ -1137,7 +1136,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeDoubleAndInt(double d, int i)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(12);
+        long offset = writeOffsetPositionMoved(Double.BYTES + Integer.BYTES);
         bytesStore.writeDouble(offset, d);
         bytesStore.writeInt(offset + 8, i);
         return this;
@@ -1220,7 +1219,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeOrderedInt(int i)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(4);
+        long offset = writeOffsetPositionMoved(Integer.BYTES);
         bytesStore.writeOrderedInt(offset, i);
         return this;
     }
@@ -1229,7 +1228,7 @@ public abstract class AbstractBytes<U>
     @Override
     public Bytes<U> writeOrderedLong(long i)
             throws BufferOverflowException, IllegalStateException {
-        long offset = writeOffsetPositionMoved(8);
+        long offset = writeOffsetPositionMoved(Long.BYTES);
         bytesStore.writeOrderedLong(offset, i);
         return this;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -353,18 +353,13 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
 
     /**
      * Returns if a number of bytes starting from an offset are inside this ByteStore limits.
-     * If you are going to write n bytes starting at offset, you need to call this method with buffer=n-1,
-     * as the 1st byte is written at offset, and the last at offset+n-1
-     * <p>
-     * Use this test to determine if an offset is considered safe to write to. Note that it checks we are
-     * inside the BytesStore limits *including* the overlap
      *
      * @param offset the starting index to check
-     * @param buffer the number of bytes after the offset to check
+     * @param bufferSize the number of bytes to be read/written
      * @return <code>true</code> if the bytes between the offset and offset+buffer are inside the BytesStore
      */
-    default boolean inside(@NonNegative long offset, @NonNegative long buffer) {
-        return start() <= offset && offset + buffer < safeLimit();
+    default boolean inside(@NonNegative long offset, @NonNegative long bufferSize) {
+        return start() <= offset && offset + bufferSize <= safeLimit();
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
@@ -110,9 +110,9 @@ public class MappedBytesStore extends NativeBytesStore<Void> {
     }
 
     @Override
-    public boolean inside(@NonNegative long offset, @NonNegative long buffer) {
-        // yes this is different than the method above
-        return start <= offset && offset + buffer < limit;
+    public boolean inside(@NonNegative long offset, @NonNegative long bufferSize) {
+        // yes this is different to the method above (we take into account the overlap because we know the length)
+        return start <= offset && offset + bufferSize <= limit;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/NoBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NoBytesStore.java
@@ -303,8 +303,8 @@ public enum NoBytesStore implements BytesStore {
     }
 
     @Override
-    public boolean inside(@NonNegative long offset, @NonNegative long buffer) {
-        return false;
+    public boolean inside(@NonNegative long offset, @NonNegative long bufferSize) {
+        return offset == 0 && bufferSize == 0;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
@@ -15,25 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-    /*
-     * Copyright 2016-2020 chronicle.software
-     *
-     *       https://chronicle.software
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
-
-    package net.openhft.chronicle.bytes;
+package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.bytes.internal.NativeBytesStore;
@@ -52,688 +34,688 @@ import java.nio.ByteBuffer;
 import static net.openhft.chronicle.core.util.Longs.requireNonNegative;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
+/**
+ * Simple Bytes implementation which is not Elastic.
+ *
+ * @param <U> Underlying type
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class VanillaBytes<U>
+        extends AbstractBytes<U>
+        implements Byteable<Bytes<U>, U>, Comparable<CharSequence> {
+
+    protected VanillaBytes(@NotNull BytesStore bytesStore)
+            throws IllegalStateException, IllegalArgumentException {
+        this(bytesStore, bytesStore.writePosition(), bytesStore.writeLimit());
+    }
+
+    public static <U> VanillaBytes<U> wrap(BytesStore<?, U> bytesStore) {
+        return new VanillaBytes<>(bytesStore);
+    }
+
+    protected VanillaBytes(@NotNull BytesStore bytesStore, long writePosition, long writeLimit)
+            throws IllegalStateException, IllegalArgumentException {
+        super(bytesStore, writePosition, writeLimit);
+    }
+
     /**
-     * Simple Bytes implementation which is not Elastic.
+     * Return a VanillaBytes which can have it's bytesStore() replaced as needed.
      *
-     * @param <U> Underlying type
+     * @return a non-elastic bytes with noByteStore()
      */
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public class VanillaBytes<U>
-            extends AbstractBytes<U>
-            implements Byteable<Bytes<U>, U>, Comparable<CharSequence> {
+    @NotNull
+    public static VanillaBytes<Void> vanillaBytes() {
+        try {
+            return new NativeBytes<>(BytesStore.empty());
 
-        protected VanillaBytes(@NotNull BytesStore bytesStore)
-                throws IllegalStateException, IllegalArgumentException {
-            this(bytesStore, bytesStore.writePosition(), bytesStore.writeLimit());
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            throw new AssertionError(e);
         }
+    }
 
-        public static <U> VanillaBytes<U> wrap(BytesStore<?, U> bytesStore) {
-            return new VanillaBytes<>(bytesStore);
-        }
+    @Java9
+    private static boolean isEqual0(byte[] bytes, byte coder, @NotNull NativeBytesStore bs, long address) {
 
-        protected VanillaBytes(@NotNull BytesStore bytesStore, long writePosition, long writeLimit)
-                throws IllegalStateException, IllegalArgumentException {
-            super(bytesStore, writePosition, writeLimit);
-        }
+        @Nullable Memory memory = bs.memory;
 
-        /**
-         * Return a VanillaBytes which can have it's bytesStore() replaced as needed.
-         *
-         * @return a non-elastic bytes with noByteStore()
-         */
-        @NotNull
-        public static VanillaBytes<Void> vanillaBytes() {
-            try {
-                return new NativeBytes<>(BytesStore.empty());
+        if (coder == 0) {
+            int i = 0;
+            for (; i < bytes.length; i++) {
+                byte b = memory.readByte(address + i);
+                char c = (char) (bytes[i] & 0xFF);
+                if (b != c) {
+                    return false;
+                }
+            }
+        } else {
+            int i = 0;
+            for (; i < bytes.length; i++) {
+                byte b = memory.readByte(address + i);
+                char c = (char) (((bytes[i + 1] & 0xFF) << 8) | (bytes[i] & 0xFF));
 
-            } catch (IllegalStateException | IllegalArgumentException e) {
-                throw new AssertionError(e);
+                if (b != c) {
+                    return false;
+                }
             }
         }
 
-        @Java9
-        private static boolean isEqual0(byte[] bytes, byte coder, @NotNull NativeBytesStore bs, long address) {
+        return true;
+    }
 
-            @Nullable Memory memory = bs.memory;
+    private static boolean isEqual0(char[] chars, @NotNull NativeBytesStore bs, long address) {
+
+        @Nullable Memory memory = bs.memory;
+        int i = 0;
+        for (; i < chars.length - 3; i += 4) {
+            int b = memory.readInt(address + i);
+            int b0 = b & 0xFF;
+            int b1 = (b >> 8) & 0xFF;
+            int b2 = (b >> 16) & 0xFF;
+            int b3 = (b >> 24) & 0xFF;
+            if (b0 != chars[i] || b1 != chars[i + 1] || b2 != chars[i + 2] || b3 != chars[i + 3])
+                return false;
+        }
+        for (; i < chars.length; i++) {
+            int b = memory.readByte(address + i) & 0xFF;
+            if (b != chars[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    private static boolean isEqual1(char[] chars, @NotNull BytesStore bytesStore, @NonNegative long readPosition)
+            throws BufferUnderflowException, IllegalStateException {
+        for (int i = 0; i < chars.length; i++) {
+            int b = bytesStore.readByte(readPosition + i) & 0xFF;
+            if (b != chars[i])
+                return false;
+        }
+        return true;
+    }
+
+    @Java9
+    private static boolean isEqual1(byte[] bytes, byte coder, @NotNull BytesStore bytesStore, @NonNegative long readPosition)
+            throws BufferUnderflowException, IllegalStateException {
+        for (int i = 0; i < bytes.length; i++) {
+            int b = bytesStore.readByte(readPosition + i) & 0xFF;
+            char c;
 
             if (coder == 0) {
-                int i = 0;
-                for (; i < bytes.length; i++) {
-                    byte b = memory.readByte(address + i);
-                    char c = (char) (bytes[i] & 0xFF);
-                    if (b != c) {
-                        return false;
-                    }
-                }
+                c = (char) (bytes[i] & 0xFF);
             } else {
-                int i = 0;
-                for (; i < bytes.length; i++) {
-                    byte b = memory.readByte(address + i);
-                    char c = (char) (((bytes[i + 1] & 0xFF) << 8) | (bytes[i] & 0xFF));
-
-                    if (b != c) {
-                        return false;
-                    }
-                }
+                c = (char) (((bytes[i + 1] & 0xFF) << 8) | (bytes[i] & 0xFF));
+                i++;
             }
 
-            return true;
+            if (b != c)
+                return false;
         }
-
-        private static boolean isEqual0(char[] chars, @NotNull NativeBytesStore bs, long address) {
-
-            @Nullable Memory memory = bs.memory;
-            int i = 0;
-            for (; i < chars.length - 3; i += 4) {
-                int b = memory.readInt(address + i);
-                int b0 = b & 0xFF;
-                int b1 = (b >> 8) & 0xFF;
-                int b2 = (b >> 16) & 0xFF;
-                int b3 = (b >> 24) & 0xFF;
-                if (b0 != chars[i] || b1 != chars[i + 1] || b2 != chars[i + 2] || b3 != chars[i + 3])
-                    return false;
-            }
-            for (; i < chars.length; i++) {
-                int b = memory.readByte(address + i) & 0xFF;
-                if (b != chars[i])
-                    return false;
-            }
-
-            return true;
-        }
-
-        private static boolean isEqual1(char[] chars, @NotNull BytesStore bytesStore, @NonNegative long readPosition)
-                throws BufferUnderflowException, IllegalStateException {
-            for (int i = 0; i < chars.length; i++) {
-                int b = bytesStore.readByte(readPosition + i) & 0xFF;
-                if (b != chars[i])
-                    return false;
-            }
-            return true;
-        }
-
-        @Java9
-        private static boolean isEqual1(byte[] bytes, byte coder, @NotNull BytesStore bytesStore, @NonNegative long readPosition)
-                throws BufferUnderflowException, IllegalStateException {
-            for (int i = 0; i < bytes.length; i++) {
-                int b = bytesStore.readByte(readPosition + i) & 0xFF;
-                char c;
-
-                if (coder == 0) {
-                    c = (char) (bytes[i] & 0xFF);
-                } else {
-                    c = (char) (((bytes[i + 1] & 0xFF) << 8) | (bytes[i] & 0xFF));
-                    i++;
-                }
-
-                if (b != c)
-                    return false;
-            }
-            return true;
-        }
-
-        @Override
-        public long readVolatileLong(@NonNegative long offset)
-                throws BufferUnderflowException, IllegalStateException {
-            readCheckOffset(offset, 8, true);
-            return bytesStore.readVolatileLong(offset);
-        }
-
-        @Override
-        public void bytesStore(final @NotNull BytesStore<Bytes<U>, U> byteStore,
-                               final @NonNegative long offset,
-                               final @NonNegative long length)
-                throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
-            requireNonNull(byteStore);
-            setBytesStore(byteStore);
-            // assume its read-only
-            readLimit(offset + length);
-            readPosition(offset);
-            try {
-                writeLimit(offset + length);
-            } catch (BufferOverflowException e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        private void setBytesStore(@NotNull BytesStore<Bytes<U>, U> bytesStore)
-                throws IllegalStateException, IllegalArgumentException {
-            if (this.bytesStore != bytesStore) {
-                @Nullable BytesStore oldBS = this.bytesStore;
-                this.bytesStore(bytesStore);
-                bytesStore.reserve(this);
-                oldBS.release(this);
-            }
-            clear();
-        }
-
-        @Override
-        public long offset() {
-            return readPosition();
-        }
-
-        @Override
-        public long maxSize() {
-            return readRemaining();
-        }
-
-        @Override
-        public boolean isElastic() {
-            return false;
-        }
-
-        @NotNull
-        @Override
-        public Bytes<U> bytesForRead()
-                throws IllegalStateException {
-            throwExceptionIfReleased();
-            try {
-                return isClear()
-                        ? new VanillaBytes<>(bytesStore, writePosition(), bytesStore.writeLimit())
-                        : new SubBytes<>(bytesStore, readPosition(), readLimit());
-            } catch (IllegalArgumentException | BufferUnderflowException e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        @Override
-        public boolean isEqual(@Nullable String other)
-                throws IllegalStateException {
-            if (other == null || other.length() != readRemaining()) return false;
-            ReportUnoptimised.reportOnce();
-
-            long realLength = realReadRemaining();
-            try {
-                if (Jvm.isJava9Plus()) {
-                    byte[] bytes = StringUtils.extractBytes(other);
-                    byte coder = StringUtils.getStringCoder(other);
-                    if (bytesStore instanceof NativeBytesStore && realLength == readRemaining()) {
-                        @NotNull NativeBytesStore bs = (NativeBytesStore) this.bytesStore;
-                        long address = bs.addressForRead(readPosition);
-                        return isEqual0(bytes, coder, bs, address);
-
-                    } else {
-                        return isEqual1(bytes, coder, bytesStore, readPosition);
-                    }
-                } else {
-                    char[] chars = StringUtils.extractChars(other);
-                    if (bytesStore instanceof NativeBytesStore && realLength == readRemaining()) {
-                        @NotNull NativeBytesStore bs = (NativeBytesStore) this.bytesStore;
-                        long address = bs.addressForRead(readPosition);
-                        return isEqual0(chars, bs, address);
-
-                    } else {
-                        return isEqual1(chars, bytesStore, readPosition);
-                    }
-                }
-            } catch (BufferUnderflowException e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        @Override
-        public @NonNegative long realCapacity() {
-            return bytesStore.realCapacity();
-        }
-
-        @Override
-        public long findByte(byte stopByte) throws IllegalStateException {
-            return BytesInternal.findByte(this, stopByte);
-        }
-
-        @Override
-        public long parseLong() throws BufferUnderflowException, IllegalStateException {
-            return BytesInternal.parseLong(this);
-        }
-
-        @NotNull
-        @Override
-        public BytesStore<Bytes<U>, U> copy()
-                throws IllegalStateException {
-            throwExceptionIfReleased();
-            ReportUnoptimised.reportOnce();
-
-            if (bytesStore.underlyingObject() instanceof ByteBuffer) {
-                try {
-                    ByteBuffer bb = ByteBuffer.allocateDirect(Maths.toInt32(readRemaining()));
-                    @NotNull ByteBuffer bbu = (ByteBuffer) bytesStore.underlyingObject();
-                    ByteBuffer slice = bbu.slice();
-                    slice.position((int) readPosition());
-                    slice.limit((int) readLimit());
-                    bb.put(slice);
-                    bb.clear();
-                    return (BytesStore) BytesStore.wrap(bb);
-                } catch (ArithmeticException e) {
-                    throw new AssertionError(e);
-                }
-            } else {
-                return (BytesStore) BytesUtil.copyOf(this);
-            }
-        }
-
-        @NotNull
-        @Override
-        public Bytes<U> write(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
-                throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
-            requireNonNull(bytes);
-            if ((offset | length) < 0) {
-                requireNonNegative(offset);
-                requireNonNegative(length);
-            }
-            ensureCapacity(writePosition() + length);
-            optimisedWrite(bytes, offset, length);
-            return this;
-        }
-
-        protected void optimisedWrite(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
-                throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
-            requireNonNull(bytes);
-            if (length <= safeCopySize() && isDirectMemory() && bytes.isDirectMemory()) {
-                long len = Math.min(writeRemaining(), Math.min(bytes.capacity() - offset, length));
-                if (len > 0) {
-                    writeCheckOffset(writePosition(), len);
-                    long address = bytes.addressForRead(offset);
-                    long address2 = addressForWritePosition();
-                    assert address != 0;
-                    assert address2 != 0;
-                    OS.memory().copyMemory(address, address2, len);
-                    writeSkip(len);
-                }
-            } else {
-                super.write(bytes, offset, length);
-            }
-        }
-
-        public void write(long position, @NotNull CharSequence str, @NonNegative int offset, @NonNegative int length)
-                throws BufferOverflowException, IllegalArgumentException, ArithmeticException, IllegalStateException, BufferUnderflowException {
-            requireNonNull(str);
-            if ((offset | length | position) < 0) {
-                requireNonNegative(position);
-                requireNonNegative(offset);
-                requireNonNegative(length);
-            }
-
-            ensureCapacity(writePosition() + length);
-            if (offset + length > str.length())
-                throw new IllegalArgumentException("offset=" + offset + " + length=" + length + " > str.length =" + str.length());
-
-            for (int i = 0; i < length; i++) {
-                int index = offset + i;
-                bytesStore.writeByte(position + i, charAt(str, index));
-            }
-        }
-
-        private char charAt(@NotNull CharSequence str, @NonNegative int index) {
-            return str.charAt(index);
-        }
-
-        @Override
-        @NotNull
-        public VanillaBytes append(@NotNull CharSequence str, @NonNegative int start, @NonNegative int end)
-                throws IndexOutOfBoundsException {
-            assert end > start : "end=" + end + ",start=" + start;
-            requireNonNull(str);
-            try {
-                if (isDirectMemory()) {
-                    if (str instanceof BytesStore) {
-
-                        write((BytesStore) str, start, (long) end - start);
-                        return this;
-                    }
-                    if (str instanceof String) {
-                        if (Jvm.isJava9Plus()) {
-                            byte coder = StringUtils.getStringCoder((String) str);
-                            appendUtf8(StringUtils.extractBytes((String) str), start, end - start, coder);
-                        } else {
-                            appendUtf8(StringUtils.extractChars((String) str), start, end - start);
-                        }
-
-                        return this;
-                    }
-                }
-                ReportUnoptimised.reportOnce();
-                super.append(str, start, end);
-                return this;
-
-            } catch (Exception e) {
-                final IndexOutOfBoundsException ioobe = new IndexOutOfBoundsException(e.toString());
-                ioobe.initCause(e);
-                throw ioobe;
-            }
-        }
-
-        @NotNull
-        @Override
-        public VanillaBytes appendUtf8(@NotNull CharSequence str)
-                throws BufferOverflowException {
-            requireNonNull(str);
-            ReportUnoptimised.reportOnce();
-            try {
-                if (isDirectMemory()) {
-                    if (str instanceof BytesStore) {
-                        write((BytesStore) str, 0L, str.length());
-                        return this;
-                    }
-                    if (str instanceof String) {
-                        if (Jvm.isJava9Plus()) {
-                            String str1 = (String) str;
-                            byte coder = StringUtils.getStringCoder(str1);
-                            appendUtf8(StringUtils.extractBytes(str1), 0, str.length(), coder);
-                        } else {
-                            appendUtf8(StringUtils.extractChars((String) str), 0, str.length());
-                        }
-                        return this;
-                    }
-                }
-                super.append(str, 0, str.length());
-                return this;
-
-            } catch (Exception e) {
-                @NotNull BufferOverflowException e2 = new BufferOverflowException();
-                e2.initCause(e);
-                throw e2;
-            }
-        }
-
-        @Override
-        @NotNull
-        public Bytes<U> append8bit(@NotNull CharSequence cs)
-                throws BufferOverflowException, BufferUnderflowException, IndexOutOfBoundsException, IllegalStateException {
-            requireNonNull(cs);
-            if (cs instanceof RandomDataInput)
-                return write((RandomDataInput) cs);
-
-            if (isDirectMemory() && cs instanceof String && this.bytesStore instanceof NativeBytesStore)
-                return append8bitNBSS((String) cs);
-
-            return append8bit0(cs);
-        }
-
-        @Override
-        @NotNull
-        public Bytes<U> append8bit(@NotNull BytesStore bs)
-                throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
-            long remaining = bs.readLimit() - bs.readPosition();
-            return write0(bs, 0L, remaining);
-        }
-
-        @NotNull
-        @Override
-        public Bytes<U> write(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
-                throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
-            requireNonNull(bytes);
-            if ((offset | length) < 0) {
-                requireNonNegative(offset);
-                requireNonNegative(length);
-            }
-            return write0(bytes, offset, length);
-        }
-
-        @NotNull
-        private VanillaBytes<U> write0(@NotNull BytesStore bytes, long offset, long length) {
-            ensureCapacity(writePosition() + length);
-            if (length == (int) length) {
-                if (bytes.canReadDirect(length) && canWriteDirect(length)) {
-                    long wAddr = addressForWritePosition();
-                    writeSkip(length);
-                    long rAddr = bytes.addressForRead(offset);
-                    UnsafeMemory.copyMemory(rAddr, wAddr, (int) length);
-                    return this;
-
-                } else {
-                    bytesStore.write(writePosition(), bytes.bytesStore(), offset, length);
-                    uncheckedWritePosition(writePosition() + length);
-                    return this;
-                }
-            }
-            ReportUnoptimised.reportOnce();
-            BytesInternal.writeFully(bytes, offset, length, this);
-            return this;
-        }
-
-        @Override
-        @NotNull
-        public Bytes<U> append8bit(@NotNull String cs)
-                throws BufferOverflowException, IllegalStateException {
-            requireNonNull(cs);
-            if (isDirectMemory())
-                return append8bitNBSS(cs);
-            return append8bit0(cs);
-        }
-
-        @NotNull
-        private Bytes<U> append8bitNBSS(@NotNull String s)
-                throws BufferOverflowException, IllegalStateException {
-            int length = s.length();
-            long offset = writeOffsetPositionMoved(length); // can re-assign the byteStore if not large enough.
-            // only valid after the previous call
-            NativeBytesStore bytesStore = (NativeBytesStore) this.bytesStore;
-            final long address = bytesStore.address + bytesStore.translate(offset);
-            @Nullable final Memory memory = bytesStore.memory;
-
-            if (memory == null) {
-                bytesStore.throwExceptionIfReleased();
-                throw new NullPointerException("byteStore.memory is null.");
-            }
-
-            if (Jvm.isJava9Plus()) {
-                final byte[] chars = StringUtils.extractBytes(s);
-
-                int i;
-                for (i = 0; i < length; i++) {
-                    memory.writeByte(address + i, chars[i]);
-                }
-            } else {
-                final char[] chars = StringUtils.extractChars(s);
-                int i;
-                for (i = 0; i < length - 3; i += 4) {
-                    int c0 = chars[i] & 0xFF;
-                    int c1 = chars[i + 1] & 0xFF;
-                    int c2 = chars[i + 2] & 0xFF;
-                    int c3 = chars[i + 3] & 0xFF;
-                    memory.writeInt(address + i, c0 | (c1 << 8) | (c2 << 16) | (c3 << 24));
-                }
-                for (; i < length; i++) {
-                    int c0 = chars[i];
-                    memory.writeByte(address + i, (byte) c0);
-                }
-            }
-            return this;
-        }
-
-        @Override
-        @NotNull
-        public String toString() {
-            // Reserving prevents access to this Bytes object if released by another thread
-            reserve(this);
-            try {
-                return bytesStore instanceof NativeBytesStore
-                        ? toString2((NativeBytesStore) bytesStore)
-                        : toString0();
-            } catch (IllegalStateException e) {
-                throw Jvm.rethrow(e);
-            } finally {
-                release(this);
-            }
-        }
-
-        private String toString2(@NotNull NativeBytesStore bytesStore) {
-            @Nullable final Memory memory = bytesStore.memory;
-            int length = (int)
-                    Math.min(Bytes.MAX_HEAP_CAPACITY, realReadRemaining());
-            @NotNull char[] chars = new char[length];
-            final long address = bytesStore.address + bytesStore.translate(readPosition());
-            for (int i = 0; i < length && i < realCapacity(); i++)
-                chars[i] = (char) (memory.readByte(address + i) & 0xFF);
-
-            return StringUtils.newString(chars);
-        }
-
-        @NotNull
-        protected String toString0()
-                throws IllegalStateException {
-            int length = (int) Math.min(Bytes.MAX_HEAP_CAPACITY, readRemaining());
-            @NotNull char[] chars = new char[length];
-            try {
-                for (int i = 0; i < length; i++) {
-                    chars[i] = (char) (bytesStore.readByte(readPosition() + i) & 0xFF);
-                }
-            } catch (BufferUnderflowException e) {
-                // ignored
-            }
-            return StringUtils.newString(chars);
-        }
-
-        @NotNull
-        protected Bytes<U> append8bit0(@NotNull CharSequence cs)
-                throws BufferOverflowException, IllegalStateException {
-            int length = cs.length();
-            long offset = writeOffsetPositionMoved(length);
-            for (int i = 0; i < length; i++) {
-                char c = charAt(cs, i);
-                if (c > 255) c = '?';
-                bytesStore.writeByte(offset + i, (byte) c);
-            }
-            return this;
-        }
-
-        @Override
-        public boolean equalBytes(@NotNull BytesStore bytesStore, long length)
-                throws BufferUnderflowException, IllegalStateException {
-            requireNonNull(bytesStore);
-            ReportUnoptimised.reportOnce();
-            if (length < 0) throw new IllegalArgumentException();
-
-            if (isDirectMemory() &&
-                    bytesStore instanceof VanillaBytes &&
-                    bytesStore.isDirectMemory()) {
-                @NotNull VanillaBytes b2 = (VanillaBytes) bytesStore;
-                @NotNull NativeBytesStore nbs0 = (NativeBytesStore) this.bytesStore;
-                @Nullable NativeBytesStore nbs2 = (NativeBytesStore) b2.bytesStore();
-                long i = 0;
-                for (; i < length - 7; i += 8) {
-                    long addr0 = nbs0.address + readPosition() - nbs0.start() + i;
-                    long addr2 = nbs2.address + b2.readPosition() - nbs2.start() + i;
-                    long l0 = nbs0.memory.readLong(addr0);
-                    long l2 = nbs2.memory.readLong(addr2);
-                    if (l0 != l2)
-                        return false;
-                }
-                for (; i < length; i++) {
-                    long offset2 = readPosition() + i - nbs0.start();
-                    long offset21 = b2.readPosition() + i - nbs2.start();
-                    byte b0 = nbs0.memory.readByte(nbs0.address + offset2);
-                    byte b1 = nbs2.memory.readByte(nbs2.address + offset21);
-                    if (b0 != b1)
-                        return false;
-                }
-                return true;
-            } else {
-                return super.equalBytes(bytesStore, length);
-            }
-        }
-
-        public void read8Bit(char[] chars, @NonNegative int length)
-                throws BufferUnderflowException, IllegalStateException {
-            ReportUnoptimised.reportOnce();
-
-            if (isDirectMemory()) {
-                long position = readPosition();
-                @NotNull NativeBytesStore nbs = (NativeBytesStore) bytesStore();
-                nbs.read8bit(position, chars, length);
-            } else {
-                long pos = this.readPosition();
-                for (int i = 0; i < length; i++)
-                    chars[i] = (char) this.readUnsignedByte(pos + i);
-            }
-        }
-
-        // TODO: protected?
-        @Override
-        public int byteCheckSum(@NonNegative int start, @NonNegative int end)
-                throws IORuntimeException, BufferUnderflowException {
-            byte b = 0;
-            // the below cast is safe as should only be called from net.openhft.chronicle.bytes.AbstractBytes.byteCheckSum(long, long)
-            @Nullable final NativeBytesStore bytesStore = (NativeBytesStore) bytesStore();
-            @Nullable final Memory memory = bytesStore.memory;
-            assert memory != null;
-            final long addr = bytesStore.addressForRead(start);
-            int i = 0;
-            final int len = end - start;
-            for (; i < len - 3; i += 4) {
-                b += memory.readByte(addr + i)
-                        + memory.readByte(addr + i + 1)
-                        + memory.readByte(addr + i + 2)
-                        + memory.readByte(addr + i + 3);
-            }
-            for (; i < len; i++) {
-                b += memory.readByte(addr + i);
-            }
-            return b & 0xFF;
-        }
-
-        @NotNull
-        @Override
-        public Bytes<U> appendUtf8(char[] chars, @NonNegative int offset, @NonNegative int length)
-                throws BufferOverflowException, IllegalStateException, BufferUnderflowException, IllegalArgumentException {
-            long actualUTF8Length = AppendableUtil.findUtf8Length(chars, offset, length);
-            ensureCapacity(writePosition() + actualUTF8Length);
-            if (bytesStore instanceof NativeBytesStore) {
-                @Nullable NativeBytesStore nbs = (NativeBytesStore) this.bytesStore;
-                long position = nbs.appendUtf8(writePosition(), chars, offset, length);
-                writePosition(position);
-            } else {
-                ReportUnoptimised.reportOnce();
-                super.appendUtf8(chars, offset, length);
-            }
-            return this;
-        }
-
-        @Override
-        public ByteBuffer toTemporaryDirectByteBuffer()
-                throws IllegalArgumentException, ArithmeticException, IllegalStateException {
-            throwExceptionIfReleased();
-            if (isClear())
-                return bytesStore.toTemporaryDirectByteBuffer();
-            return super.toTemporaryDirectByteBuffer();
-        }
-
-        @Override
-        public int read(byte[] bytes)
-                throws BufferUnderflowException, IllegalStateException {
-            requireNonNull(bytes);
-            ReportUnoptimised.reportOnce();
-
-            int len = (int) Math.min(bytes.length, readRemaining());
-            if (bytesStore instanceof NativeBytesStore) {
-                @Nullable NativeBytesStore nbs = (NativeBytesStore) this.bytesStore;
-                long len2 = nbs.read(readPosition(), bytes, 0, len);
-                try {
-                    readSkip(len2);
-                } catch (BufferUnderflowException e) {
-                    throw new AssertionError(e);
-                }
-                return (int) (len2);
-            }
-            return super.read(bytes);
-        }
-
-        @Override
-        public int compareTo(@NotNull CharSequence cs) {
-            long len1 = readRemaining();
-            int len2 = cs.length();
-            long lim = Math.min(len1, len2);
-
-            int k = 0;
-            while (k < lim) {
-                char c1 = charAt(bytesStore, k);
-                char c2 = charAt(cs, k);
-                if (c1 != c2) {
-                    return c1 - c2;
-                }
-                k++;
-            }
-            return (int) (len1 - len2);
-        }
-
+        return true;
     }
+
+    @Override
+    public long readVolatileLong(@NonNegative long offset)
+            throws BufferUnderflowException, IllegalStateException {
+        readCheckOffset(offset, Long.BYTES, true);
+        return bytesStore.readVolatileLong(offset);
+    }
+
+    @Override
+    public void bytesStore(final @NotNull BytesStore<Bytes<U>, U> byteStore,
+                           final @NonNegative long offset,
+                           final @NonNegative long length)
+            throws IllegalStateException, IllegalArgumentException, BufferUnderflowException {
+        requireNonNull(byteStore);
+        setBytesStore(byteStore);
+        // assume its read-only
+        readLimit(offset + length);
+        readPosition(offset);
+        try {
+            writeLimit(offset + length);
+        } catch (BufferOverflowException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private void setBytesStore(@NotNull BytesStore<Bytes<U>, U> bytesStore)
+            throws IllegalStateException, IllegalArgumentException {
+        if (this.bytesStore != bytesStore) {
+            @Nullable BytesStore oldBS = this.bytesStore;
+            this.bytesStore(bytesStore);
+            bytesStore.reserve(this);
+            oldBS.release(this);
+        }
+        clear();
+    }
+
+    @Override
+    public long offset() {
+        return readPosition();
+    }
+
+    @Override
+    public long maxSize() {
+        return readRemaining();
+    }
+
+    @Override
+    public boolean isElastic() {
+        return false;
+    }
+
+    @NotNull
+    @Override
+    public Bytes<U> bytesForRead()
+            throws IllegalStateException {
+        throwExceptionIfReleased();
+        try {
+            return isClear()
+                    ? new VanillaBytes<>(bytesStore, writePosition(), bytesStore.writeLimit())
+                    : new SubBytes<>(bytesStore, readPosition(), readLimit());
+        } catch (IllegalArgumentException | BufferUnderflowException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Override
+    public boolean isEqual(@Nullable String other)
+            throws IllegalStateException {
+        if (other == null || other.length() != readRemaining()) return false;
+        ReportUnoptimised.reportOnce();
+
+        long realLength = realReadRemaining();
+        try {
+            if (Jvm.isJava9Plus()) {
+                byte[] bytes = StringUtils.extractBytes(other);
+                byte coder = StringUtils.getStringCoder(other);
+                if (bytesStore instanceof NativeBytesStore && realLength == readRemaining()) {
+                    @NotNull NativeBytesStore bs = (NativeBytesStore) this.bytesStore;
+                    long address = bs.addressForRead(readPosition);
+                    return isEqual0(bytes, coder, bs, address);
+
+                } else {
+                    return isEqual1(bytes, coder, bytesStore, readPosition);
+                }
+            } else {
+                char[] chars = StringUtils.extractChars(other);
+                if (bytesStore instanceof NativeBytesStore && realLength == readRemaining()) {
+                    @NotNull NativeBytesStore bs = (NativeBytesStore) this.bytesStore;
+                    long address = bs.addressForRead(readPosition);
+                    return isEqual0(chars, bs, address);
+
+                } else {
+                    return isEqual1(chars, bytesStore, readPosition);
+                }
+            }
+        } catch (BufferUnderflowException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Override
+    public @NonNegative long realCapacity() {
+        return bytesStore.realCapacity();
+    }
+
+    @Override
+    public long findByte(byte stopByte) throws IllegalStateException {
+        return BytesInternal.findByte(this, stopByte);
+    }
+
+    @Override
+    public long parseLong() throws BufferUnderflowException, IllegalStateException {
+        return BytesInternal.parseLong(this);
+    }
+
+    @NotNull
+    @Override
+    public BytesStore<Bytes<U>, U> copy()
+            throws IllegalStateException {
+        throwExceptionIfReleased();
+        ReportUnoptimised.reportOnce();
+
+        if (bytesStore.underlyingObject() instanceof ByteBuffer) {
+            try {
+                ByteBuffer bb = ByteBuffer.allocateDirect(Maths.toInt32(readRemaining()));
+                @NotNull ByteBuffer bbu = (ByteBuffer) bytesStore.underlyingObject();
+                ByteBuffer slice = bbu.slice();
+                slice.position((int) readPosition());
+                slice.limit((int) readLimit());
+                bb.put(slice);
+                bb.clear();
+                return (BytesStore) BytesStore.wrap(bb);
+            } catch (ArithmeticException e) {
+                throw new AssertionError(e);
+            }
+        } else {
+            return (BytesStore) BytesUtil.copyOf(this);
+        }
+    }
+
+    @NotNull
+    @Override
+    public Bytes<U> write(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
+            throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
+        requireNonNull(bytes);
+        if ((offset | length) < 0) {
+            requireNonNegative(offset);
+            requireNonNegative(length);
+        }
+        ensureCapacity(writePosition() + length);
+        optimisedWrite(bytes, offset, length);
+        return this;
+    }
+
+    protected void optimisedWrite(@NotNull RandomDataInput bytes, @NonNegative long offset, @NonNegative long length)
+            throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
+        requireNonNull(bytes);
+        if (length <= safeCopySize() && isDirectMemory() && bytes.isDirectMemory()) {
+            long len = Math.min(writeRemaining(), Math.min(bytes.capacity() - offset, length));
+            if (len > 0) {
+                writeCheckOffset(writePosition(), len);
+                long address = bytes.addressForRead(offset);
+                long address2 = addressForWritePosition();
+                assert address != 0;
+                assert address2 != 0;
+                OS.memory().copyMemory(address, address2, len);
+                writeSkip(len);
+            }
+        } else {
+            super.write(bytes, offset, length);
+        }
+    }
+
+    public void write(long position, @NotNull CharSequence str, @NonNegative int offset, @NonNegative int length)
+            throws BufferOverflowException, IllegalArgumentException, ArithmeticException, IllegalStateException, BufferUnderflowException {
+        requireNonNull(str);
+        if ((offset | length | position) < 0) {
+            requireNonNegative(position);
+            requireNonNegative(offset);
+            requireNonNegative(length);
+        }
+
+        ensureCapacity(writePosition() + length);
+        if (offset + length > str.length())
+            throw new IllegalArgumentException("offset=" + offset + " + length=" + length + " > str.length =" + str.length());
+
+        for (int i = 0; i < length; i++) {
+            int index = offset + i;
+            bytesStore.writeByte(position + i, charAt(str, index));
+        }
+    }
+
+    private char charAt(@NotNull CharSequence str, @NonNegative int index) {
+        return str.charAt(index);
+    }
+
+    @Override
+    @NotNull
+    public VanillaBytes append(@NotNull CharSequence str, @NonNegative int start, @NonNegative int end)
+            throws IndexOutOfBoundsException {
+        assert end > start : "end=" + end + ",start=" + start;
+        requireNonNull(str);
+        try {
+            if (isDirectMemory()) {
+                if (str instanceof BytesStore) {
+
+                    write((BytesStore) str, start, (long) end - start);
+                    return this;
+                }
+                if (str instanceof String) {
+                    if (Jvm.isJava9Plus()) {
+                        byte coder = StringUtils.getStringCoder((String) str);
+                        appendUtf8(StringUtils.extractBytes((String) str), start, end - start, coder);
+                    } else {
+                        appendUtf8(StringUtils.extractChars((String) str), start, end - start);
+                    }
+
+                    return this;
+                }
+            }
+            ReportUnoptimised.reportOnce();
+            super.append(str, start, end);
+            return this;
+
+        } catch (Exception e) {
+            final IndexOutOfBoundsException ioobe = new IndexOutOfBoundsException(e.toString());
+            ioobe.initCause(e);
+            throw ioobe;
+        }
+    }
+
+    @NotNull
+    @Override
+    public VanillaBytes appendUtf8(@NotNull CharSequence str)
+            throws BufferOverflowException {
+        requireNonNull(str);
+        ReportUnoptimised.reportOnce();
+        try {
+            if (isDirectMemory()) {
+                if (str instanceof BytesStore) {
+                    write((BytesStore) str, 0L, str.length());
+                    return this;
+                }
+                if (str instanceof String) {
+                    if (Jvm.isJava9Plus()) {
+                        String str1 = (String) str;
+                        byte coder = StringUtils.getStringCoder(str1);
+                        appendUtf8(StringUtils.extractBytes(str1), 0, str.length(), coder);
+                    } else {
+                        appendUtf8(StringUtils.extractChars((String) str), 0, str.length());
+                    }
+                    return this;
+                }
+            }
+            super.append(str, 0, str.length());
+            return this;
+
+        } catch (Exception e) {
+            @NotNull BufferOverflowException e2 = new BufferOverflowException();
+            e2.initCause(e);
+            throw e2;
+        }
+    }
+
+    @Override
+    @NotNull
+    public Bytes<U> append8bit(@NotNull CharSequence cs)
+            throws BufferOverflowException, BufferUnderflowException, IndexOutOfBoundsException, IllegalStateException {
+        requireNonNull(cs);
+        if (cs instanceof RandomDataInput)
+            return write((RandomDataInput) cs);
+
+        if (isDirectMemory() && cs instanceof String && this.bytesStore instanceof NativeBytesStore)
+            return append8bitNBSS((String) cs);
+
+        return append8bit0(cs);
+    }
+
+    @Override
+    @NotNull
+    public Bytes<U> append8bit(@NotNull BytesStore bs)
+            throws BufferOverflowException, BufferUnderflowException, IllegalStateException {
+        long remaining = bs.readLimit() - bs.readPosition();
+        return write0(bs, 0L, remaining);
+    }
+
+    @NotNull
+    @Override
+    public Bytes<U> write(@NotNull BytesStore bytes, @NonNegative long offset, @NonNegative long length)
+            throws BufferOverflowException, BufferUnderflowException, IllegalStateException, IllegalArgumentException {
+        requireNonNull(bytes);
+        if ((offset | length) < 0) {
+            requireNonNegative(offset);
+            requireNonNegative(length);
+        }
+        return write0(bytes, offset, length);
+    }
+
+    @NotNull
+    private VanillaBytes<U> write0(@NotNull BytesStore bytes, long offset, long length) {
+        ensureCapacity(writePosition() + length);
+        if (length == (int) length) {
+            if (bytes.canReadDirect(length) && canWriteDirect(length)) {
+                long wAddr = addressForWritePosition();
+                writeSkip(length);
+                long rAddr = bytes.addressForRead(offset);
+                UnsafeMemory.copyMemory(rAddr, wAddr, (int) length);
+                return this;
+
+            } else {
+                bytesStore.write(writePosition(), bytes.bytesStore(), offset, length);
+                uncheckedWritePosition(writePosition() + length);
+                return this;
+            }
+        }
+        ReportUnoptimised.reportOnce();
+        BytesInternal.writeFully(bytes, offset, length, this);
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public Bytes<U> append8bit(@NotNull String cs)
+            throws BufferOverflowException, IllegalStateException {
+        requireNonNull(cs);
+        if (isDirectMemory())
+            return append8bitNBSS(cs);
+        return append8bit0(cs);
+    }
+
+    @NotNull
+    private Bytes<U> append8bitNBSS(@NotNull String s)
+            throws BufferOverflowException, IllegalStateException {
+        int length = s.length();
+        long offset = writeOffsetPositionMoved(length); // can re-assign the byteStore if not large enough.
+        // only valid after the previous call
+        NativeBytesStore bytesStore = (NativeBytesStore) this.bytesStore;
+        final long address = bytesStore.address + bytesStore.translate(offset);
+        @Nullable final Memory memory = bytesStore.memory;
+
+        if (memory == null) {
+            bytesStore.throwExceptionIfReleased();
+            throw new NullPointerException("byteStore.memory is null.");
+        }
+
+        if (Jvm.isJava9Plus()) {
+            final byte[] chars = StringUtils.extractBytes(s);
+
+            int i;
+            for (i = 0; i < length; i++) {
+                memory.writeByte(address + i, chars[i]);
+            }
+        } else {
+            final char[] chars = StringUtils.extractChars(s);
+            int i;
+            for (i = 0; i < length - 3; i += 4) {
+                int c0 = chars[i] & 0xFF;
+                int c1 = chars[i + 1] & 0xFF;
+                int c2 = chars[i + 2] & 0xFF;
+                int c3 = chars[i + 3] & 0xFF;
+                memory.writeInt(address + i, c0 | (c1 << 8) | (c2 << 16) | (c3 << 24));
+            }
+            for (; i < length; i++) {
+                int c0 = chars[i];
+                memory.writeByte(address + i, (byte) c0);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    @NotNull
+    public String toString() {
+        // Reserving prevents access to this Bytes object if released by another thread
+        reserve(this);
+        try {
+            return bytesStore instanceof NativeBytesStore
+                    ? toString2((NativeBytesStore) bytesStore)
+                    : toString0();
+        } catch (IllegalStateException e) {
+            throw Jvm.rethrow(e);
+        } finally {
+            release(this);
+        }
+    }
+
+    private String toString2(@NotNull NativeBytesStore bytesStore) {
+        @Nullable final Memory memory = bytesStore.memory;
+        int length = (int)
+                Math.min(Bytes.MAX_HEAP_CAPACITY, realReadRemaining());
+        @NotNull char[] chars = new char[length];
+        final long address = bytesStore.address + bytesStore.translate(readPosition());
+        for (int i = 0; i < length && i < realCapacity(); i++)
+            chars[i] = (char) (memory.readByte(address + i) & 0xFF);
+
+        return StringUtils.newString(chars);
+    }
+
+    @NotNull
+    protected String toString0()
+            throws IllegalStateException {
+        int length = (int) Math.min(Bytes.MAX_HEAP_CAPACITY, readRemaining());
+        @NotNull char[] chars = new char[length];
+        try {
+            for (int i = 0; i < length; i++) {
+                chars[i] = (char) (bytesStore.readByte(readPosition() + i) & 0xFF);
+            }
+        } catch (BufferUnderflowException e) {
+            // ignored
+        }
+        return StringUtils.newString(chars);
+    }
+
+    @NotNull
+    protected Bytes<U> append8bit0(@NotNull CharSequence cs)
+            throws BufferOverflowException, IllegalStateException {
+        int length = cs.length();
+        long offset = writeOffsetPositionMoved(length);
+        for (int i = 0; i < length; i++) {
+            char c = charAt(cs, i);
+            if (c > 255) c = '?';
+            bytesStore.writeByte(offset + i, (byte) c);
+        }
+        return this;
+    }
+
+    @Override
+    public boolean equalBytes(@NotNull BytesStore bytesStore, long length)
+            throws BufferUnderflowException, IllegalStateException {
+        requireNonNull(bytesStore);
+        ReportUnoptimised.reportOnce();
+        if (length < 0) throw new IllegalArgumentException();
+
+        if (isDirectMemory() &&
+                bytesStore instanceof VanillaBytes &&
+                bytesStore.isDirectMemory()) {
+            @NotNull VanillaBytes b2 = (VanillaBytes) bytesStore;
+            @NotNull NativeBytesStore nbs0 = (NativeBytesStore) this.bytesStore;
+            @Nullable NativeBytesStore nbs2 = (NativeBytesStore) b2.bytesStore();
+            long i = 0;
+            for (; i < length - 7; i += 8) {
+                long addr0 = nbs0.address + readPosition() - nbs0.start() + i;
+                long addr2 = nbs2.address + b2.readPosition() - nbs2.start() + i;
+                long l0 = nbs0.memory.readLong(addr0);
+                long l2 = nbs2.memory.readLong(addr2);
+                if (l0 != l2)
+                    return false;
+            }
+            for (; i < length; i++) {
+                long offset2 = readPosition() + i - nbs0.start();
+                long offset21 = b2.readPosition() + i - nbs2.start();
+                byte b0 = nbs0.memory.readByte(nbs0.address + offset2);
+                byte b1 = nbs2.memory.readByte(nbs2.address + offset21);
+                if (b0 != b1)
+                    return false;
+            }
+            return true;
+        } else {
+            return super.equalBytes(bytesStore, length);
+        }
+    }
+
+    public void read8Bit(char[] chars, @NonNegative int length)
+            throws BufferUnderflowException, IllegalStateException {
+        ReportUnoptimised.reportOnce();
+
+        if (isDirectMemory()) {
+            long position = readPosition();
+            @NotNull NativeBytesStore nbs = (NativeBytesStore) bytesStore();
+            nbs.read8bit(position, chars, length);
+        } else {
+            long pos = this.readPosition();
+            for (int i = 0; i < length; i++)
+                chars[i] = (char) this.readUnsignedByte(pos + i);
+        }
+    }
+
+    // TODO: protected?
+    @Override
+    public int byteCheckSum(@NonNegative int start, @NonNegative int end)
+            throws IORuntimeException, BufferUnderflowException {
+        byte b = 0;
+        // the below cast is safe as should only be called from net.openhft.chronicle.bytes.AbstractBytes.byteCheckSum(long, long)
+        @Nullable final NativeBytesStore bytesStore = (NativeBytesStore) bytesStore();
+        @Nullable final Memory memory = bytesStore.memory;
+        assert memory != null;
+        final long addr = bytesStore.addressForRead(start);
+        int i = 0;
+        final int len = end - start;
+        for (; i < len - 3; i += 4) {
+            b += memory.readByte(addr + i)
+                    + memory.readByte(addr + i + 1)
+                    + memory.readByte(addr + i + 2)
+                    + memory.readByte(addr + i + 3);
+        }
+        for (; i < len; i++) {
+            b += memory.readByte(addr + i);
+        }
+        return b & 0xFF;
+    }
+
+    @NotNull
+    @Override
+    public Bytes<U> appendUtf8(char[] chars, @NonNegative int offset, @NonNegative int length)
+            throws BufferOverflowException, IllegalStateException, BufferUnderflowException, IllegalArgumentException {
+        long actualUTF8Length = AppendableUtil.findUtf8Length(chars, offset, length);
+        ensureCapacity(writePosition() + actualUTF8Length);
+        if (bytesStore instanceof NativeBytesStore) {
+            @Nullable NativeBytesStore nbs = (NativeBytesStore) this.bytesStore;
+            long position = nbs.appendUtf8(writePosition(), chars, offset, length);
+            writePosition(position);
+        } else {
+            ReportUnoptimised.reportOnce();
+            super.appendUtf8(chars, offset, length);
+        }
+        return this;
+    }
+
+    @Override
+    public ByteBuffer toTemporaryDirectByteBuffer()
+            throws IllegalArgumentException, ArithmeticException, IllegalStateException {
+        throwExceptionIfReleased();
+        if (isClear())
+            return bytesStore.toTemporaryDirectByteBuffer();
+        return super.toTemporaryDirectByteBuffer();
+    }
+
+    @Override
+    public int read(byte[] bytes)
+            throws BufferUnderflowException, IllegalStateException {
+        requireNonNull(bytes);
+        ReportUnoptimised.reportOnce();
+
+        int len = (int) Math.min(bytes.length, readRemaining());
+        if (bytesStore instanceof NativeBytesStore) {
+            @Nullable NativeBytesStore nbs = (NativeBytesStore) this.bytesStore;
+            long len2 = nbs.read(readPosition(), bytes, 0, len);
+            try {
+                readSkip(len2);
+            } catch (BufferUnderflowException e) {
+                throw new AssertionError(e);
+            }
+            return (int) (len2);
+        }
+        return super.read(bytes);
+    }
+
+    @Override
+    public int compareTo(@NotNull CharSequence cs) {
+        long len1 = readRemaining();
+        int len2 = cs.length();
+        long lim = Math.min(len1, len2);
+
+        int k = 0;
+        while (k < lim) {
+            char c1 = charAt(bytesStore, k);
+            char c2 = charAt(cs, k);
+            if (c1 != c2) {
+                return c1 - c2;
+            }
+            k++;
+        }
+        return (int) (len1 - len2);
+    }
+
+}

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -218,12 +218,12 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
      * overlap region
      */
     @Override
-    public long addressForRead(@NonNegative final long offset, @NonNegative final int buffer)
+    public long addressForRead(@NonNegative final long offset, @NonNegative final int bufferSize)
             throws UnsupportedOperationException, BufferUnderflowException, IllegalStateException {
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, buffer))
-            bytesStore = acquireNextByteStore0(offset,  true);
+        if (!bytesStore.inside(offset, bufferSize))
+            bytesStore = acquireNextByteStore0(offset, true);
         return bytesStore.addressForRead(offset);
     }
 
@@ -260,13 +260,10 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         if (offset + adding < start() || offset > mappedFile.capacity() - adding)
             throw writeBufferOverflowException0(offset);
         BytesStore bytesStore = this.bytesStore;
-        if (adding > 0 && !bytesStore.inside(offset, checkSize0(adding - 1))) {
-            if (bytesStore.start() > offset)
-                acquireNextByteStore0(offset, false);
-            else
-                acquireNextByteStore0(offset + adding - 1, false);
+        if (adding > 0 && !bytesStore.inside(offset, checkSize0(adding))) {
+            acquireNextByteStore0(offset, false);
 
-            if (!this.bytesStore.inside(offset, checkSize0(adding - 1)))
+            if (!this.bytesStore.inside(offset, checkSize0(adding)))
                 throw new DecoratedBufferUnderflowException(String.format("Acquired the next BytesStore, but still not room to add %d when realCapacity %d", adding, this.bytesStore.realCapacity()));
         }
     }
@@ -443,7 +440,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 0)) {
+        if (!bytesStore.inside(offset, Byte.BYTES)) {
             bytesStore = acquireNextByteStore0(offset, false);
         }
         return bytesStore.readVolatileByte(offset);
@@ -455,8 +452,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 1)) {
-            bytesStore = acquireNextByteStore0(offset + 1, false);
+        if (!bytesStore.inside(offset, Short.BYTES)) {
+            bytesStore = acquireNextByteStore0(offset, false);
         }
         return bytesStore.readVolatileShort(offset);
     }
@@ -467,8 +464,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 3)) {
-            bytesStore = acquireNextByteStore0(offset + 3, false);
+        if (!bytesStore.inside(offset, Integer.BYTES)) {
+            bytesStore = acquireNextByteStore0(offset, false);
         }
         return bytesStore.readVolatileInt(offset);
     }
@@ -479,8 +476,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 7)) {
-            bytesStore = acquireNextByteStore0(offset + 7, false);
+        if (!bytesStore.inside(offset, Long.BYTES)) {
+            bytesStore = acquireNextByteStore0(offset, false);
         }
         return bytesStore.readVolatileLong(offset);
     }
@@ -491,7 +488,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(readPosition, 0)) {
+        if (!bytesStore.inside(readPosition, Byte.BYTES)) {
             bytesStore = acquireNextByteStore0(readPosition, false);
         }
         try {
@@ -507,7 +504,7 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         throwExceptionIfClosed();
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(offset, 0)) {
+        if (!bytesStore.inside(offset, Byte.BYTES)) {
             bytesStore = acquireNextByteStore0(offset, false);
         }
         return offset < start() || readLimit() <= offset ? -1 : bytesStore.peekUnsignedByte(offset);
@@ -519,8 +516,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
             throws IllegalStateException {
 
         BytesStore bytesStore = this.bytesStore;
-        if (!bytesStore.inside(readPosition, 3)) {
-            bytesStore = acquireNextByteStore0(readPosition + 3, true);
+        if (!bytesStore.inside(readPosition, Integer.BYTES)) {
+            bytesStore = acquireNextByteStore0(readPosition, true);
         }
         MappedBytesStore mbs = (MappedBytesStore) bytesStore;
         long address = mbs.address + mbs.translate(readPosition);

--- a/src/main/java/net/openhft/chronicle/bytes/internal/NoBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/NoBytesStore.java
@@ -309,8 +309,8 @@ public final class NoBytesStore implements BytesStore {
     }
 
     @Override
-    public boolean inside(@NonNegative long offset, @NonNegative long buffer) {
-        return false;
+    public boolean inside(@NonNegative long offset, @NonNegative long bufferSize) {
+        return offset == 0 && bufferSize == 0;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryTwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryTwoLongReference.java
@@ -42,7 +42,7 @@ public class BinaryTwoLongReference extends BinaryLongReference implements TwoLo
     public long getValue2()
             throws IllegalStateException {
         try {
-            return bytes.readLong(offset + 8);
+            return bytes.readLong(offset + Long.BYTES);
         } catch (NullPointerException e) {
             throwExceptionIfClosed();
             throw e;
@@ -55,7 +55,7 @@ public class BinaryTwoLongReference extends BinaryLongReference implements TwoLo
     public void setValue2(long value)
             throws IllegalStateException {
         try {
-            bytes.writeLong(offset + 8, value);
+            bytes.writeLong(offset + Long.BYTES, value);
         } catch (NullPointerException e) {
             throwExceptionIfClosed();
             throw e;
@@ -68,7 +68,7 @@ public class BinaryTwoLongReference extends BinaryLongReference implements TwoLo
     public long getVolatileValue2()
             throws IllegalStateException {
         try {
-            return bytes.readVolatileLong(offset + 8);
+            return bytes.readVolatileLong(offset + Long.BYTES);
         } catch (NullPointerException e) {
             throwExceptionIfClosed();
             throw e;
@@ -82,7 +82,7 @@ public class BinaryTwoLongReference extends BinaryLongReference implements TwoLo
     public void setVolatileValue2(long value)
             throws IllegalStateException {
         try {
-            bytes.writeVolatileLong(offset + 8, value);
+            bytes.writeVolatileLong(offset + Long.BYTES, value);
         } catch (NullPointerException e) {
             throwExceptionIfClosed();
             throw e;
@@ -95,7 +95,7 @@ public class BinaryTwoLongReference extends BinaryLongReference implements TwoLo
     public void setOrderedValue2(long value)
             throws IllegalStateException {
         try {
-            bytes.writeOrderedLong(offset + 8, value);
+            bytes.writeOrderedLong(offset + Long.BYTES, value);
         } catch (NullPointerException e) {
             throwExceptionIfClosed();
             throw e;
@@ -108,7 +108,7 @@ public class BinaryTwoLongReference extends BinaryLongReference implements TwoLo
     public long addValue2(long delta)
             throws IllegalStateException {
         try {
-            return bytes.addAndGetLong(offset + 8, delta);
+            return bytes.addAndGetLong(offset + Long.BYTES, delta);
         } catch (NullPointerException e) {
             throwExceptionIfClosed();
             throw e;
@@ -132,7 +132,7 @@ public class BinaryTwoLongReference extends BinaryLongReference implements TwoLo
     public boolean compareAndSwapValue2(long expected, long value)
             throws IllegalStateException {
         try {
-            return bytes.compareAndSwapLong(offset + 8, expected, value);
+            return bytes.compareAndSwapLong(offset + Long.BYTES, expected, value);
         } catch (NullPointerException e) {
             throwExceptionIfClosed();
             throw e;

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
@@ -17,12 +17,15 @@
  */
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class MappedBytesEdgeTest extends BytesTestCommon {
+    private static final int CHUNK_SIZE = 262144;
     private final int size;
     private final ReadWrite rw;
     private final Consumer<Bytes<?>> doit;
@@ -45,22 +49,26 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
     @Parameterized.Parameters(name = "size {0} rw {1} lambda {2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                {1, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::peekUnsignedByte) },
-                {4, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::readInt) },
-                {4, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::readVolatileInt) },
-                {4, ReadWrite.READ, (Consumer<Bytes<?>>)(b -> b.peekVolatileInt()) },
-                {8, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::readLong) },
-                {8, ReadWrite.READ, (Consumer<Bytes<?>>)(StreamingDataInput::readDouble) },
+                {1, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::peekUnsignedByte)},
+                {4, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::readInt)},
+                {4, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::readVolatileInt)},
+                {4, ReadWrite.READ, (Consumer<Bytes<?>>) (RandomDataInput::peekVolatileInt)},
+                {8, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::readLong)},
+                {8, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::readDouble)},
+                {256, ReadWrite.READ, (Consumer<Bytes<?>>) (b -> b.read(Bytes.allocateDirect(256)))},
+                {512, ReadWrite.READ, (Consumer<Bytes<?>>) (b -> b.read(ByteBuffer.allocate(512)))},
+                {1024, ReadWrite.READ, (Consumer<Bytes<?>>) (b -> b.read(new byte[1024]))},
 
-                {1, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeByte((byte) 99)) },
-                {2, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeShort((short) 123)) },
-                {4, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeInt(1234)) },
-                {4, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeOrderedInt(1234)) },
-                {8, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeLong(1234)) },
-                {8, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.writeDouble(1234)) },
-                {6, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.write8bit("hello")) },
-                {7, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.appendUtf8("doggie")) },
-                {10, ReadWrite.WRITE, (Consumer<Bytes<?>>)(b -> b.write(Bytes.from("armadillo"))) },
+                {1, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeByte((byte) 99))},
+                {2, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeShort((short) 123))},
+                {4, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeInt(1234))},
+                {4, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeOrderedInt(1234))},
+                {8, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeLong(1234))},
+                {8, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeDouble(1234))},
+                {6, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.write8bit("hello"))},
+                {7, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.appendUtf8("doggie"))},
+                {10, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.write(Bytes.from("armadillo")))},
+                // {1024, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.write(new byte[1024]))}, // <-- this behaves differently, it won't start a write in the offset
 
         });
     }
@@ -68,57 +76,81 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
     @Test
     public void testCorrectChunkResolved() throws IOException {
         final File tempMBFile = Files.createTempFile("mapped", "bytes").toFile();
-        int chunk = 262144;
-        int overlap = 65536;
-        try (final MappedBytes bytes = MappedBytes.mappedBytes(tempMBFile, chunk, overlap)) {
+        final long overlap = OS.mapAlign(overlap(CHUNK_SIZE));
+        if (overlap != overlap(CHUNK_SIZE)) {
+            Jvm.warn().on(MappedBytesEdgeTest.class, "You configured an invalid overlap " + overlap(CHUNK_SIZE) + ", actual one used will be " + overlap);
+        }
+        try (final MappedBytes bytes = MappedBytes.mappedBytes(tempMBFile, CHUNK_SIZE, overlap)) {
             // map in the real file
             bytes.writePosition(0).writeByte((byte) 0);
             assertEquals(0, bytes.bytesStore().start());
 
             if (rw == ReadWrite.WRITE) {
-                checkWritePosition(bytes, chunk + overlap - size, 0);
-                checkWritePosition(bytes, chunk + overlap, chunk);
-                checkWritePosition(bytes, chunk + overlap + size, chunk);
+                checkWritePosition(bytes, CHUNK_SIZE + overlap - size, 0);
+                checkWritePosition(bytes, CHUNK_SIZE + overlap, CHUNK_SIZE);
+                checkWritePosition(bytes, CHUNK_SIZE + overlap + size, CHUNK_SIZE);
                 // go back to just before the overlap - will still be in second chunk
-                checkWritePosition(bytes, chunk + overlap - size, chunk);
-                checkWritePosition(bytes, chunk - size, 0);
+                checkWritePosition(bytes, CHUNK_SIZE + overlap - size, CHUNK_SIZE);
+                checkWritePosition(bytes, CHUNK_SIZE - size, 0);
+                // now try and write over the end of the chunk
+                checkWritePosition(bytes, CHUNK_SIZE - 1, 0);
+                // and end of chunk plus offset
+                checkWritePosition(bytes, CHUNK_SIZE + overlap - 1, size > 1 ? CHUNK_SIZE : 0);
+
                 if (size > 1) {
-                    // now try and write over the end of the chunk
-                    bytes.writePosition(chunk - 1);
-                    doit.accept(bytes);
-                    // and end of chunk plus offset
-                    bytes.writePosition(chunk + overlap - 1);
-                    doit.accept(bytes);
+                    // load the first chunk
+                    checkWritePosition(bytes, CHUNK_SIZE - 1, 0);
+
+                    // write to just before the end of the third chunk
+                    checkWritePosition(bytes, (3 * CHUNK_SIZE) - 1, 2 * CHUNK_SIZE);
+
+                    // we've got the third chunk loaded, now go back and write something to the end of the first chunk
+                    checkWritePosition(bytes, CHUNK_SIZE - 1, 0);
                 }
             } else {
                 // ensure WP is far ahead as Bytes generally won't allow a read past the WP
-                bytes.writePosition(chunk + 1_000);
-                checkReadPosition(bytes, chunk - size, 0);
-                checkReadPosition(bytes, chunk, chunk);
-                checkReadPosition(bytes, chunk + size, chunk);
-                checkReadPosition(bytes, chunk - size, 0);
-                // read over the end should work as we have the overlap
+                bytes.writePosition(CHUNK_SIZE * 5);
+
+                checkReadPosition(bytes, CHUNK_SIZE - size, 0);
+                checkReadPosition(bytes, CHUNK_SIZE, CHUNK_SIZE);
+                checkReadPosition(bytes, CHUNK_SIZE + size, CHUNK_SIZE);
+                checkReadPosition(bytes, CHUNK_SIZE - size, 0);
+
                 if (size > 1) {
-                    bytes.readPosition(chunk - 1);
-                    doit.accept(bytes);
+                    // read over the end should work as we have the overlap
+                    checkReadPosition(bytes, CHUNK_SIZE - 1, 0);
+
+                    // we've got the first chunk loaded, now read from just before the end of the third chunk
+                    checkReadPosition(bytes, (3 * CHUNK_SIZE) - 1, CHUNK_SIZE * 2);
+
+                    // we've got the third chunk loaded, now read from just before the end of the first chunk
+                    checkReadPosition(bytes, CHUNK_SIZE - 1, 0);
                 }
             }
         }
     }
 
-    private void checkWritePosition(MappedBytes bytes, int writePosition, int expectedStart) {
+    protected long overlap(long chunkSize) {
+        return chunkSize / 4;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    private void checkWritePosition(MappedBytes bytes, long writePosition, long expectedStart) {
         bytes.writePosition(writePosition);
         doit.accept(bytes);
         assertEquals(expectedStart, bytes.bytesStore().start());
     }
 
-    private void checkReadPosition(MappedBytes bytes, int readPosition, int expectedStart) {
+    private void checkReadPosition(MappedBytes bytes, long readPosition, long expectedStart) {
         bytes.readPosition(readPosition);
         doit.accept(bytes);
         assertEquals(expectedStart, bytes.bytesStore().start());
     }
 
-    private enum ReadWrite {
+    protected enum ReadWrite {
         READ,
         WRITE
     }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
@@ -56,7 +56,7 @@ public class MappedFileTest extends BytesTestCommon {
         // this is what it will end up as
         final long chunkSize = OS.mapAlign(64);
         final ReferenceOwner test = ReferenceOwner.temporary("test");
-        try (final MappedFile mappedFile = MappedFile.mappedFile(file, 64)) {
+        try (final MappedFile mappedFile = MappedFile.mappedFile(file, 64, 0)) {
             final MappedBytesStore first = mappedFile.acquireByteStore(test, 1);
 
             final int expected = MappedFile.RETAIN ? 2 : 1;

--- a/src/test/java/net/openhft/chronicle/bytes/UTF8BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UTF8BytesTest.java
@@ -17,6 +17,7 @@
  */
 package net.openhft.chronicle.bytes;
 
+import net.openhft.chronicle.core.OS;
 import org.junit.Test;
 
 import java.io.File;
@@ -34,7 +35,7 @@ public class UTF8BytesTest extends BytesTestCommon {
             throws IOException {
         File f = Files.createTempFile("testUtfEncoding", "data").toFile();
         f.deleteOnExit();
-        final MappedBytes bytes = MappedBytes.mappedBytes(f, 256);
+        final MappedBytes bytes = MappedBytes.mappedBytes(f, 256, 0);
         int len = (int) AppendableUtil.findUtf8Length(MESSAGE);
         bytes.appendUtf8(MESSAGE);
 

--- a/src/test/java/net/openhft/chronicle/bytes/internal/EmptyBytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/EmptyBytesStoreTest.java
@@ -293,7 +293,7 @@ public class EmptyBytesStoreTest extends BytesTestCommon {
 
     @Test
     public void inside() {
-        assertFalse(instance.inside(0, 0));
+        assertTrue(instance.inside(0, 0));  // Nothing at index zero is in the empty store
         assertFalse(instance.inside(0, 1));
         assertFalse(instance.inside(1, 0));
     }


### PR DESCRIPTION
Fixes #481 

Hide whitespace when reviewing, one file had an extra indent through the whole file that I removed