### PR TITLE
JLBH for contentEquals. Allow perf tests to run on all Java versions. Closes #472

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,12 +485,6 @@
                         <artifactId>exec-maven-plugin</artifactId>
 
                         <configuration>
-                            <systemProperties>
-                                <systemProperty>
-                                    <key>jvm.resource.tracing</key>
-                                    <value>false</value>
-                                </systemProperty>
-                            </systemProperties>
                             <classpathScope>test</classpathScope>
                         </configuration>
                         <executions>
@@ -498,48 +492,88 @@
                                 <id>NativeBytesArrayReadWriteJLBH</id>
                                 <phase>test</phase>
                                 <goals>
-                                    <goal>java</goal>
+                                    <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <mainClass>
-                                        net.openhft.chronicle.bytes.perf.NativeBytesReadWriteJLBH
-                                    </mainClass>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.bytes.perf.NativeBytesReadWriteJLBH</commandlineArgs>
                                 </configuration>
                             </execution>
                             <execution>
                                 <id>OnHeapBytesArrayReadWriteJLBH</id>
                                 <phase>test</phase>
                                 <goals>
-                                    <goal>java</goal>
+                                    <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <mainClass>
-                                        net.openhft.chronicle.bytes.perf.OnHeapBytesReadWriteJLBH
-                                    </mainClass>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.bytes.perf.OnHeapBytesReadWriteJLBH</commandlineArgs>
                                 </configuration>
                             </execution>
                             <execution>
                                 <id>ChunkedMappedBytesArrayReadWriteJLBH</id>
                                 <phase>test</phase>
                                 <goals>
-                                    <goal>java</goal>
+                                    <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <mainClass>
-                                        net.openhft.chronicle.bytes.perf.ChunkedMappedBytesReadWriteJLBH
-                                    </mainClass>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.bytes.perf.ChunkedMappedBytesReadWriteJLBH</commandlineArgs>
                                 </configuration>
                             </execution>
                             <execution>
                                 <id>SingleMappedBytesArrayReadWriteJLBH</id>
                                 <phase>test</phase>
                                 <goals>
-                                    <goal>java</goal>
+                                    <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <mainClass>
-                                        net.openhft.chronicle.bytes.perf.SingleMappedBytesReadWriteJLBH
-                                    </mainClass>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.bytes.perf.SingleMappedBytesReadWriteJLBH</commandlineArgs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ContentEqual2JLBH</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.bytes.perf.ContentEqual2JLBH</commandlineArgs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ContentEqual20JLBH</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.bytes.perf.ContentEqual20JLBH</commandlineArgs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ContentEqual128JLBH</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.bytes.perf.ContentEqual128JLBH</commandlineArgs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ContentEqual8192JLBH</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath %classpath net.openhft.chronicle.bytes.perf.ContentEqual8192JLBH</commandlineArgs>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual128JLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual128JLBH.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes.perf;
+
+public class ContentEqual128JLBH {
+    public static void main(String[] args) {
+        ContentEqualJLBH.runWith(() -> ContentEqualJLBH.bytesFor(128));
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual20JLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual20JLBH.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes.perf;
+
+public class ContentEqual20JLBH {
+    public static void main(String[] args) {
+        ContentEqualJLBH.runWith(() -> ContentEqualJLBH.bytesFor(20));
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual2JLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual2JLBH.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes.perf;
+
+public class ContentEqual2JLBH {
+    public static void main(String[] args) {
+        ContentEqualJLBH.runWith(() -> ContentEqualJLBH.bytesFor(2));
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual8192JLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual8192JLBH.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes.perf;
+
+public class ContentEqual8192JLBH {
+    public static void main(String[] args) {
+        ContentEqualJLBH.runWith(() -> ContentEqualJLBH.bytesFor(8192));
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqualJLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqualJLBH.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes.perf;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesUtil;
+import net.openhft.chronicle.bytes.internal.BytesInternal;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.jlbh.JLBH;
+import net.openhft.chronicle.jlbh.JLBHOptions;
+import net.openhft.chronicle.jlbh.JLBHTask;
+import net.openhft.chronicle.jlbh.TeamCityHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class ContentEqualJLBH implements JLBHTask {
+    private static final int ITERATIONS = 5_000_000;
+    private final Bytes<?> bytes1;
+    private final Bytes<?>[] comparisons;
+    private JLBH jlbh;
+    private int counter;
+
+    public ContentEqualJLBH(Supplier<Bytes<?>> bytesSupplier) {
+        bytes1 = bytesSupplier.get();
+        comparisons = generateComparisons(bytesSupplier);
+    }
+
+    /**
+     * Create a set of Bytes to compare against including best case - totally reversed and worst case - exactly the same
+     */
+    private Bytes<?>[] generateComparisons(Supplier<Bytes<?>> bytesSupplier) {
+        final List<Bytes<?>> rv = new ArrayList<>();
+        final Bytes<?> example = bytesSupplier.get();
+        final int step = Math.max(1, example.length() / 8);
+        for (int i = 0; i < example.length(); i += step) {
+            final Bytes<?> b = bytesSupplier.get();
+            BytesUtil.reverse(b, i);
+            rv.add(b);
+        }
+        rv.add(example);
+        return rv.toArray(new Bytes<?>[rv.size()]);
+    }
+
+    @Override
+    public void init(JLBH jlbh) {
+        this.jlbh = jlbh;
+    }
+
+    @Override
+    public void complete() {
+        // this is horrible - it would be easier if Bootstrap.getMajorVersion0 was exposed
+        String javaVersion = Jvm.isJava9Plus() ? Jvm.isJava15Plus() ? "17" : "11" : "8";
+        TeamCityHelper.teamCityStatsLastRun(getClass().getSimpleName() + "-Java" + javaVersion + "-" + bytes1.length(), jlbh, ITERATIONS, System.out);
+    }
+
+    @Override
+    public void run(long startTimeNS) {
+        BytesInternal.contentEqual(bytes1, comparisons[counter % comparisons.length]);
+        counter++;
+        jlbh.sampleNanos(System.nanoTime() - startTimeNS);
+    }
+
+    static void runWith(Supplier<Bytes<?>> bytesSupplier) {
+        System.setProperty("jvm.resource.tracing", "false");
+        new JLBH(new JLBHOptions()
+                .warmUpIterations(50_000)
+                .iterations(ITERATIONS)
+                .runs(4)
+                .skipFirstRun(true)
+                .recordOSJitter(false)
+                .throughput(500_000)
+                .pauseAfterWarmupMS(100)
+                .accountForCoordinatedOmission(true)
+                .jlbhTask(new ContentEqualJLBH(bytesSupplier)))
+                .start();
+    }
+
+    static Bytes<?> bytesFor(int length) {
+        final Bytes b = Bytes.elasticHeapByteBuffer(length);
+        for (int i = 0; i < length; i++) {
+            b.append(i % 10);
+        }
+        return b;
+    }
+}


### PR DESCRIPTION
Also improves diagnosis around vectorizedMismatch and allows to be disabled with `disable.vectorized.content_equals`