### PR TITLE
ensure that CommonMappedBytes.backingFileIsReadOnly is true if you open a readOnly view of a writeable file

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
@@ -145,6 +145,11 @@ public abstract class MappedBytes extends AbstractBytes<Void> implements Closeab
         }
     }
 
+    /**
+     * Is backing file opened read only
+     *
+     * @return if backing file is opened read only
+     */
     public abstract boolean isBackingFileReadOnly();
 
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
@@ -73,7 +73,7 @@ public abstract class CommonMappedBytes extends MappedBytes {
         assert mappedFile != null;
         this.mappedFile = mappedFile;
         mappedFile.reserve(this);
-        this.backingFileIsReadOnly = !mappedFile.file().canWrite();
+        this.backingFileIsReadOnly = mappedFile.readOnly();
         assert !mappedFile.isClosed();
         clear();
         capacity = mappedFile.capacity();


### PR DESCRIPTION
build-all-branch looks good