### PR TITLE
Undo potential regression from scoped-thread-locals change

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -96,7 +96,9 @@ enum BytesInternal {
     private static final String WAS = " was ";
     private static final String CAN_T_PARSE_FLEXIBLE_LONG_WITHOUT_PRECISION_LOSS = "Can't parse flexible long without precision loss: ";
     private static final byte[] MIN_VALUE_TEXT = ("" + Long.MIN_VALUE).getBytes(ISO_8859_1);
-    private static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal();
+    @Deprecated(/* To be removed in x.26 */)
+    private static final StringBuilderPool SBP = new StringBuilderPool();
+    private static final ScopedResourcePool<StringBuilder> STRING_BUILDER_SCOPED_RESOURCE_POOL = StringBuilderPool.createThreadLocal();
     private static final BytesPool BP = new BytesPool();
     private static final byte[] INFINITY_BYTES = INFINITY.getBytes(ISO_8859_1);
     private static final byte[] NAN_BYTES = NAN.getBytes(ISO_8859_1);
@@ -2181,14 +2183,11 @@ enum BytesInternal {
      */
     @Deprecated(/* To be removed in x.26 */)
     public static StringBuilder acquireStringBuilder() {
-        try (final ScopedResource<StringBuilder> scopedResource = SBP.get()) {
-            // This is very wrong, it will be cleared if a nested scope acquires it, but equivalent to existing behaviour
-            return scopedResource.get();
-        }
+        return SBP.acquireStringBuilder();
     }
 
     public static ScopedResource<StringBuilder> acquireStringBuilderScoped() {
-        return SBP.get();
+        return STRING_BUILDER_SCOPED_RESOURCE_POOL.get();
     }
 
     /**


### PR DESCRIPTION
This is also a potential regression, just sticking with the dedicated pool for legacy support for now