### PR TITLE
Deprecated appendBytesFromStart

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
@@ -518,7 +518,7 @@ public enum BytesUtil {
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way.
      */
-    // used by Chronicle FIX.
+    @Deprecated(/* to be removed in x.27 */)
     public static void appendBytesFromStart(@NotNull Bytes<?> bytes, @NonNegative long startPosition, @NotNull StringBuilder sb)
             throws IllegalStateException {
         try {


### PR DESCRIPTION
Deprecated method as part of removing use from Chronicle FIX.

Appending the unicode character \u2016 to the exception message causes issues when the exception message is used as part of generating a Reject message. The Reject message is treated as a single-byte character string when being output, create a garbled reject message.