### PR TITLE
JMH Benchmarks need annotation processing turned on and this requires…

### DIFF
--- a/microbenchmarks/pom.xml
+++ b/microbenchmarks/pom.xml
@@ -25,12 +25,13 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>1.26.0</version>
+        <!-- processing annotations is off on 1.26.0, and turning it on requires Java 11 -->
+        <version>1.25.4</version>
         <relativePath />
     </parent>
 
     <artifactId>chronicle-bytes-benchmarks</artifactId>
-    <version>2.24ea-SNAPSHOT</version>
+    <version>2.26ea-SNAPSHOT</version>
     <name>OpenHFT/Chronicle-Bytes/Benchmarks</name>
     <description>Chronicle-Bytes-Benchmarks</description>
 

--- a/src/main/java/net/openhft/chronicle/bytes/MethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodWriterBuilder.java
@@ -71,6 +71,8 @@ public interface MethodWriterBuilder<T> extends Supplier<T> {
 
     /**
      * Controls whether type information should be included in a verbose manner.
+     * <p>
+     * NOTE: If you are using JSONWire, you also need to set {@code useTypes(true)} to include type information.
      *
      * @param verboseTypes true if type information should be verbose; false otherwise
      * @return this builder, so invocations can be chained


### PR DESCRIPTION
… Java 11 to override it.