### PR TITLE
Ticket 2877 - Fixes copyTo() bug

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
@@ -401,8 +401,10 @@ public interface RandomDataInput extends RandomCommon {
         int len = (int) Math.min(bb.remaining(), readRemaining());
         long readPosition = readPosition();
         int i;
-        for (i = 0; i < len - 7; i += 8)
-            bb.putLong(pos + i, readLong(readPosition + i));
+        for (i = 0; i < len - 7; i += 8) {
+            long value = readLong(readPosition + i);
+            bb.putLong(pos + i, bb.order() == ByteOrder.BIG_ENDIAN ? Long.reverseBytes(value) : value);
+        }
         for (; i < len; i++)
             bb.put(pos + i, readByte(readPosition + i));
         return len;

--- a/src/test/java/net/openhft/chronicle/bytes/CopyToTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CopyToTest.java
@@ -27,10 +27,10 @@ public class CopyToTest {
 
     @Test
     public void testCopyFromBytesIntoByteBuffer() {
-        Bytes<?> bytesToTest = Bytes.fromDirect("Hello, world");
+        Bytes<?> bytesToTest = Bytes.fromDirect("THIS IS A TEST STRING");
         ByteBuffer copyToDestination = ByteBuffer.allocateDirect(128);
         copyToDestination.limit((int) bytesToTest.readLimit());
         bytesToTest.copyTo(copyToDestination);
-        assertEquals("Hello, world", Bytes.wrapForRead(copyToDestination).toUtf8String());
+        assertEquals("THIS IS A TEST STRING", Bytes.wrapForRead(copyToDestination).toUtf8String());
     }
 }

--- a/src/test/java/net/openhft/chronicle/bytes/CopyToTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CopyToTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2022 chronicle.software
+ *
+ *     https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class CopyToTest {
+
+    @Test
+    public void testCopyFromBytesIntoByteBuffer() {
+        Bytes<?> bytesToTest = Bytes.fromDirect("Hello, world");
+        ByteBuffer copyToDestination = ByteBuffer.allocateDirect(128);
+        copyToDestination.limit((int) bytesToTest.readLimit());
+        bytesToTest.copyTo(copyToDestination);
+        assertEquals("Hello, world", Bytes.wrapForRead(copyToDestination).toUtf8String());
+    }
+}


### PR DESCRIPTION
copyTo now accounts for different byte orders of the buffer