### PR TITLE
Reduce memory usage in ReentrantFileLockTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLockTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLockTest.java
@@ -49,8 +49,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ReentrantFileLockTest extends BytesTestCommon {
 
-    private static final int NUM_THREADS = 4;
-    private static final int NUM_ITERATIONS = 300;
+    // Reduced the number of spawned processes to limit memory
+    // consumption which occasionally caused "os::commit_memory" errors
+    // on low memory environments running the test suite.
+    private static final int NUM_THREADS = 2;
+    // Fewer iterations are sufficient to verify behaviour and keep
+    // resource consumption down during the test runs.
+    private static final int NUM_ITERATIONS = 100;
     private File fileToLock;
 
     @BeforeEach


### PR DESCRIPTION
## Summary
- shrink number of subprocesses in `ReentrantFileLockTest`
- run fewer iterations in each locker process

The test occasionally failed with `os::commit_memory` errors when the
child VMs consumed too much memory. Running fewer processes with fewer
iterations keeps resource usage lower.

## Testing
- `mvn test` *(fails: `mvn: command not found`)*