### PR TITLE
Improve Javadoc in ref package

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -63,13 +63,13 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     }
 
     /**
-     * Sets the underlying BytesStore to work with, along with the offset and length.
+     * Sets the underlying {@link BytesStore} together with the offset and length.
      *
-     * @param bytes  the BytesStore to set
-     * @param offset the offset to set
-     * @param length the length to set
-     * @throws IllegalArgumentException If the arguments are invalid
-     * @throws BufferOverflowException  If the provided buffer is too small
+     * @param bytes  the {@code BytesStore} providing the backing memory
+     * @param offset the non-negative offset within the store
+     * @param length the number of bytes this reference spans
+     * @throws IllegalArgumentException if {@code length} does not match {@link #maxSize()}
+     * @throws BufferOverflowException  if the region exceeds the store capacity
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */
@@ -86,7 +86,7 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     }
 
     /**
-     * @return the BytesStore associated with this reference
+     * Returns the {@link BytesStore} that backs this reference, or {@code null} if none is set.
      */
     @Nullable
     @Override
@@ -95,7 +95,7 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     }
 
     /**
-     * @return the offset within the BytesStore for this reference
+     * Returns the byte offset relative to the start of the associated store.
      */
     @Override
     public long offset() {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -54,6 +54,9 @@ import java.nio.BufferUnderflowException;
  */
 @SuppressWarnings("rawtypes")
 public class BinaryIntReference extends AbstractReference implements IntValue {
+    /**
+     * Sentinel value used when an integer operation fails to complete normally.
+     */
     public static final int INT_NOT_COMPLETE = Integer.MIN_VALUE;
 
     /**
@@ -109,12 +112,12 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
     }
 
     /**
-     * Retrieves the 32-bit integer value from the BytesStore.
+     * Performs a plain read of the value from the backing store.
      *
-     * @return the 32-bit integer value
-     * @throws BufferUnderflowException If the offset is too large
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @return the current value
+     * @throws BufferUnderflowException if the offset is invalid
+     * @throws ClosedIllegalStateException    if the resource has been released or closed.
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @Override
     public int getValue()
@@ -125,12 +128,12 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
     }
 
     /**
-     * Sets the 32-bit integer value in the BytesStore.
+     * Writes the value to the backing store using plain semantics.
      *
-     * @param value the 32-bit integer value to set
-     * @throws BufferOverflowException If the offset is too large
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param value the value to store
+     * @throws BufferOverflowException if the offset is invalid
+     * @throws ClosedIllegalStateException    if the resource has been released or closed.
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @Override
     public void setValue(int value)

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -54,6 +54,9 @@ import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
  */
 @SuppressWarnings("rawtypes")
 public class BinaryLongReference extends AbstractReference implements LongReference {
+    /**
+     * Sentinel value indicating that a long operation did not complete as expected.
+     */
     public static final long LONG_NOT_COMPLETE = -1;
 
     /**
@@ -110,11 +113,11 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
     }
 
     /**
-     * Retrieves the 64-bit long value from the BytesStore.
+     * Performs a plain read of the value from the backing store.
      *
-     * @return the 64-bit long value
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @return the current value
+     * @throws ClosedIllegalStateException    if the resource has been released or closed.
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @Override
     public long getValue()
@@ -123,11 +126,11 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
     }
 
     /**
-     * Sets the 64-bit long value in the BytesStore.
+     * Writes the value to the backing store using plain semantics.
      *
-     * @param value the 64-bit long value to set
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param value the value to store
+     * @throws ClosedIllegalStateException    if the resource has been released or closed.
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @Override
     public void setValue(long value)

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
@@ -37,22 +37,22 @@ import net.openhft.chronicle.core.values.IntArrayValues;
 public interface ByteableIntArrayValues extends IntArrayValues, Byteable, DynamicallySized {
 
     /**
-     * Calculates the size in bytes needed to store the given number of integers.
+     * Calculates the byte size required to hold the provided element capacity.
      *
-     * @param sizeInBytes the number of integers to be stored.
-     * @return the size in bytes needed to store the specified number of integers.
+     * @param capacity the number of elements
+     * @return total bytes needed for this capacity
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */
     @Override
-    long sizeInBytes(@NonNegative long sizeInBytes)
+    long sizeInBytes(@NonNegative long capacity)
             throws IllegalStateException;
 
     /**
-     * Sets the capacity of the array, in terms of the number of integers it can hold.
+     * Sets the capacity of the array as a count of elements, not bytes.
      *
-     * @param arrayLength the desired array capacity, in number of integers.
-     * @return this {@code ByteableIntArrayValues} instance.
+     * @param arrayLength the desired element count
+     * @return this instance for chaining
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
@@ -38,22 +38,22 @@ import net.openhft.chronicle.core.values.LongArrayValues;
 public interface ByteableLongArrayValues extends LongArrayValues, Byteable, DynamicallySized {
 
     /**
-     * Calculates the size in bytes needed to store the given number of long integers.
+     * Calculates the byte size required to hold the provided element capacity.
      *
-     * @param sizeInBytes the number of long integers to be stored.
-     * @return the size in bytes needed to store the specified number of long integers.
+     * @param capacity the number of elements
+     * @return total bytes needed for this capacity
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */
     @Override
-    long sizeInBytes(@NonNegative long sizeInBytes)
+    long sizeInBytes(@NonNegative long capacity)
             throws IllegalStateException;
 
     /**
-     * Sets the capacity of the array, in terms of the number of long integers it can hold.
+     * Sets the capacity of the array as a count of elements, not bytes.
      *
-     * @param arrayLength the desired array capacity, in number of long integers.
-     * @return this {@code ByteableLongArrayValues} instance.
+     * @param arrayLength the desired element count
+     * @return this instance for chaining
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
@@ -42,7 +42,7 @@ import net.openhft.chronicle.core.values.TwoLongValue;
  * apply to the first {@code long} value, providing a consistent interface for operations on both values.
  * <p>
  * Implementations of this interface should ensure thread safety and proper synchronization to maintain consistency
- * across threads, especially in multi-threaded environments. Additional optimizations and behaviors may be
+ * across threads, especially in multi-threaded environments. Additional optimisations and behaviours may be
  * implemented but are not mandated by this interface.
  * <p>
  * This documentation should be paired with specific class-level details in concrete implementations to guide

--- a/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
@@ -1,8 +1,7 @@
 /**
- * Provides classes and interfaces for handling references to arrays of
- * various primitive types with byte representation. This package is a part of
- * the Chronicle Bytes library, which offers high-performance byte manipulation
- * and I/O capabilities.
+ * Provides references to primitive values and arrays stored directly in a {@link net.openhft.chronicle.bytes.BytesStore}.
+ * These references permit low-level manipulation of off-heap or memory-mapped data.
+ * The reference objects themselves are not thread-safe.
  *
  * <p>Key classes and interfaces included in this package:
  * <ul>


### PR DESCRIPTION
## Summary
- improve British English wording
- clarify nullability and offset descriptions in `AbstractReference`
- document sentinel constants for binary references
- refine Javadoc in `Byteable*ArrayValues`
- revise package summary

## Testing
- `mvn -q verify` *(fails: mvn not found)*