### PR TITLE
Improve Javadoc across ref package

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -29,12 +29,12 @@ import java.nio.BufferUnderflowException;
 import java.nio.channels.FileLock;
 
 /**
- * Represents an abstract reference to a {@link BytesStore}.
+ * Base class for references backed by a {@link BytesStore}.
+ * <p>{@link #acceptNewBytesStore(BytesStore)} reserves the store and
+ * {@link #performClose()} releases it. Subclasses must call
+ * {@code throwExceptionIfClosed...()} before mutating state.</p>
  *
- * <p>This class provides an abstraction for managing a reference to a BytesStore. It provides
- * functionality to read and write data from/to the BytesStore, manage a reference count, and lock
- * resources.
- *
+ * @implSpec {@link #unmonitor()} propagates to the wrapped store.
  * @see BytesStore
  * @see Byteable
  * @see Closeable

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
@@ -29,11 +29,12 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
 
 /**
- * Represents a binary reference to a boolean value.
+ * Stores a boolean as a single byte.
+ * <p>The encoding uses {@code 0xB0} for {@code false} and {@code 0xB1} for
+ * {@code true} to avoid confusion with ASCII digits.</p>
  *
- * <p>This class encapsulates a reference to a boolean value stored in binary form. It provides
- * functionality to read and write a boolean value to/from a {@link BytesStore}.
- *
+ * @implNote Any other byte value yields undefined behaviour in
+ * {@link #getValue()}.
  * @see BytesStore
  * @see BooleanValue
  */
@@ -85,6 +86,8 @@ public class BinaryBooleanReference extends AbstractReference implements Boolean
      * @throws BufferUnderflowException If the bytes store contains insufficient data
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @implNote Behaviour is undefined if the stored byte is neither
+     * {@code 0xB0} nor {@code 0xB1}.
      */
     @Override
     public boolean getValue()

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
@@ -35,17 +35,10 @@ import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
 import static net.openhft.chronicle.bytes.ref.BinaryIntReference.INT_NOT_COMPLETE;
 
 /**
- * Represents a binary array of integers, backed by a {@link BytesStore}.
- * <p>
- * This class provides operations to access and manipulate an array of integers in binary form.
- * The integers are stored in a BytesStore, and this class provides various methods to perform
- * atomic operations, read/write values, and manage the state of the array.
- * <p>
- * The BinaryIntArrayReference class also contains the ability to throw exceptions in cases
- * of buffer underflows or illegal states, and to read the array in a volatile fashion,
- * ensuring a happens-before relationship between threads.
- * <p>
- * Example usage:
+ * Array of 32-bit values laid out as
+ * {@code [capacity][used][values...]} in little-endian order.
+ * Each entry is shifted by {@code SHIFT} bytes from {@code VALUES}.
+ * <p>Example usage:</p>
  * <pre>
  * BytesStore bytesStore = ...
  * BinaryIntArrayReference arrayRef = new BinaryIntArrayReference();
@@ -54,8 +47,8 @@ import static net.openhft.chronicle.bytes.ref.BinaryIntReference.INT_NOT_COMPLET
  * int value = arrayRef.getValueAt(5);
  * </pre>
  * <p>
- * Note: This class is not thread-safe, and external synchronization may be necessary if instances
- * are shared between threads. The data referenced is thread safe when the appropriate methods are used.
+ * Note: This class is not thread-safe. External synchronisation may be
+ * required if instances are shared between threads.
  */
 @SuppressWarnings("rawtypes")
 public class BinaryIntArrayReference extends AbstractReference implements ByteableIntArrayValues, BytesMarshallable {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -27,27 +27,22 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 /**
- * Represents a 32-bit integer in binary form, backed by a {@link BytesStore}.
- * <p>
- * This class provides various operations to access and manipulate a single integer in binary form.
- * The integer is stored in a BytesStore, and this class provides methods for atomic operations,
- * reading/writing the value, and managing its state.
- * <p>
- * The class also supports volatile reads, ordered writes, and compare-and-swap operations.
- * The maximum size of the backing storage is 4 bytes, corresponding to a 32-bit integer.
- * <p>
- * Example usage:
- * <pre>
- * BytesStore bytesStore = BytesStore.nativeStoreWithFixedCapacity(32);
+ * Holds a 32-bit integer in little-endian native order within a
+ * {@link BytesStore}.
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
  * try (BinaryIntReference ref = new BinaryIntReference()) {
- *     ref.bytesStore(bytesStore, 16, 4);
+ *     ref.bytesStore(store, offset, ref.maxSize());
  *     ref.setValue(10);
- *     int value = ref.getVolatileValue();
  * }
- * </pre>
- * <p>
- * Note: This class is not thread-safe. External synchronization may be necessary if instances
- * are shared between threads.
+ * }</pre>
+ *
+ * @implSpec All volatile methods provide a full happens-before edge. Ordered
+ * methods use lazy set semantics. {@link #maxSize()} always returns {@code
+ * Integer.BYTES}.
+ * @apiNote Negative values are valid; {@link #INT_NOT_COMPLETE} is only a
+ * replay sentinel.
  *
  * @see BytesStore
  * @see IntValue
@@ -183,6 +178,8 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
      * @throws BufferUnderflowException If the offset is too large
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @implSpec This atomic fetch-and-add forms a happens-before edge with
+     *           subsequent reads of the value.
      */
     @Override
     public int addValue(int delta)
@@ -219,6 +216,8 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
      * @throws BufferOverflowException If the offset is too large
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @implSpec A successful swap establishes a happens-before relation with
+     *           subsequent reads of the value.
      */
     @Override
     public boolean compareAndSwapValue(int expected, int value)

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
@@ -36,12 +36,11 @@ import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
 import static net.openhft.chronicle.bytes.ref.BinaryLongReference.LONG_NOT_COMPLETE;
 
 /**
- * Represents a binary array of 64-bit long values backed by a {@link BytesStore}.
- * <p>
- * This class provides various operations to access and manipulate an array of 64-bit long integers in binary form.
- * The long integers are stored in a BytesStore, and this class provides methods for reading and writing values at specific indices.
- * <p>
- * Example usage:
+ * Array of 64-bit values stored as
+ * {@code [capacity][used][values...]} in little-endian order.
+ * The value region starts at offset {@code VALUES} and each entry is shifted by
+ * {@code SHIFT} bytes.
+ * <p>Example usage:</p>
  * <pre>
  * BytesStore bytesStore = BytesStore.nativeStoreWithFixedCapacity(32);
  * BinaryLongArrayReference ref = new BinaryLongArrayReference(4); // Creates an array with 4 longs
@@ -50,7 +49,7 @@ import static net.openhft.chronicle.bytes.ref.BinaryLongReference.LONG_NOT_COMPL
  * long value = ref.getValueAt(0);
  * </pre>
  * <p>
- * Note: This class is not thread-safe. External synchronization may be necessary if instances
+ * Note: This class is not thread-safe. External synchronisation may be necessary if instances
  * are shared between threads.
  *
  * @see BytesStore

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -27,27 +27,14 @@ import java.nio.BufferOverflowException;
 import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
 
 /**
- * Represents a 64-bit long integer in binary form, backed by a {@link BytesStore}.
- * <p>
- * This class provides various operations to access and manipulate a single long integer in binary form.
- * The long integer is stored in a BytesStore, and this class provides methods for atomic operations,
- * reading/writing the value, and managing its state.
- * <p>
- * The class also supports volatile reads, ordered writes, and compare-and-swap operations.
- * The maximum size of the backing storage is 8 bytes, corresponding to a 64-bit long integer.
- * <p>
- * Example usage:
- * <pre>
- * BytesStore bytesStore = BytesStore.nativeStoreWithFixedCapacity(32);
- * try (BinaryLongReference ref = new BinaryLongReference()) {
- *     ref.bytesStore(bytesStore, 16, 8);
- *     ref.setValue(1234567890L);
- *     long value = ref.getVolatileValue();
- * }
- * </pre>
- * <p>
- * Note: This class is not thread-safe. External synchronization may be necessary if instances
- * are shared between threads.
+ * Holds a 64-bit long in little-endian binary form.
+ * <p>The value may temporarily be {@link #LONG_NOT_COMPLETE} when used as part
+ * of a state machine.</p>
+ *
+ * @implSpec Volatile and ordered methods follow the same guarantees as
+ * {@link java.util.concurrent.atomic.AtomicLong}.
+ * @apiNote Dereferencing a {@code null} store in {@link #toString()} is solely
+ * for debugging.
  *
  * @see BytesStore
  * @see LongReference
@@ -65,6 +52,8 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
      * @param bytes  The BytesStore from which bytes will be stored.
      * @param offset The starting point in bytes from where the value will be stored.
      * @param length The number of bytes that should be stored.
+     *               If {@code bytes} is a {@link HexDumpBytes}, the offset is
+     *               masked with {@link HexDumpBytes#MASK}.
      * @throws IllegalArgumentException If the length provided is not equal to 8.
      * @throws BufferOverflowException  If the bytes cannot be written.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
@@ -79,9 +68,8 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
         if (length != maxSize())
             throw new IllegalArgumentException();
 
-        if (bytes instanceof HexDumpBytes) {
-            offset &= MASK;
-        }
+        if (bytes instanceof HexDumpBytes)
+            offset &= MASK; // align with HexDump masking
 
         super.bytesStore(bytes, offset, length);
     }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
@@ -23,15 +23,15 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 import net.openhft.chronicle.core.values.IntArrayValues;
 
 /**
- * Represents an array of integer values, where each integer in the array is byteable and dynamically sized.
+ * Off-heap, contiguous array of signed 32-bit values.
  * <p>
- * Implementations of this interface should provide means to manage the array of integers, with
- * support for resizing the array dynamically. It is meant to be used where direct, low-level access
- * to the bytes representing the integer values is needed.
+ * Values must be stored contiguously following
+ * {@link BinaryIntArrayReference#SHIFT} in little-endian order.
  *
  * @see IntArrayValues
  * @see Byteable
  * @see DynamicallySized
+ * @see BinaryIntArrayReference
  */
 @SuppressWarnings("rawtypes")
 public interface ByteableIntArrayValues extends IntArrayValues, Byteable, DynamicallySized {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
@@ -23,16 +23,16 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 import net.openhft.chronicle.core.values.LongArrayValues;
 
 /**
- * Represents an array of long integer values, where each long integer in the array is byteable and dynamically sized.
+ * Off-heap, contiguous array of signed 64-bit values.
  * <p>
- * Implementations of this interface should provide means to manage the array of long integers, with
- * support for resizing the array dynamically. It is meant to be used where direct, low-level access
- * to the bytes representing the long integer values is needed.
- * 
+ * Implementations must store each value contiguously according to
+ * {@link BinaryLongArrayReference#SHIFT} and are expected to use
+ * little-endian aligned storage.
  *
  * @see LongArrayValues
  * @see Byteable
  * @see DynamicallySized
+ * @see BinaryLongArrayReference
  */
 @SuppressWarnings("rawtypes")
 public interface ByteableLongArrayValues extends LongArrayValues, Byteable, DynamicallySized {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
@@ -26,13 +26,12 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 /**
- * TextBooleanReference is an implementation of a reference to a boolean value,
- * represented in text wire format. The class enables the efficient serialization
- * and deserialization of boolean values using a text-based representation.
- * <p>
- * The boolean values ' true' and 'false' are represented internally as
- * 32-bit integers in a specific format. The class also provides methods for
- * writing the boolean values into {@link BytesStore} objects.
+ * Reference to a fixed-width text boolean.
+ * <p>The format is four ASCII bytes containing either {@code " tru"}
+ * or {@code "fals"} and includes a simple spin-lock.</p>
+ *
+ * @implNote {@code FALSE} and {@code TRUE} hold the encoded text.
+ * @apiNote These classes target debugging, not production performance.
  */
 @SuppressWarnings("rawtypes")
 public class TextBooleanReference extends AbstractReference implements BooleanValue {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
@@ -29,14 +29,13 @@ import java.nio.BufferOverflowException;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * TextIntArrayReference is an implementation of a reference to an array of integers, represented
- * in a text format. It extends AbstractReference and implements ByteableIntArrayValues. This class
- * facilitates the serialization and deserialization of an array of integers in a custom textual
- * representation. The text representation is structured as JSON-like content.
- * <p>
- * The format of the text representation of an integer array is:
- * {@code { capacity: 00000001234, used: 0000000128, values: [ 1234567890, ... ] }}
- * 
+ * Fixed-width text array of 32-bit integers for diagnostics.
+ * <p>The bytes encode {@code capacity}, {@code used} and zero-padded values.
+ * Locking relies on the {@code locked} flag in each entry.</p>
+ *
+ * @implNote Magic constants such as {@code FALSE} and {@code TRUE} hold the
+ * lock state.
+ * @apiNote Debugging aid; not for high performance operations.
  */
 @SuppressWarnings("rawtypes")
 public class TextIntArrayReference extends AbstractReference implements ByteableIntArrayValues {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
@@ -31,13 +31,11 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static net.openhft.chronicle.bytes.BytesUtil.roundUpTo8ByteAlign;
 
 /**
- * TextIntReference is an implementation of a reference to a 32-bit integer, represented
- * in text wire format. It extends AbstractReference and implements IntValue. The text representation
- * is formatted to resemble a JSON-like content for an atomic 32-bit integer with a lock indicator.
- * <p>
- * The format of the text representation is:
- * {@code !!atomic { locked: false, value: 0000000000 }}
- * 
+ * Reference to a 10-digit, zero-padded integer in text form.
+ * <p>The 34-byte layout embeds a CAS-based lock.</p>
+ *
+ * @implNote {@code FALSE} and {@code TRUE} store the lock field.
+ * @apiNote Debug-only; avoid on performance critical paths.
  */
 @SuppressWarnings("rawtypes")
 public class TextIntReference extends AbstractReference implements IntValue {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -31,15 +31,11 @@ import java.nio.BufferUnderflowException;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * TextLongArrayReference is an implementation of a reference to a long array, represented
- * in text wire format. It extends AbstractReference and implements ByteableLongArrayValues.
- * The text representation is formatted to resemble a JSON-like content for an array of long values with a lock indicator.
- * <p>
- * The format of the text representation is:
- * {@code { capacity: 12345678901234567890, used: 00000000000000000000, values: [ 12345678901234567890, ... ] }}
- * 
+ * Fixed-width text array of 64-bit integers for diagnostics.
+ * <p>Each entry is zero padded to twenty digits and guarded by a spin-lock flag.</p>
  *
- * @author Peter Lawrey
+ * @implNote Constants such as {@code TRU} and {@code FALS} encode the lock state.
+ * @apiNote For debugging only, not tuned for throughput.
  */
 @SuppressWarnings("rawtypes")
 public class TextLongArrayReference extends AbstractReference implements ByteableLongArrayValues {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
@@ -31,9 +31,14 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static net.openhft.chronicle.bytes.BytesUtil.roundUpTo8ByteAlign;
 
 /**
- * Implementation of a reference to an array of 64-bit long values in Text wire format.
- * The text representation includes an atomic lock flag along with the value.
- * The format is: {@code !!atomic {  locked: false, value: 00000000000000000000 } }.
+ * Reference to a 20-digit, zero-padded long held in text format.
+ * <p>The layout is exactly {@code 34} bytes and includes a spin-lock
+ * flag.  The lock is obtained via CAS in {@link #withLock(ThrowingLongSupplier)}.</p>
+ *
+ * @implNote {@code FALSE} and {@code TRUE} encode the lock state as four ASCII
+ * characters.
+ * @apiNote These text classes are intended for debugging rather than production
+ * use.
  */
 @SuppressWarnings("rawtypes")
 public class TextLongReference extends AbstractReference implements LongReference {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
@@ -19,38 +19,12 @@ import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.core.values.TwoLongValue;
 
 /**
- * Interface defining a reference to two {@code long} values stored in off-heap memory or memory-mapped files,
- * facilitating direct, efficient manipulation of these values with support for various memory ordering semantics.
- * <p>
- * This interface extends {@link net.openhft.chronicle.core.values.TwoLongValue}, which provides the basic
- * operations for interacting with two separate {@code long} values, and implements {@link net.openhft.chronicle.bytes.Byteable}
- * to allow these values to be backed directly by a {@link net.openhft.chronicle.bytes.Bytes} storage mechanism.
- * <p>
- * Implementations must handle the storage and retrieval of these two long values, ensuring that operations
- * on them respect the semantics of memory ordering prescribed by their method signatures. This interface
- * is particularly useful in low-latency environments where operations directly on raw memory are necessary.
- * <p>
- * Key methods inherited from {@link net.openhft.chronicle.core.values.TwoLongValue} include:
- * <ul>
- *     <li>{@code getValue2()}, {@code setValue2(long)} - Access and update the second {@code long} value.</li>
- *     <li>{@code getVolatileValue2()}, {@code setVolatileValue2(long)} - Volatile read and write operations on the second {@code long} value.</li>
- *     <li>{@code addValue2(long)} - Atomically adds to the second {@code long} value.</li>
- *     <li>{@code compareAndSwapValue2(long, long)} - Attempts to set the second {@code long} value if it matches an expected value.</li>
- * </ul>
- * <p>
- * The methods {@code getValue()} and {@code setValue(long)} from {@link net.openhft.chronicle.core.values.LongValue}
- * apply to the first {@code long} value, providing a consistent interface for operations on both values.
- * <p>
- * Implementations of this interface should ensure thread safety and proper synchronization to maintain consistency
- * across threads, especially in multi-threaded environments. Additional optimisations and behaviours may be
- * implemented but are not mandated by this interface.
- * <p>
- * This documentation should be paired with specific class-level details in concrete implementations to guide
- * developers on the expected performance characteristics and operational specifics.
+ * Reference to two contiguous 64-bit values.
  *
- * @author Peter Lawrey
- * @see net.openhft.chronicle.bytes.Byteable
- * @see net.openhft.chronicle.core.values.TwoLongValue
+ * <p>The interface itself does not prescribe thread-safety; the
+ * implementation decides.</p>
+ *
+ * @see BinaryTwoLongReference
  */
 @SuppressWarnings("rawtypes")
 public interface TwoLongReference extends TwoLongValue, Byteable {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
@@ -28,11 +28,12 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 /**
- * A class for managing references to long values stored in a {@link BytesStore} without performing bounds checking.
- * This class is optimized for high performance in scenarios involving off-heap memory or memory-mapped files where bounds checks could impair performance.
- * <p>
- * This class is thread-safe provided that external synchronization is applied. It uses different implementations based on the JVM's debug status:
- * in debug mode, it uses {@link BinaryLongReference} for safety checks; otherwise, it uses {@link UncheckedLongReference} for better performance.
+ * Unsafe view of a long value with no bounds checking.
+ * <p>The {@link #create(BytesStore, long, int)} factory chooses
+ * {@link BinaryLongReference} when {@link Jvm#isDebug()} is true and otherwise
+ * returns an {@code UncheckedLongReference}.</p>
+ *
+ * All methods are unsafe: callers must ensure bounds and thread discipline.
  *
  * @see LongReference
  * @see ReferenceOwner

--- a/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
@@ -7,7 +7,7 @@
  * <ul>
  *     <li>{@link net.openhft.chronicle.bytes.ref.AbstractReference} - A base class representing a reference to a byte store.</li>
  *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryBooleanReference} - A concrete implementation for reading and writing boolean values in binary format.</li>
- *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryIntArrayReference} - Represents a binary array of 64-bit integers with support for reading, writing, and reference counts.</li>
+ *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryIntArrayReference} - Represents a binary array of 32-bit integers.</li>
  *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryIntReference} - Represents a 32-bit integer value in binary form.</li>
  *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryLongArrayReference} - Represents an array of 64-bit values in binary format.</li>
  *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryLongReference} - Represents a 64-bit long reference in binary format.</li>
@@ -24,11 +24,11 @@
  *     <li>{@link net.openhft.chronicle.bytes.ref.UncheckedLongReference} - Provides an unchecked reference to a 64-bit long value.</li>
  * </ul>
  *
- * <p>This package is mainly used when there is a need for efficient low-level manipulation
- * of arrays and values at the byte level, for instance, when working with memory-mapped files
- * or high-performance I/O.
+ * <p>Binary references are suited to latency-sensitive code whereas the text variants
+ * exist primarily for debugging. See {@link net.openhft.chronicle.bytes.ref} and the
+ * <a href="../adoc/wire-integration.adoc">wire integration guide</a> for usage advice.</p>
  *
- * @author OpenHFT
+ * @apiNote Prefer binary classes on the hot path; use text classes for observability.
  * @see net.openhft.chronicle.bytes.BytesStore
  * @see net.openhft.chronicle.bytes.Byteable
  */


### PR DESCRIPTION
## Summary
- refine BinaryIntReference docs
- clarify byte array interfaces and array reference classes
- document text reference formats and locking
- add sentinel and masking notes for binary classes
- update package overview and other helper classes

## Testing
- `mvn -q verify` *(fails: command not found)*
- `javadoc -Xdoclint:all -quiet -d /tmp/javadoc.out $(find src/main/java -name '*.java')` *(fails: missing dependencies)*