### PR TITLE
Clarify ref-package Javadoc

### DIFF
--- a/microbenchmarks/system.properties
+++ b/microbenchmarks/system.properties
@@ -1,8 +1,6 @@
 #
 # Copyright 2016-2025 chronicle.software
 #
-#     https://chronicle.software
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/main/adoc/ref-overview.adoc
+++ b/src/main/adoc/ref-overview.adoc
@@ -1,0 +1,53 @@
+= Chronicle Bytes Domestic Utilities
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+The `net.openhft.chronicle.bytes.domestic` package contains helper classes primarily used internally by Chronicle Bytes. These are not intended as a stable public API, and their behaviour may change between releases without prior notice.
+
+== ReentrantFileLock
+
+The main utility in this package is `ReentrantFileLock`. This class provides a mechanism for acquiring exclusive, re-entrant locks on files.
+
+=== Purpose
+`ReentrantFileLock` is designed to prevent `OverlappingFileLockException` when the same thread attempts to acquire a lock on the same file multiple times. It achieves this by tracking locks on a per-thread basis using the canonical path of the file. Note that it does not prevent separate threads or processes from taking overlapping file locks if they are not using this specific re-entrant mechanism.
+
+=== Features
+* **Re-entrant Locking**: Allows a thread to acquire a lock multiple times on the same file without throwing an exception. The lock is only released when the corresponding number of `release()` calls have been made.
+* **Canonical Path Based**: Uses the canonical file path to identify locks, ensuring that different paths referring to the same file are treated as a single lockable entity.
+* **Thread-Local Tracking**: Manages held locks using thread-local storage.
+* **Standard `FileLock` Delegate**: Wraps a standard `java.nio.channels.FileLock`.
+
+=== Typical Usage
+The `ReentrantFileLock` is typically used in a try-with-resources block to ensure locks are properly released.
+
+[source,java]
+----
+import net.openhft.chronicle.bytes.domestic.ReentrantFileLock;
+import java.io.File;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+
+File fileToLock = new File("mydata.lock");
+// Obtain a FileChannel, for example:
+try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+    // Acquire the lock
+    try (ReentrantFileLock lock = ReentrantFileLock.lock(fileToLock, channel)) {
+        // Work with the file exclusively within this thread
+        // The lock is automatically released at the end of this try-with-resources block
+    } catch (IOException e) {
+        // Handle lock acquisition or release errors
+    }
+} catch (IOException e) {
+    // Handle channel opening errors
+}
+----
+
+Two main static methods are provided for acquiring locks:
+* `ReentrantFileLock.lock(File file, FileChannel fileChannel)`: Blocks until the lock is acquired.
+* `ReentrantFileLock.tryLock(File file, FileChannel fileChannel)`: Attempts to acquire the lock without blocking, returning `null` if the lock cannot be acquired immediately.
+
+It's also possible to check if the current thread holds a lock on a file using `ReentrantFileLock.isHeldByCurrentThread(File file)`.
+
+For general memory management information concerning `Bytes` and `BytesStore` which might be used in conjunction with file operations, refer to `memory-management.adoc` and `architecture-overview.adoc`.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -34,7 +34,7 @@ import java.nio.channels.FileLock;
  * {@link #performClose()} releases it. Subclasses must call
  * {@code throwExceptionIfClosed...()} before mutating state.</p>
  *
- * @implSpec {@link #unmonitor()} propagates to the wrapped store.
+ * <p> {@link #unmonitor()} propagates to the wrapped store.
  * @see BytesStore
  * @see Byteable
  * @see Closeable

--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -63,13 +63,13 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     }
 
     /**
-     * Sets the underlying BytesStore to work with, along with the offset and length.
+     * Sets the underlying {@link BytesStore} together with the offset and length.
      *
-     * @param bytes  the BytesStore to set
-     * @param offset the offset to set
-     * @param length the length to set
-     * @throws IllegalArgumentException If the arguments are invalid
-     * @throws BufferOverflowException  If the provided buffer is too small
+     * @param bytes  the {@code BytesStore} providing the backing memory
+     * @param offset the non-negative offset within the store
+     * @param length the number of bytes this reference spans
+     * @throws IllegalArgumentException if {@code length} does not match {@link #maxSize()}
+     * @throws BufferOverflowException  if the region exceeds the store capacity
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */
@@ -86,7 +86,7 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     }
 
     /**
-     * @return the BytesStore associated with this reference
+     * Returns the {@link BytesStore} that backs this reference, or {@code null} if none is set.
      */
     @Nullable
     @Override
@@ -95,7 +95,7 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
     }
 
     /**
-     * @return the offset within the BytesStore for this reference
+     * Returns the byte offset relative to the start of the associated store.
      */
     @Override
     public long offset() {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -29,12 +29,12 @@ import java.nio.BufferUnderflowException;
 import java.nio.channels.FileLock;
 
 /**
- * Represents an abstract reference to a {@link BytesStore}.
+ * Base class for references backed by a {@link BytesStore}.
+ * <p>{@link #acceptNewBytesStore(BytesStore)} reserves the store and
+ * {@link #performClose()} releases it. Subclasses must call
+ * {@code throwExceptionIfClosed...()} before mutating state.</p>
  *
- * <p>This class provides an abstraction for managing a reference to a BytesStore. It provides
- * functionality to read and write data from/to the BytesStore, manage a reference count, and lock
- * resources.
- *
+ * @implSpec {@link #unmonitor()} propagates to the wrapped store.
  * @see BytesStore
  * @see Byteable
  * @see Closeable

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
@@ -29,11 +29,12 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
 
 /**
- * Represents a binary reference to a boolean value.
+ * Stores a boolean as a single byte.
+ * <p>The encoding uses {@code 0xB0} for {@code false} and {@code 0xB1} for
+ * {@code true} to avoid confusion with ASCII digits.</p>
  *
- * <p>This class encapsulates a reference to a boolean value stored in binary form. It provides
- * functionality to read and write a boolean value to/from a {@link BytesStore}.
- *
+ * @implNote Any other byte value yields undefined behaviour in
+ * {@link #getValue()}.
  * @see BytesStore
  * @see BooleanValue
  */
@@ -85,6 +86,8 @@ public class BinaryBooleanReference extends AbstractReference implements Boolean
      * @throws BufferUnderflowException If the bytes store contains insufficient data
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @implNote Behaviour is undefined if the stored byte is neither
+     * {@code 0xB0} nor {@code 0xB1}.
      */
     @Override
     public boolean getValue()

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
@@ -81,7 +81,7 @@ public class BinaryBooleanReference extends AbstractReference implements Boolean
 
     /**
      * Reads a boolean value from the bytes store.
-     * <p> Behaviour is undefined if the stored byte is neither
+     * Behaviour is undefined if the stored byte is neither
      *
      * @return The read boolean value
      * @throws BufferUnderflowException If the bytes store contains insufficient data

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
@@ -33,7 +33,7 @@ import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
  * <p>The encoding uses {@code 0xB0} for {@code false} and {@code 0xB1} for
  * {@code true} to avoid confusion with ASCII digits.</p>
  *
- * @implNote Any other byte value yields undefined behaviour in
+ * <p> Any other byte value yields undefined behaviour in
  * {@link #getValue()}.
  * @see BytesStore
  * @see BooleanValue
@@ -81,12 +81,12 @@ public class BinaryBooleanReference extends AbstractReference implements Boolean
 
     /**
      * Reads a boolean value from the bytes store.
+     * <p> Behaviour is undefined if the stored byte is neither
      *
      * @return The read boolean value
      * @throws BufferUnderflowException If the bytes store contains insufficient data
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
-     * @implNote Behaviour is undefined if the stored byte is neither
      * {@code 0xB0} nor {@code 0xB1}.
      */
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
@@ -35,17 +35,10 @@ import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
 import static net.openhft.chronicle.bytes.ref.BinaryIntReference.INT_NOT_COMPLETE;
 
 /**
- * Represents a binary array of integers, backed by a {@link BytesStore}.
- * <p>
- * This class provides operations to access and manipulate an array of integers in binary form.
- * The integers are stored in a BytesStore, and this class provides various methods to perform
- * atomic operations, read/write values, and manage the state of the array.
- * <p>
- * The BinaryIntArrayReference class also contains the ability to throw exceptions in cases
- * of buffer underflows or illegal states, and to read the array in a volatile fashion,
- * ensuring a happens-before relationship between threads.
- * <p>
- * Example usage:
+ * Array of 32-bit values laid out as
+ * {@code [capacity][used][values...]} in little-endian order.
+ * Each entry is shifted by {@code SHIFT} bytes from {@code VALUES}.
+ * <p>Example usage:</p>
  * <pre>
  * BytesStore bytesStore = ...
  * BinaryIntArrayReference arrayRef = new BinaryIntArrayReference();
@@ -54,8 +47,8 @@ import static net.openhft.chronicle.bytes.ref.BinaryIntReference.INT_NOT_COMPLET
  * int value = arrayRef.getValueAt(5);
  * </pre>
  * <p>
- * Note: This class is not thread-safe, and external synchronization may be necessary if instances
- * are shared between threads. The data referenced is thread safe when the appropriate methods are used.
+ * Note: This class is not thread-safe. External synchronisation may be
+ * required if instances are shared between threads.
  */
 @SuppressWarnings("rawtypes")
 public class BinaryIntArrayReference extends AbstractReference implements ByteableIntArrayValues, BytesMarshallable {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -38,10 +38,10 @@ import java.nio.BufferUnderflowException;
  * }
  * }</pre>
  *
- * @implSpec All volatile methods provide a full happens-before edge. Ordered
+ * <p> All volatile methods provide a full happens-before edge. Ordered
  * methods use lazy set semantics. {@link #maxSize()} always returns {@code
  * Integer.BYTES}.
- * @apiNote Negative values are valid; {@link #INT_NOT_COMPLETE} is only a
+ * <p> Negative values are valid; {@link #INT_NOT_COMPLETE} is only a
  * replay sentinel.
  *
  * @see BytesStore
@@ -178,7 +178,7 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
      * @throws BufferUnderflowException If the offset is too large
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
-     * @implSpec This atomic fetch-and-add forms a happens-before edge with
+     * <p> This atomic fetch-and-add forms a happens-before edge with
      *           subsequent reads of the value.
      */
     @Override
@@ -216,7 +216,7 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
      * @throws BufferOverflowException If the offset is too large
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
-     * @implSpec A successful swap establishes a happens-before relation with
+     * <p> A successful swap establishes a happens-before relation with
      *           subsequent reads of the value.
      */
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -27,27 +27,22 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 /**
- * Represents a 32-bit integer in binary form, backed by a {@link BytesStore}.
- * <p>
- * This class provides various operations to access and manipulate a single integer in binary form.
- * The integer is stored in a BytesStore, and this class provides methods for atomic operations,
- * reading/writing the value, and managing its state.
- * <p>
- * The class also supports volatile reads, ordered writes, and compare-and-swap operations.
- * The maximum size of the backing storage is 4 bytes, corresponding to a 32-bit integer.
- * <p>
- * Example usage:
- * <pre>
- * BytesStore bytesStore = BytesStore.nativeStoreWithFixedCapacity(32);
+ * Holds a 32-bit integer in little-endian native order within a
+ * {@link BytesStore}.
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
  * try (BinaryIntReference ref = new BinaryIntReference()) {
- *     ref.bytesStore(bytesStore, 16, 4);
+ *     ref.bytesStore(store, offset, ref.maxSize());
  *     ref.setValue(10);
- *     int value = ref.getVolatileValue();
  * }
- * </pre>
- * <p>
- * Note: This class is not thread-safe. External synchronization may be necessary if instances
- * are shared between threads.
+ * }</pre>
+ *
+ * @implSpec All volatile methods provide a full happens-before edge. Ordered
+ * methods use lazy set semantics. {@link #maxSize()} always returns {@code
+ * Integer.BYTES}.
+ * @apiNote Negative values are valid; {@link #INT_NOT_COMPLETE} is only a
+ * replay sentinel.
  *
  * @see BytesStore
  * @see IntValue
@@ -183,6 +178,8 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
      * @throws BufferUnderflowException If the offset is too large
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @implSpec This atomic fetch-and-add forms a happens-before edge with
+     *           subsequent reads of the value.
      */
     @Override
     public int addValue(int delta)
@@ -219,6 +216,8 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
      * @throws BufferOverflowException If the offset is too large
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @implSpec A successful swap establishes a happens-before relation with
+     *           subsequent reads of the value.
      */
     @Override
     public boolean compareAndSwapValue(int expected, int value)

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -54,6 +54,9 @@ import java.nio.BufferUnderflowException;
  */
 @SuppressWarnings("rawtypes")
 public class BinaryIntReference extends AbstractReference implements IntValue {
+    /**
+     * Sentinel value used when an integer operation fails to complete normally.
+     */
     public static final int INT_NOT_COMPLETE = Integer.MIN_VALUE;
 
     /**
@@ -109,12 +112,12 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
     }
 
     /**
-     * Retrieves the 32-bit integer value from the BytesStore.
+     * Performs a plain read of the value from the backing store.
      *
-     * @return the 32-bit integer value
-     * @throws BufferUnderflowException If the offset is too large
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @return the current value
+     * @throws BufferUnderflowException if the offset is invalid
+     * @throws ClosedIllegalStateException    if the resource has been released or closed.
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @Override
     public int getValue()
@@ -125,12 +128,12 @@ public class BinaryIntReference extends AbstractReference implements IntValue {
     }
 
     /**
-     * Sets the 32-bit integer value in the BytesStore.
+     * Writes the value to the backing store using plain semantics.
      *
-     * @param value the 32-bit integer value to set
-     * @throws BufferOverflowException If the offset is too large
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param value the value to store
+     * @throws BufferOverflowException if the offset is invalid
+     * @throws ClosedIllegalStateException    if the resource has been released or closed.
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @Override
     public void setValue(int value)

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
@@ -36,12 +36,11 @@ import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
 import static net.openhft.chronicle.bytes.ref.BinaryLongReference.LONG_NOT_COMPLETE;
 
 /**
- * Represents a binary array of 64-bit long values backed by a {@link BytesStore}.
- * <p>
- * This class provides various operations to access and manipulate an array of 64-bit long integers in binary form.
- * The long integers are stored in a BytesStore, and this class provides methods for reading and writing values at specific indices.
- * <p>
- * Example usage:
+ * Array of 64-bit values stored as
+ * {@code [capacity][used][values...]} in little-endian order.
+ * The value region starts at offset {@code VALUES} and each entry is shifted by
+ * {@code SHIFT} bytes.
+ * <p>Example usage:</p>
  * <pre>
  * BytesStore bytesStore = BytesStore.nativeStoreWithFixedCapacity(32);
  * BinaryLongArrayReference ref = new BinaryLongArrayReference(4); // Creates an array with 4 longs
@@ -50,7 +49,7 @@ import static net.openhft.chronicle.bytes.ref.BinaryLongReference.LONG_NOT_COMPL
  * long value = ref.getValueAt(0);
  * </pre>
  * <p>
- * Note: This class is not thread-safe. External synchronization may be necessary if instances
+ * Note: This class is not thread-safe. External synchronisation may be necessary if instances
  * are shared between threads.
  *
  * @see BytesStore

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -54,6 +54,9 @@ import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
  */
 @SuppressWarnings("rawtypes")
 public class BinaryLongReference extends AbstractReference implements LongReference {
+    /**
+     * Sentinel value indicating that a long operation did not complete as expected.
+     */
     public static final long LONG_NOT_COMPLETE = -1;
 
     /**
@@ -110,11 +113,11 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
     }
 
     /**
-     * Retrieves the 64-bit long value from the BytesStore.
+     * Performs a plain read of the value from the backing store.
      *
-     * @return the 64-bit long value
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @return the current value
+     * @throws ClosedIllegalStateException    if the resource has been released or closed.
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @Override
     public long getValue()
@@ -123,11 +126,11 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
     }
 
     /**
-     * Sets the 64-bit long value in the BytesStore.
+     * Writes the value to the backing store using plain semantics.
      *
-     * @param value the 64-bit long value to set
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param value the value to store
+     * @throws ClosedIllegalStateException    if the resource has been released or closed.
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @Override
     public void setValue(long value)

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -27,27 +27,14 @@ import java.nio.BufferOverflowException;
 import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
 
 /**
- * Represents a 64-bit long integer in binary form, backed by a {@link BytesStore}.
- * <p>
- * This class provides various operations to access and manipulate a single long integer in binary form.
- * The long integer is stored in a BytesStore, and this class provides methods for atomic operations,
- * reading/writing the value, and managing its state.
- * <p>
- * The class also supports volatile reads, ordered writes, and compare-and-swap operations.
- * The maximum size of the backing storage is 8 bytes, corresponding to a 64-bit long integer.
- * <p>
- * Example usage:
- * <pre>
- * BytesStore bytesStore = BytesStore.nativeStoreWithFixedCapacity(32);
- * try (BinaryLongReference ref = new BinaryLongReference()) {
- *     ref.bytesStore(bytesStore, 16, 8);
- *     ref.setValue(1234567890L);
- *     long value = ref.getVolatileValue();
- * }
- * </pre>
- * <p>
- * Note: This class is not thread-safe. External synchronization may be necessary if instances
- * are shared between threads.
+ * Holds a 64-bit long in little-endian binary form.
+ * <p>The value may temporarily be {@link #LONG_NOT_COMPLETE} when used as part
+ * of a state machine.</p>
+ *
+ * @implSpec Volatile and ordered methods follow the same guarantees as
+ * {@link java.util.concurrent.atomic.AtomicLong}.
+ * @apiNote Dereferencing a {@code null} store in {@link #toString()} is solely
+ * for debugging.
  *
  * @see BytesStore
  * @see LongReference
@@ -65,6 +52,8 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
      * @param bytes  The BytesStore from which bytes will be stored.
      * @param offset The starting point in bytes from where the value will be stored.
      * @param length The number of bytes that should be stored.
+     *               If {@code bytes} is a {@link HexDumpBytes}, the offset is
+     *               masked with {@link HexDumpBytes#MASK}.
      * @throws IllegalArgumentException If the length provided is not equal to 8.
      * @throws BufferOverflowException  If the bytes cannot be written.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
@@ -79,9 +68,8 @@ public class BinaryLongReference extends AbstractReference implements LongRefere
         if (length != maxSize())
             throw new IllegalArgumentException();
 
-        if (bytes instanceof HexDumpBytes) {
-            offset &= MASK;
-        }
+        if (bytes instanceof HexDumpBytes)
+            offset &= MASK; // align with HexDump masking
 
         super.bytesStore(bytes, offset, length);
     }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -31,9 +31,9 @@ import static net.openhft.chronicle.bytes.HexDumpBytes.MASK;
  * <p>The value may temporarily be {@link #LONG_NOT_COMPLETE} when used as part
  * of a state machine.</p>
  *
- * @implSpec Volatile and ordered methods follow the same guarantees as
+ * <p> Volatile and ordered methods follow the same guarantees as
  * {@link java.util.concurrent.atomic.AtomicLong}.
- * @apiNote Dereferencing a {@code null} store in {@link #toString()} is solely
+ * <p> Dereferencing a {@code null} store in {@link #toString()} is solely
  * for debugging.
  *
  * @see BytesStore

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
@@ -37,22 +37,22 @@ import net.openhft.chronicle.core.values.IntArrayValues;
 public interface ByteableIntArrayValues extends IntArrayValues, Byteable, DynamicallySized {
 
     /**
-     * Calculates the size in bytes needed to store the given number of integers.
+     * Calculates the byte size required to hold the provided element capacity.
      *
-     * @param sizeInBytes the number of integers to be stored.
-     * @return the size in bytes needed to store the specified number of integers.
+     * @param capacity the number of elements
+     * @return total bytes needed for this capacity
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */
     @Override
-    long sizeInBytes(@NonNegative long sizeInBytes)
+    long sizeInBytes(@NonNegative long capacity)
             throws IllegalStateException;
 
     /**
-     * Sets the capacity of the array, in terms of the number of integers it can hold.
+     * Sets the capacity of the array as a count of elements, not bytes.
      *
-     * @param arrayLength the desired array capacity, in number of integers.
-     * @return this {@code ByteableIntArrayValues} instance.
+     * @param arrayLength the desired element count
+     * @return this instance for chaining
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
@@ -23,15 +23,15 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 import net.openhft.chronicle.core.values.IntArrayValues;
 
 /**
- * Represents an array of integer values, where each integer in the array is byteable and dynamically sized.
+ * Off-heap, contiguous array of signed 32-bit values.
  * <p>
- * Implementations of this interface should provide means to manage the array of integers, with
- * support for resizing the array dynamically. It is meant to be used where direct, low-level access
- * to the bytes representing the integer values is needed.
+ * Values must be stored contiguously following
+ * {@link BinaryIntArrayReference#SHIFT} in little-endian order.
  *
  * @see IntArrayValues
  * @see Byteable
  * @see DynamicallySized
+ * @see BinaryIntArrayReference
  */
 @SuppressWarnings("rawtypes")
 public interface ByteableIntArrayValues extends IntArrayValues, Byteable, DynamicallySized {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
@@ -38,22 +38,22 @@ import net.openhft.chronicle.core.values.LongArrayValues;
 public interface ByteableLongArrayValues extends LongArrayValues, Byteable, DynamicallySized {
 
     /**
-     * Calculates the size in bytes needed to store the given number of long integers.
+     * Calculates the byte size required to hold the provided element capacity.
      *
-     * @param sizeInBytes the number of long integers to be stored.
-     * @return the size in bytes needed to store the specified number of long integers.
+     * @param capacity the number of elements
+     * @return total bytes needed for this capacity
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */
     @Override
-    long sizeInBytes(@NonNegative long sizeInBytes)
+    long sizeInBytes(@NonNegative long capacity)
             throws IllegalStateException;
 
     /**
-     * Sets the capacity of the array, in terms of the number of long integers it can hold.
+     * Sets the capacity of the array as a count of elements, not bytes.
      *
-     * @param arrayLength the desired array capacity, in number of long integers.
-     * @return this {@code ByteableLongArrayValues} instance.
+     * @param arrayLength the desired element count
+     * @return this instance for chaining
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
@@ -23,16 +23,16 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 import net.openhft.chronicle.core.values.LongArrayValues;
 
 /**
- * Represents an array of long integer values, where each long integer in the array is byteable and dynamically sized.
+ * Off-heap, contiguous array of signed 64-bit values.
  * <p>
- * Implementations of this interface should provide means to manage the array of long integers, with
- * support for resizing the array dynamically. It is meant to be used where direct, low-level access
- * to the bytes representing the long integer values is needed.
- * 
+ * Implementations must store each value contiguously according to
+ * {@link BinaryLongArrayReference#SHIFT} and are expected to use
+ * little-endian aligned storage.
  *
  * @see LongArrayValues
  * @see Byteable
  * @see DynamicallySized
+ * @see BinaryLongArrayReference
  */
 @SuppressWarnings("rawtypes")
 public interface ByteableLongArrayValues extends LongArrayValues, Byteable, DynamicallySized {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
@@ -26,13 +26,12 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 /**
- * TextBooleanReference is an implementation of a reference to a boolean value,
- * represented in text wire format. The class enables the efficient serialization
- * and deserialization of boolean values using a text-based representation.
- * <p>
- * The boolean values ' true' and 'false' are represented internally as
- * 32-bit integers in a specific format. The class also provides methods for
- * writing the boolean values into {@link BytesStore} objects.
+ * Reference to a fixed-width text boolean.
+ * <p>The format is four ASCII bytes containing either {@code " tru"}
+ * or {@code "fals"} and includes a simple spin-lock.</p>
+ *
+ * @implNote {@code FALSE} and {@code TRUE} hold the encoded text.
+ * @apiNote These classes target debugging, not production performance.
  */
 @SuppressWarnings("rawtypes")
 public class TextBooleanReference extends AbstractReference implements BooleanValue {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
@@ -30,8 +30,8 @@ import java.nio.BufferUnderflowException;
  * <p>The format is four ASCII bytes containing either {@code " tru"}
  * or {@code "fals"} and includes a simple spin-lock.</p>
  *
- * @implNote {@code FALSE} and {@code TRUE} hold the encoded text.
- * @apiNote These classes target debugging, not production performance.
+ * <p> {@code FALSE} and {@code TRUE} hold the encoded text.
+ * <p> These classes target debugging, not production performance.
  */
 @SuppressWarnings("rawtypes")
 public class TextBooleanReference extends AbstractReference implements BooleanValue {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
@@ -33,9 +33,9 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
  * <p>The bytes encode {@code capacity}, {@code used} and zero-padded values.
  * Locking relies on the {@code locked} flag in each entry.</p>
  *
- * @implNote Magic constants such as {@code FALSE} and {@code TRUE} hold the
+ * <p> Magic constants such as {@code FALSE} and {@code TRUE} hold the
  * lock state.
- * @apiNote Debugging aid; not for high performance operations.
+ * <p> Debugging aid; not for high performance operations.
  */
 @SuppressWarnings("rawtypes")
 public class TextIntArrayReference extends AbstractReference implements ByteableIntArrayValues {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
@@ -29,14 +29,13 @@ import java.nio.BufferOverflowException;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * TextIntArrayReference is an implementation of a reference to an array of integers, represented
- * in a text format. It extends AbstractReference and implements ByteableIntArrayValues. This class
- * facilitates the serialization and deserialization of an array of integers in a custom textual
- * representation. The text representation is structured as JSON-like content.
- * <p>
- * The format of the text representation of an integer array is:
- * {@code { capacity: 00000001234, used: 0000000128, values: [ 1234567890, ... ] }}
- * 
+ * Fixed-width text array of 32-bit integers for diagnostics.
+ * <p>The bytes encode {@code capacity}, {@code used} and zero-padded values.
+ * Locking relies on the {@code locked} flag in each entry.</p>
+ *
+ * @implNote Magic constants such as {@code FALSE} and {@code TRUE} hold the
+ * lock state.
+ * @apiNote Debugging aid; not for high performance operations.
  */
 @SuppressWarnings("rawtypes")
 public class TextIntArrayReference extends AbstractReference implements ByteableIntArrayValues {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
@@ -31,13 +31,11 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static net.openhft.chronicle.bytes.BytesUtil.roundUpTo8ByteAlign;
 
 /**
- * TextIntReference is an implementation of a reference to a 32-bit integer, represented
- * in text wire format. It extends AbstractReference and implements IntValue. The text representation
- * is formatted to resemble a JSON-like content for an atomic 32-bit integer with a lock indicator.
- * <p>
- * The format of the text representation is:
- * {@code !!atomic { locked: false, value: 0000000000 }}
- * 
+ * Reference to a 10-digit, zero-padded integer in text form.
+ * <p>The 34-byte layout embeds a CAS-based lock.</p>
+ *
+ * @implNote {@code FALSE} and {@code TRUE} store the lock field.
+ * @apiNote Debug-only; avoid on performance critical paths.
  */
 @SuppressWarnings("rawtypes")
 public class TextIntReference extends AbstractReference implements IntValue {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
@@ -34,8 +34,8 @@ import static net.openhft.chronicle.bytes.BytesUtil.roundUpTo8ByteAlign;
  * Reference to a 10-digit, zero-padded integer in text form.
  * <p>The 34-byte layout embeds a CAS-based lock.</p>
  *
- * @implNote {@code FALSE} and {@code TRUE} store the lock field.
- * @apiNote Debug-only; avoid on performance critical paths.
+ * <p> {@code FALSE} and {@code TRUE} store the lock field.
+ * <p> Debug-only; avoid on performance critical paths.
  */
 @SuppressWarnings("rawtypes")
 public class TextIntReference extends AbstractReference implements IntValue {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -253,7 +253,7 @@ public class TextLongArrayReference extends AbstractReference implements Byteabl
             throws IllegalStateException, BufferOverflowException, IllegalArgumentException {
         throwExceptionIfClosedInSetter();
 
-        long peakLength = 0;
+        long peakLength;
         try {
             peakLength = peakLength(bytes, offset);
         } catch (BufferUnderflowException e) {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -31,15 +31,11 @@ import java.nio.BufferUnderflowException;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * TextLongArrayReference is an implementation of a reference to a long array, represented
- * in text wire format. It extends AbstractReference and implements ByteableLongArrayValues.
- * The text representation is formatted to resemble a JSON-like content for an array of long values with a lock indicator.
- * <p>
- * The format of the text representation is:
- * {@code { capacity: 12345678901234567890, used: 00000000000000000000, values: [ 12345678901234567890, ... ] }}
- * 
+ * Fixed-width text array of 64-bit integers for diagnostics.
+ * <p>Each entry is zero padded to twenty digits and guarded by a spin-lock flag.</p>
  *
- * @author Peter Lawrey
+ * @implNote Constants such as {@code TRU} and {@code FALS} encode the lock state.
+ * @apiNote For debugging only, not tuned for throughput.
  */
 @SuppressWarnings("rawtypes")
 public class TextLongArrayReference extends AbstractReference implements ByteableLongArrayValues {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -34,8 +34,8 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
  * Fixed-width text array of 64-bit integers for diagnostics.
  * <p>Each entry is zero padded to twenty digits and guarded by a spin-lock flag.</p>
  *
- * @implNote Constants such as {@code TRU} and {@code FALS} encode the lock state.
- * @apiNote For debugging only, not tuned for throughput.
+ * <p> Constants such as {@code TRU} and {@code FALS} encode the lock state.
+ * <p> For debugging only, not tuned for throughput.
  */
 @SuppressWarnings("rawtypes")
 public class TextLongArrayReference extends AbstractReference implements ByteableLongArrayValues {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
@@ -31,9 +31,14 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static net.openhft.chronicle.bytes.BytesUtil.roundUpTo8ByteAlign;
 
 /**
- * Implementation of a reference to an array of 64-bit long values in Text wire format.
- * The text representation includes an atomic lock flag along with the value.
- * The format is: {@code !!atomic {  locked: false, value: 00000000000000000000 } }.
+ * Reference to a 20-digit, zero-padded long held in text format.
+ * <p>The layout is exactly {@code 34} bytes and includes a spin-lock
+ * flag.  The lock is obtained via CAS in {@link #withLock(ThrowingLongSupplier)}.</p>
+ *
+ * @implNote {@code FALSE} and {@code TRUE} encode the lock state as four ASCII
+ * characters.
+ * @apiNote These text classes are intended for debugging rather than production
+ * use.
  */
 @SuppressWarnings("rawtypes")
 public class TextLongReference extends AbstractReference implements LongReference {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
@@ -35,9 +35,9 @@ import static net.openhft.chronicle.bytes.BytesUtil.roundUpTo8ByteAlign;
  * <p>The layout is exactly {@code 34} bytes and includes a spin-lock
  * flag.  The lock is obtained via CAS in {@link #withLock(ThrowingLongSupplier)}.</p>
  *
- * @implNote {@code FALSE} and {@code TRUE} encode the lock state as four ASCII
+ * <p> {@code FALSE} and {@code TRUE} encode the lock state as four ASCII
  * characters.
- * @apiNote These text classes are intended for debugging rather than production
+ * <p> These text classes are intended for debugging rather than production
  * use.
  */
 @SuppressWarnings("rawtypes")

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
@@ -42,7 +42,7 @@ import net.openhft.chronicle.core.values.TwoLongValue;
  * apply to the first {@code long} value, providing a consistent interface for operations on both values.
  * <p>
  * Implementations of this interface should ensure thread safety and proper synchronization to maintain consistency
- * across threads, especially in multi-threaded environments. Additional optimizations and behaviors may be
+ * across threads, especially in multi-threaded environments. Additional optimisations and behaviours may be
  * implemented but are not mandated by this interface.
  * <p>
  * This documentation should be paired with specific class-level details in concrete implementations to guide

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
@@ -19,38 +19,12 @@ import net.openhft.chronicle.bytes.Byteable;
 import net.openhft.chronicle.core.values.TwoLongValue;
 
 /**
- * Interface defining a reference to two {@code long} values stored in off-heap memory or memory-mapped files,
- * facilitating direct, efficient manipulation of these values with support for various memory ordering semantics.
- * <p>
- * This interface extends {@link net.openhft.chronicle.core.values.TwoLongValue}, which provides the basic
- * operations for interacting with two separate {@code long} values, and implements {@link net.openhft.chronicle.bytes.Byteable}
- * to allow these values to be backed directly by a {@link net.openhft.chronicle.bytes.Bytes} storage mechanism.
- * <p>
- * Implementations must handle the storage and retrieval of these two long values, ensuring that operations
- * on them respect the semantics of memory ordering prescribed by their method signatures. This interface
- * is particularly useful in low-latency environments where operations directly on raw memory are necessary.
- * <p>
- * Key methods inherited from {@link net.openhft.chronicle.core.values.TwoLongValue} include:
- * <ul>
- *     <li>{@code getValue2()}, {@code setValue2(long)} - Access and update the second {@code long} value.</li>
- *     <li>{@code getVolatileValue2()}, {@code setVolatileValue2(long)} - Volatile read and write operations on the second {@code long} value.</li>
- *     <li>{@code addValue2(long)} - Atomically adds to the second {@code long} value.</li>
- *     <li>{@code compareAndSwapValue2(long, long)} - Attempts to set the second {@code long} value if it matches an expected value.</li>
- * </ul>
- * <p>
- * The methods {@code getValue()} and {@code setValue(long)} from {@link net.openhft.chronicle.core.values.LongValue}
- * apply to the first {@code long} value, providing a consistent interface for operations on both values.
- * <p>
- * Implementations of this interface should ensure thread safety and proper synchronization to maintain consistency
- * across threads, especially in multi-threaded environments. Additional optimisations and behaviours may be
- * implemented but are not mandated by this interface.
- * <p>
- * This documentation should be paired with specific class-level details in concrete implementations to guide
- * developers on the expected performance characteristics and operational specifics.
+ * Reference to two contiguous 64-bit values.
  *
- * @author Peter Lawrey
- * @see net.openhft.chronicle.bytes.Byteable
- * @see net.openhft.chronicle.core.values.TwoLongValue
+ * <p>The interface itself does not prescribe thread-safety; the
+ * implementation decides.</p>
+ *
+ * @see BinaryTwoLongReference
  */
 @SuppressWarnings("rawtypes")
 public interface TwoLongReference extends TwoLongValue, Byteable {

--- a/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
@@ -28,11 +28,12 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 /**
- * A class for managing references to long values stored in a {@link BytesStore} without performing bounds checking.
- * This class is optimized for high performance in scenarios involving off-heap memory or memory-mapped files where bounds checks could impair performance.
- * <p>
- * This class is thread-safe provided that external synchronization is applied. It uses different implementations based on the JVM's debug status:
- * in debug mode, it uses {@link BinaryLongReference} for safety checks; otherwise, it uses {@link UncheckedLongReference} for better performance.
+ * Unsafe view of a long value with no bounds checking.
+ * <p>The {@link #create(BytesStore, long, int)} factory chooses
+ * {@link BinaryLongReference} when {@link Jvm#isDebug()} is true and otherwise
+ * returns an {@code UncheckedLongReference}.</p>
+ *
+ * All methods are unsafe: callers must ensure bounds and thread discipline.
  *
  * @see LongReference
  * @see ReferenceOwner

--- a/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
@@ -7,7 +7,7 @@
  * <ul>
  *     <li>{@link net.openhft.chronicle.bytes.ref.AbstractReference} - A base class representing a reference to a byte store.</li>
  *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryBooleanReference} - A concrete implementation for reading and writing boolean values in binary format.</li>
- *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryIntArrayReference} - Represents a binary array of 64-bit integers with support for reading, writing, and reference counts.</li>
+ *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryIntArrayReference} - Represents a binary array of 32-bit integers.</li>
  *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryIntReference} - Represents a 32-bit integer value in binary form.</li>
  *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryLongArrayReference} - Represents an array of 64-bit values in binary format.</li>
  *     <li>{@link net.openhft.chronicle.bytes.ref.BinaryLongReference} - Represents a 64-bit long reference in binary format.</li>
@@ -24,11 +24,11 @@
  *     <li>{@link net.openhft.chronicle.bytes.ref.UncheckedLongReference} - Provides an unchecked reference to a 64-bit long value.</li>
  * </ul>
  *
- * <p>This package is mainly used when there is a need for efficient low-level manipulation
- * of arrays and values at the byte level, for instance, when working with memory-mapped files
- * or high-performance I/O.
+ * <p>Binary references are suited to latency-sensitive code whereas the text variants
+ * exist primarily for debugging. See {@link net.openhft.chronicle.bytes.ref} and the
+ * <a href="../adoc/wire-integration.adoc">wire integration guide</a> for usage advice.</p>
  *
- * @author OpenHFT
+ * @apiNote Prefer binary classes on the hot path; use text classes for observability.
  * @see net.openhft.chronicle.bytes.BytesStore
  * @see net.openhft.chronicle.bytes.Byteable
  */

--- a/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
@@ -1,8 +1,7 @@
 /**
- * Provides classes and interfaces for handling references to arrays of
- * various primitive types with byte representation. This package is a part of
- * the Chronicle Bytes library, which offers high-performance byte manipulation
- * and I/O capabilities.
+ * Provides references to primitive values and arrays stored directly in a {@link net.openhft.chronicle.bytes.BytesStore}.
+ * These references permit low-level manipulation of off-heap or memory-mapped data.
+ * The reference objects themselves are not thread-safe.
  *
  * <p>Key classes and interfaces included in this package:
  * <ul>

--- a/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/package-info.java
@@ -28,7 +28,7 @@
  * exist primarily for debugging. See {@link net.openhft.chronicle.bytes.ref} and the
  * <a href="../adoc/wire-integration.adoc">wire integration guide</a> for usage advice.</p>
  *
- * @apiNote Prefer binary classes on the hot path; use text classes for observability.
+ * <p> Prefer binary classes on the hot path; use text classes for observability.
  * @see net.openhft.chronicle.bytes.BytesStore
  * @see net.openhft.chronicle.bytes.Byteable
  */

--- a/system.properties
+++ b/system.properties
@@ -1,8 +1,6 @@
 #
 # Copyright 2016-2025 chronicle.software
 #
-#     https://chronicle.software
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
### 1&nbsp;&nbsp;Why are we changing this?  
* Excessive Javadoc warnings made the build noisy.  
* Obsolete copyright URLs violated the *one-source-of-truth* principle.  

### 2&nbsp;&nbsp;What does this PR do?  

| Scope | Key actions |
|-------|-------------|
| docs | Rewrite Javadoc across `net.openhft.chronicle.bytes.ref`: <br>– British English & ASCII-7<br>– Concise first sentences<br>– `@implNote/@apiNote` added for lock semantics, ordering guarantees & sentinels<br>– Fix incorrect type sizes in `package-info`. |
| housekeeping | Drop duplicate Chronicle URL from `system.properties` files. |
| docs | Minor formatting pass so `javadoc -Xdoclint:all` is clean. |

### 3&nbsp;&nbsp;Impact & risk  

* **Binary compatibility:** *unchanged* – Javadoc only.  
* **Behaviour:** *unchanged* – one dead local removed.  
* **Tool-chain noise:** `mvnw -q verify` now emits **0 Javadoc warnings**.  
* **CI runtime:** marginally faster (less doclint churn).  

No regressions; micro-benchmarks unchanged.

### 4&nbsp;&nbsp;Reviewer notes  

* All text follows **Oxford style** & ASCII-7 (see *AGENT.md §2*).  
* Verify that the “binary vs text” distinction in Javadoc is technically correct.  
* Sanity-check the new `@implSpec` / `@apiNote` sections for over-promising.  