### PR TITLE
Improve Javadoc in algo, domestic and pool packages

### DIFF
--- a/src/main/adoc/algo-overview.adoc
+++ b/src/main/adoc/algo-overview.adoc
@@ -1,0 +1,17 @@
+= Chronicle Bytes Hash Algorithms
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+This module provides non-cryptographic hash functions for `BytesStore` data.
+It is typically used for in-memory indexes and integrity checks where speed is
+more important than collision resistance.
+
+.Common call flow
+```
+BytesStoreHash hash = OptimisedBytesStoreHash.INSTANCE;
+long value = hash.applyAsLong(bytesStore, bytesStore.readRemaining());
+```
+
+See `memory-management.adoc` for details about memory ownership and lifetimes.

--- a/src/main/adoc/domestic-overview.adoc
+++ b/src/main/adoc/domestic-overview.adoc
@@ -1,0 +1,20 @@
+= Chronicle Bytes Domestic Utilities
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+The domestic package contains helpers used by the rest of Chronicle Bytes but
+not intended as stable public API. Behaviour may change between releases.
+
+Typical usage is to acquire a reentrant file lock:
+```
+FileLock lock = ReentrantFileLock.lock(file, channel);
+try {
+    // work with the file
+} finally {
+    lock.release();
+}
+```
+
+For memory management information refer to `memory-management.adoc`.

--- a/src/main/adoc/pool-overview.adoc
+++ b/src/main/adoc/pool-overview.adoc
@@ -1,0 +1,17 @@
+= Chronicle Bytes Pooling
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+Pooling reuses `Bytes` objects to minimise allocation churn in very
+low-latency scenarios. Each thread keeps a small cache of instances.
+
+.Acquiring and releasing
+```
+try (Bytes<?> b = pool.acquire()) {
+    // use b
+}
+```
+
+See `memory-management.adoc` for advice on native memory budget.

--- a/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
@@ -26,8 +26,15 @@ import java.util.function.ToLongFunction;
 
 /**
  * Represents a function that computes a 64-bit hash value from a {@link BytesStore}.
- * This interface provides static methods for computing 32-bit and 64-bit hash values,
- * using either optimized or vanilla implementations.
+ * Implementations provide fast, deterministic hashing based on little-endian
+ * variants of the Murmur3 algorithm.
+ * This interface also exposes static helpers for computing 32-bit and 64-bit
+ * hashes using the bundled implementations.
+ *
+ * @implSpec Implementations should avoid allocating memory and may assume that
+ * {@code length} bytes can be read without extra bounds checks.
+ *
+ * See {@code algo-overview.adoc} for usage examples.
  *
  * @param <B> the type of {@link BytesStore} that this function can compute hash values for.
  */
@@ -39,6 +46,8 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      *
      * @param b the {@link BytesStore} to compute the hash for.
      * @return the 64-bit hash value.
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      */
     static long hash(@NotNull BytesStore<?, ?> b) {
         return b.isDirectMemory()
@@ -52,9 +61,9 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      * @param b      the {@link BytesStore} to compute the hash for.
      * @param length the number of bytes to include in the hash computation.
      * @return the 64-bit hash value.
-     * @throws BufferUnderflowException If the length specified is greater than the available bytes.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @throws BufferUnderflowException       if the length specified is greater than the available bytes
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      */
     static long hash(@NotNull BytesStore<?, ?> b, @NonNegative long length) throws IllegalStateException, BufferUnderflowException {
         return b.isDirectMemory()
@@ -67,6 +76,8 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      *
      * @param b the {@link BytesStore} to compute the hash for.
      * @return the 32-bit hash value.
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      */
     static int hash32(BytesStore<?, ?> b) {
         long hash = hash(b);
@@ -79,9 +90,9 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      * @param b      the {@link BytesStore} to compute the hash for.
      * @param length the number of bytes to include in the hash computation.
      * @return the 32-bit hash value.
-     * @throws BufferUnderflowException If the length specified is greater than the available bytes.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @throws BufferUnderflowException       if the length specified is greater than the available bytes
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      */
     static int hash32(@NotNull BytesStore<?, ?> b, @NonNegative int length) throws IllegalStateException, BufferUnderflowException {
         long hash = hash(b, length);
@@ -94,9 +105,11 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      * @param bytes  the {@link BytesStore} to compute the hash for.
      * @param length the number of bytes to include in the hash computation.
      * @return the 64-bit hash value.
-     * @throws BufferUnderflowException If the length specified is greater than the available bytes.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @throws BufferUnderflowException       if the length specified is greater than the available bytes
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
+     *
+     * @implNote Implementations are typically branch-free and perform no allocations.
      */
     long applyAsLong(BytesStore<?, ?> bytes, long length) throws IllegalStateException, BufferUnderflowException;
 }

--- a/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
@@ -30,28 +30,40 @@ import java.nio.ByteOrder;
 import static net.openhft.chronicle.bytes.algo.VanillaBytesStoreHash.*;
 
 /**
- * Optimized hashing algorithm for BytesStore.
+ * Optimised hashing algorithm for BytesStore.
  * <p>
- * This enumeration implements BytesStoreHash for optimized hashing of BytesStore
- * depending on the size of the data and architecture of the system.
+ * This enumeration implements BytesStoreHash for optimised hashing of BytesStore
+ * depending on the data size and whether the {@code BytesStore} resides in direct memory,
+ * leveraging system architecture details like endianness for performance.
  */
 @SuppressWarnings("rawtypes")
 public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
     INSTANCE;
 
+    /**
+     * Provides access to low-level memory operations for optimised hashing.
+     */
     public static final Memory MEMORY = OS.memory();
+    /**
+     * Flag indicating if the native byte order of the system is little-endian.
+     */
     public static final boolean IS_LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+    /**
+     * Offset used to select the top four bytes of a long, dependent on system endianness.
+     */
     private static final int TOP_BYTES = IS_LITTLE_ENDIAN ? 4 : 0;
 
     /**
      * Computes a 64-bit hash value for the given BytesStore for data sizes between 1 to 7 bytes.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (between 1 and 7 inclusive).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     *
+     * @implNote This method is on the hot path for small direct {@link BytesStore} instances and allocates no objects.
      */
     static long applyAsLong1to7(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws IllegalStateException, BufferUnderflowException {
         final long address = store.addressForRead(store.readPosition());
@@ -67,6 +79,8 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * @throws BufferUnderflowException If there is not enough data.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     *
+     * @implNote Suitable for hot paths and performs no allocation.
      */
     static long applyAsLong8(@NotNull BytesStore<?, ?> store) throws IllegalStateException, BufferUnderflowException {
         final long address = store.addressForRead(store.readPosition());
@@ -99,9 +113,11 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * Computes a 64-bit hash value for the given BytesStore for data sizes between 9 to 16 bytes.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (between 9 and 16 inclusive).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
+     *
+     * @implNote Handles medium sized payloads without allocation.
      */
     static long applyAsLong9to16(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -133,9 +149,11 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * Computes a 64-bit hash value for the given BytesStore for data sizes between 17 to 32 bytes.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (between 17 and 32 inclusive).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
+     *
+     * @implNote Designed for medium payloads, free from allocation.
      */
     static long applyAsLong17to32(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -167,9 +185,11 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * Computes a 64-bit hash value for the given BytesStore for data sizes that are multiple of 32 bytes.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (must be a multiple of 32).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
+     *
+     * @implNote Intended for large direct {@link BytesStore} blocks.
      */
     public static long applyAsLong32bytesMultiple(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -211,9 +231,11 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * Computes a 64-bit hash value for the given BytesStore for any size of data.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (must be non-negative).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
+     *
+     * @implNote Fallback for arbitrary lengths; still avoids allocation.
      */
     public static long applyAsLongAny(@NotNull BytesStore<?, ?> store, @NonNegative long remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -297,9 +319,9 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * it reads as many bytes as specified and converts them to a long.
      * Endianness is considered for reading bytes.
      *
-     * @param address the starting address of the memory to read from.
-     * @param len     the number of bytes to read (between 1 and 7, inclusive).
-     * @return the value read from memory converted to a {@code long}.
+     * @param address the starting address of the memory to read from
+     * @param len     the number of bytes to read (must be non-negative). Reads up to eight bytes
+     * @return the value read from memory converted to a {@code long}. Returns {@code 0} if {@code len} is 0 or negative
      */
     static long readIncompleteLong(long address, @NonNegative int len) {
         switch (len) {

--- a/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
@@ -39,22 +39,30 @@ public enum VanillaBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      */
     INSTANCE;
 
+    /** Mixing constant used in the hashing algorithm. */
     static final int K0 = 0x6d0f27bd;
+    /** Mixing constant used in the hashing algorithm. */
     static final int K1 = 0xc1f3bfc9;
+    /** Mixing constant used in the hashing algorithm. */
     static final int K2 = 0x6b192397;
+    /** Mixing constant used in the hashing algorithm. */
     static final int K3 = 0x6b915657;
+    /** Multiplicative constant used in the hashing algorithm. */
     static final int M0 = 0x5bc80bad;
+    /** Multiplicative constant used in the hashing algorithm. */
     static final int M1 = 0xea7585d7;
+    /** Multiplicative constant used in the hashing algorithm. */
     static final int M2 = 0x7a646e19;
+    /** Multiplicative constant used in the hashing algorithm. */
     static final int M3 = 0x855dd4db;
 
     /**
-     * Constant indicating the byte order for reading multi-byte values.
+     * Offset to select the higher four bytes of a long during hashing, dependent on system endianness.
      */
     private static final int HI_BYTES = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN ? 4 : 0;
 
     /**
-     * Agitates the given long value to generate a hash value.
+     * Applies a series of bitwise operations (XORs and rotations) to the given long value to improve its hash distribution.
      *
      * @param l The input value.
      * @return The agitated hash value.

--- a/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
@@ -35,10 +35,15 @@ import java.nio.BufferUnderflowException;
 @SuppressWarnings("rawtypes")
 public class XxHash implements BytesStoreHash<BytesStore<?, ?>> {
     // Primes if treated as unsigned
+    /** Prime constant used in xxHash. */
     private static final long P1 = -7046029288634856825L;
+    /** Prime constant used in xxHash. */
     private static final long P2 = -4417276706812531889L;
+    /** Prime constant used in xxHash. */
     private static final long P3 = 1609587929392839161L;
+    /** Prime constant used in xxHash. */
     private static final long P4 = -8796714831421723037L;
+    /** Prime constant used in xxHash. */
     private static final long P5 = 2870177450012600261L;
 
     /**
@@ -58,10 +63,10 @@ public class XxHash implements BytesStoreHash<BytesStore<?, ?>> {
     }
 
     /**
-     * Finalizes the hash calculation.
+     * Performs the final mixing steps of the xxHash algorithm on the accumulated hash value.
      *
-     * @param hash the hash to finalize.
-     * @return the finalized hash.
+     * @param hash the hash to finalise
+     * @return the finalised hash value
      */
     private static long finishUp(long hash) {
         hash ^= hash >>> 33;

--- a/src/main/java/net/openhft/chronicle/bytes/algo/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/package-info.java
@@ -1,21 +1,24 @@
 /**
- * Provides classes for hash computations on ByteStore objects.
+ * Provides classes for non-cryptographic hash computations on {@link net.openhft.chronicle.bytes.BytesStore} objects.
  * <p>
- * This package includes two hash implementations, {@link net.openhft.chronicle.bytes.algo.VanillaBytesStoreHash}
- * and {@link net.openhft.chronicle.bytes.algo.XxHash}. Both implement the {@link net.openhft.chronicle.bytes.algo.BytesStoreHash}
- * interface for the {@link net.openhft.chronicle.bytes.BytesStore} objects. These hashing algorithms are designed for
- * speed and effectiveness. VanillaBytesStoreHash provides a single instance of the hashing algorithm with constants
- * for faster computation, while XxHash is a more customizable hash implementation with seed support.
+ * The package offers three implementations:
+ * {@link net.openhft.chronicle.bytes.algo.VanillaBytesStoreHash},
+ * {@link net.openhft.chronicle.bytes.algo.XxHash} and
+ * {@link net.openhft.chronicle.bytes.algo.OptimisedBytesStoreHash}. They all
+ * implement {@link net.openhft.chronicle.bytes.algo.BytesStoreHash}.
+ * VanillaBytesStoreHash uses a fixed set of mixing constants for quick hashing
+ * while XxHash supports a seed. OptimisedBytesStoreHash chooses the most
+ * efficient strategy based on size and direct memory access.
  * <p>
- * Both classes feature the fetch and applyAsLong methods for fetching values from a byte store and computing their
- * hash respectively. Errors during execution are thrown as IllegalStateException and BufferUnderflowException.
+ * {@code XxHash} was migrated from the Zero-Allocation-Hashing project and is
+ * renowned for speed. These algorithms are deterministic across platforms but
+ * should not be used for security or privacy-sensitive computations.
  * <p>
- * {@code XxHash} is migrated from the Zero-Allocation-Hashing project, renowned for its speed.
- * <p>
- * Note: As these algorithms are non-cryptographic, they should not be used for any security or privacy sensitive
- * computations.
+ * See the AsciiDoc module overview {@code algo-overview.adoc} for examples and
+ * performance notes.
  *
  * @see net.openhft.chronicle.bytes.BytesStore
  * @see net.openhft.chronicle.bytes.algo.BytesStoreHash
+ * @see <a href="../../../../src/main/adoc/algo-overview.adoc">algo-overview.adoc</a>
  */
 package net.openhft.chronicle.bytes.algo;

--- a/src/main/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLock.java
+++ b/src/main/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLock.java
@@ -33,12 +33,15 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 /**
  * A way of acquiring exclusive locks on files in a re-entrant fashion.
  * <p>
- * It will prevent a single thread that uses this interface to acquire locks from causing
+ * It will prevent a single thread that uses the static {@link #lock(File, FileChannel)} or
+ * {@link #tryLock(File, FileChannel)} methods to acquire locks from causing
  * an {@link OverlappingFileLockException}. Separate threads will not be prevented from taking
  * overlapping file locks.
  * <p>
  * All the usual caveats around file locks apply, shared locks and locks for specific ranges are
  * not supported.
+ *
+ * See {@code domestic-overview.adoc} for usage notes.
  */
 public final class ReentrantFileLock extends FileLock {
 
@@ -108,6 +111,9 @@ public final class ReentrantFileLock extends FileLock {
 
     /**
      * Releases the lock.
+     *
+     * Decrements the re-entrance counter and only releases the underlying file lock
+     * when the counter reaches zero.
      *
      * @throws IOException If an I/O error occurs.
      */
@@ -191,7 +197,7 @@ public final class ReentrantFileLock extends FileLock {
     }
 
     /**
-     * Log an error if someone is passing around ReentrantFileLocks between threads
+     * Logs an error via {@link Jvm#error()} if a lock created by one thread is used on another.
      */
     private void checkThreadAccess() {
         @SuppressWarnings("deprecation")

--- a/src/main/java/net/openhft/chronicle/bytes/domestic/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/domestic/package-info.java
@@ -1,13 +1,14 @@
 /**
- * The package contains classes related to handling bytes in a reentrant manner.
+ * Utilities used internally by Chronicle Bytes.
  * <p>
- * The primary class in this package is {@link net.openhft.chronicle.bytes.domestic.ReentrantFileLock},
- * a way of acquiring exclusive locks on files in a re-entrant fashion. This class ensures that
- * a single thread that uses this interface to acquire locks won't cause an
- * {@link java.nio.channels.OverlappingFileLockException}. Separate threads will not be
- * prevented from taking overlapping file locks.
+ * The primary class is {@link net.openhft.chronicle.bytes.domestic.ReentrantFileLock},
+ * which allows the same thread to acquire a {@link java.nio.channels.FileLock} multiple times
+ * without triggering {@link java.nio.channels.OverlappingFileLockException}. Other threads may
+ * still take overlapping locks.
  * <p>
- * This package is a part of the open-source library Chronicle Bytes.
- * Please visit <a href="https://chronicle.software">chronicle.software</a> for more information.
+ * This package is not considered a stable public API and binary compatibility is not
+ * guaranteed between releases.
+ * <p>
+ * See the AsciiDoc module overview {@code domestic-overview.adoc} for examples and further notes.
  */
 package net.openhft.chronicle.bytes.domestic;

--- a/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
+++ b/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
@@ -23,18 +23,17 @@ import net.openhft.chronicle.core.scoped.ScopedThreadLocal;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A thread-local pool of reusable {@link Bytes} instances.
+ * Provides factory methods for creating thread-local pools of reusable {@link Bytes} instances.
  * <p>
- * This class uses a {@link ThreadLocal} to store a single {@link Bytes} instance per thread,
- * which can be reused to avoid the overhead of creating a new instance every time bytes are
- * needed for operations.
- * <p>
- * This class is primarily meant to be used in high-performance environments where reducing
- * object creation is crucial.
+ * The {@link ScopedResourcePool} returned by {@link #createThreadLocal()} manages the lifecycle of
+ * {@link Bytes} objects per thread to minimise allocation overhead.
+ * See {@code pool-overview.adoc} for tuning guidelines.
  */
 public final class BytesPool {
 
-    private static final int DEFAULT_BYTES_POOL_SIZE_PER_THREAD = Jvm.getInteger("chronicle.bytesPool.instancesPerThread", 4);
+    /** Default number of {@link Bytes} instances cached per thread. */
+    private static final int DEFAULT_BYTES_POOL_SIZE_PER_THREAD =
+            Jvm.getInteger("chronicle.bytesPool.instancesPerThread", 4);
 
     /**
      * Create a scoped-thread-local pool of bytes resources
@@ -60,14 +59,13 @@ public final class BytesPool {
 
     /**
      * Thread-local variable that holds the {@link Bytes} instance for each thread.
+     * Used by legacy code paths that do not employ {@link ScopedResourcePool}.
      */
     final ThreadLocal<Bytes<?>> bytesTL = new ThreadLocal<>();
 
     /**
-     * Creates a new {@link Bytes} instance.
-     * <p>
-     * This method is called internally when there is no {@link Bytes} instance available
-     * in the thread-local pool for the current thread.
+     * Creates a new {@link Bytes} instance for use by the pool.
+     * Invoked when no cached instance is available for the current thread.
      *
      * @return A newly created {@link Bytes} instance.
      */

--- a/src/main/java/net/openhft/chronicle/bytes/pool/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/pool/package-info.java
@@ -1,9 +1,14 @@
 /**
  * This package provides a pool for managing {@link net.openhft.chronicle.bytes.Bytes} instances.
  * <p>
- * The {@link net.openhft.chronicle.bytes.pool.BytesPool} class is used for pooling {@link net.openhft.chronicle.bytes.Bytes}
- * instances to reduce the overhead of frequently creating new instances. It uses a {@link java.lang.ThreadLocal} storage to ensure
- * that each thread has its own instance of {@link net.openhft.chronicle.bytes.Bytes}.
- * 
+ * {@link net.openhft.chronicle.bytes.pool.BytesPool} exposes factory methods
+ * such as {@link net.openhft.chronicle.bytes.pool.BytesPool#createThreadLocal()}
+ * that create thread-local caches of {@link net.openhft.chronicle.bytes.Bytes}
+ * objects. Pooling helps reduce allocation churn even with modern garbage
+ * collectors when latencies of only a few micro-seconds are required.
+ * <p>
+ * See the AsciiDoc module overview {@code pool-overview.adoc} for configuration
+ * examples and tuning hints.
+ *
  */
 package net.openhft.chronicle.bytes.pool;


### PR DESCRIPTION
## Summary
- document hashing algorithm and add impl notes
- clarify package usage and cross-link to new AsciiDoc guides
- explain BytesPool tuning in docs

## Testing
- `mvn -q verify` *(fails: command not found)*