### PR TITLE
Documentation Overhaul for algo, domestic & pool

### DIFF
--- a/src/main/adoc/algo-overview.adoc
+++ b/src/main/adoc/algo-overview.adoc
@@ -4,14 +4,77 @@
 :toclevels: 2
 :lang: en-GB
 
-This module provides non-cryptographic hash functions for `BytesStore` data.
-It is typically used for in-memory indexes and integrity checks where speed is
-more important than collision resistance.
+This module provides non-cryptographic hash functions for `BytesStore` data. [cite: 136]
+It is typically used for in-memory indexes and integrity checks where speed is more important than collision resistance.
+The available algorithms are designed for efficiency when processing byte sequences.
 
-.Common call flow
-```
-BytesStoreHash hash = OptimisedBytesStoreHash.INSTANCE;
-long value = hash.applyAsLong(bytesStore, bytesStore.readRemaining());
-```
+== Available Algorithms
 
-See `memory-management.adoc` for details about memory ownership and lifetimes.
+Chronicle Bytes provides several hashing implementations:
+
+* **`OptimisedBytesStoreHash`**: This algorithm dynamically selects an optimised hashing strategy based on the size of the data and whether it resides in direct memory. [cite: 116, 125] It considers system architecture details like endianness for performance. [cite: 116]
+* **`VanillaBytesStoreHash`**: A general-purpose hashing algorithm for `BytesStore` instances. [cite: 133] It provides a consistent hashing approach suitable for various data sizes.
+* **`XxHash`**: An implementation of the xxHash algorithm, known for its speed.
+This version is migrated from the Zero-Allocation-Hashing project and supports a configurable seed. [cite: 128]
+
+All hashing algorithms implement the `BytesStoreHash` interface. [cite: 126, 136]
+
+== Usage
+
+The primary interface for using these hash functions is `BytesStoreHash`.
+You can obtain an instance of a specific algorithm or use the static helper methods.
+
+.Common call flow using `OptimisedBytesStoreHash`
+[source,java]
+----
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.algo.BytesStoreHash;
+import net.openhft.chronicle.bytes.algo.OptimisedBytesStoreHash;
+
+// Obtain a BytesStore instance (e.g., from Bytes.from("some data"))
+BytesStore<?, ?> bytesStore = ...;
+
+// Get an instance of the desired hash algorithm
+BytesStoreHash hashAlgorithm = OptimisedBytesStoreHash.INSTANCE;
+
+// Calculate the hash for the readable portion of the BytesStore
+long hashValue = hashAlgorithm.applyAsLong(bytesStore, bytesStore.readRemaining());
+----
+
+Alternatively, you can use the static convenience methods in `BytesStoreHash`:
+
+.Static helper method usage
+[source,java]
+----
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.algo.BytesStoreHash;
+
+BytesStore<?, ?> bytesStore = ...;
+
+// Compute a 64-bit hash; this internally selects an optimised algorithm
+// if the BytesStore is in direct memory.
+long hash64 = BytesStoreHash.hash(bytesStore);
+
+// Compute a 32-bit hash
+int hash32 = BytesStoreHash.hash32(bytesStore);
+
+// Compute a hash for a specific length
+long partialHash64 = BytesStoreHash.hash(bytesStore, lengthToHash);
+int partialHash32 = BytesStoreHash.hash32(bytesStore, (int) lengthToHash);
+----
+
+== Performance Considerations
+
+* `OptimisedBytesStoreHash` aims to provide the best performance for `BytesStore` instances in direct memory by using specialized routines for different data lengths (e.g., 1-7 bytes, 8 bytes, 9-16 bytes, etc.). [cite: 116, 125]
+* For on-heap `BytesStore` instances, or when a direct memory optimized version is not available, hashing typically falls back to implementations like `VanillaBytesStoreHash`. [cite: 126]
+* Endianness (`IS_LITTLE_ENDIAN`) and specific memory access methods (`MEMORY.readLong`, `MEMORY.readInt`) are utilized by `OptimisedBytesStoreHash` to enhance speed. [cite: 116]
+* `XxHash` is also designed for high speed. [cite: 128, 136]
+
+== Important Notes
+
+* These hash functions are **non-cryptographic**.
+They should not be used for security-sensitive applications where collision resistance against malicious attacks is required. [cite: 136]
+* The hash computation depends on the readable bytes in the `BytesStore`.
+Ensure the `readPosition` and `readLimit` (or the specified length) accurately reflect the data you intend to hash.
+
+See `memory-management.adoc` for details about memory ownership and lifetimes, which is relevant when dealing with `BytesStore` instances.

--- a/src/main/adoc/algo-overview.adoc
+++ b/src/main/adoc/algo-overview.adoc
@@ -1,0 +1,17 @@
+= Chronicle Bytes Hash Algorithms
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+This module provides non-cryptographic hash functions for `BytesStore` data.
+It is typically used for in-memory indexes and integrity checks where speed is
+more important than collision resistance.
+
+.Common call flow
+```
+BytesStoreHash hash = OptimisedBytesStoreHash.INSTANCE;
+long value = hash.applyAsLong(bytesStore, bytesStore.readRemaining());
+```
+
+See `memory-management.adoc` for details about memory ownership and lifetimes.

--- a/src/main/adoc/domestic-overview.adoc
+++ b/src/main/adoc/domestic-overview.adoc
@@ -1,0 +1,20 @@
+= Chronicle Bytes Domestic Utilities
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+The domestic package contains helpers used by the rest of Chronicle Bytes but
+not intended as stable public API. Behaviour may change between releases.
+
+Typical usage is to acquire a reentrant file lock:
+```
+FileLock lock = ReentrantFileLock.lock(file, channel);
+try {
+    // work with the file
+} finally {
+    lock.release();
+}
+```
+
+For memory management information refer to `memory-management.adoc`.

--- a/src/main/adoc/domestic-overview.adoc
+++ b/src/main/adoc/domestic-overview.adoc
@@ -4,17 +4,57 @@
 :toclevels: 2
 :lang: en-GB
 
-The domestic package contains helpers used by the rest of Chronicle Bytes but
-not intended as stable public API. Behaviour may change between releases.
+The `net.openhft.chronicle.bytes.domestic` package contains helper classes primarily used internally by Chronicle Bytes.
+These are not intended as a stable public API, and their behaviour may change between releases without prior notice.
 
-Typical usage is to acquire a reentrant file lock:
-```
-FileLock lock = ReentrantFileLock.lock(file, channel);
-try {
-    // work with the file
-} finally {
-    lock.release();
+== ReentrantFileLock
+
+The main utility in this package is `ReentrantFileLock`.
+This class provides a mechanism for acquiring exclusive, re-entrant locks on files.
+
+=== Purpose
+
+`ReentrantFileLock` is designed to prevent `OverlappingFileLockException` when the same thread attempts to acquire a lock on the same file multiple times. [cite: 1395] It achieves this by tracking locks on a per-thread basis using the canonical path of the file. [cite: 1395, 1396] Note that it does not prevent separate threads or processes from taking overlapping file locks if they are not using this specific re-entrant mechanism. [cite: 1395]
+
+=== Features
+
+* **Re-entrant Locking**: Allows a thread to acquire a lock multiple times on the same file without throwing an exception.
+The lock is only released when the corresponding number of `release()` calls have been made. [cite: 1396]
+* **Canonical Path Based**: Uses the canonical file path to identify locks, ensuring that different paths referring to the same file are treated as a single lockable entity. [cite: 1395, 1396]
+* **Thread-Local Tracking**: Manages held locks using thread-local storage. [cite: 1395]
+* **Standard `FileLock` Delegate**: Wraps a standard `java.nio.channels.FileLock`. [cite: 1396]
+
+=== Typical Usage
+
+The `ReentrantFileLock` is typically used in a try-with-resources block to ensure locks are properly released.
+
+[source,java]
+----
+import net.openhft.chronicle.bytes.domestic.ReentrantFileLock;
+import java.io.File;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+
+File fileToLock = new File("mydata.lock");
+// Obtain a FileChannel, for example:
+try (FileChannel channel = FileChannel.open(fileToLock.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+    // Acquire the lock
+    try (ReentrantFileLock lock = ReentrantFileLock.lock(fileToLock, channel)) {
+        // Work with the file exclusively within this thread
+        // The lock is automatically released at the end of this try-with-resources block
+    } catch (IOException e) {
+        // Handle lock acquisition or release errors
+    }
+} catch (IOException e) {
+    // Handle channel opening errors
 }
-```
+----
 
-For memory management information refer to `memory-management.adoc`.
+Two main static methods are provided for acquiring locks:
+
+* `ReentrantFileLock.lock(File file, FileChannel fileChannel)`: Blocks until the lock is acquired. [cite: 1396]
+* `ReentrantFileLock.tryLock(File file, FileChannel fileChannel)`: Attempts to acquire the lock without blocking, returning `null` if the lock cannot be acquired immediately. [cite: 1396]
+
+It's also possible to check if the current thread holds a lock on a file using `ReentrantFileLock.isHeldByCurrentThread(File file)`. [cite: 1396]
+
+For general memory management information concerning `Bytes` and `BytesStore` which might be used in conjunction with file operations, refer to `memory-management.adoc` and `architecture-overview.adoc`.

--- a/src/main/adoc/pool-overview.adoc
+++ b/src/main/adoc/pool-overview.adoc
@@ -1,0 +1,17 @@
+= Chronicle Bytes Pooling
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+Pooling reuses `Bytes` objects to minimise allocation churn in very
+low-latency scenarios. Each thread keeps a small cache of instances.
+
+.Acquiring and releasing
+```
+try (Bytes<?> b = pool.acquire()) {
+    // use b
+}
+```
+
+See `memory-management.adoc` for advice on native memory budget.

--- a/src/main/adoc/pool-overview.adoc
+++ b/src/main/adoc/pool-overview.adoc
@@ -4,14 +4,39 @@
 :toclevels: 2
 :lang: en-GB
 
-Pooling reuses `Bytes` objects to minimise allocation churn in very
-low-latency scenarios. Each thread keeps a small cache of instances.
+Chronicle Bytes provides a pooling mechanism to reuse `Bytes` objects, primarily to minimise allocation overhead and reduce Garbage Collector (GC) pressure in very low-latency scenarios.
+This is particularly beneficial when temporary `Bytes` instances are frequently needed.
 
-.Acquiring and releasing
-```
-try (Bytes<?> b = pool.acquire()) {
-    // use b
+The `BytesPool` class offers static factory methods (e.g., `BytesPool.createThreadLocal()`) to create a thread-local pool of reusable `Bytes` instances, typically `Bytes.allocateElasticDirect()` instances.
+Each thread maintains its own small cache of these `Bytes` objects.
+When a `Bytes` instance is acquired from the pool, an available one from the cache is provided.
+Upon release, the instance is `clear()`-ed and returned to the thread's cache for future reuse.
+
+The number of `Bytes` instances retained per thread can be configured using the system property `chronicle.bytesPool.instancesPerThread` (defaulting to 4).
+
+== Acquiring and Releasing Pooled Bytes
+
+The recommended way to use the pool is with a try-with-resources statement on a `ScopedResource`, which ensures the `Bytes` instance is automatically returned to the pool.
+
+[source,java]
+----
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.pool.BytesPool;
+import net.openhft.chronicle.core.scoped.ScopedResource;
+import net.openhft.chronicle.core.scoped.ScopedResourcePool;
+
+// Create a pool (can be a static field or managed elsewhere)
+ScopedResourcePool<Bytes<?>> bytesPool = BytesPool.createThreadLocal();
+
+// Acquire a Bytes instance from the pool
+try (ScopedResource<Bytes<?>> sb = bytesPool.get()) {
+    Bytes<?> b = sb.get();
+    // Use b for operations
+    b.writeUtf8("Hello, pooled Bytes!");
+    // b is automatically cleared and returned to the pool at the end of this block
 }
-```
+----
 
-See `memory-management.adoc` for advice on native memory budget.
+This approach helps in managing the lifecycle of pooled `Bytes` objects efficiently and safely.
+
+For further details on native memory management and considerations, refer to `memory-management.adoc` and `project-requirements.adoc` (specifically requirement `CB-FN-014`).

--- a/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
@@ -31,7 +31,7 @@ import java.util.function.ToLongFunction;
  * This interface also exposes static helpers for computing 32-bit and 64-bit
  * hashes using the bundled implementations.
  *
- * @implSpec Implementations should avoid allocating memory and may assume that
+ * <p> Implementations should avoid allocating memory and may assume that
  * {@code length} bytes can be read without extra bounds checks.
  *
  * See {@code algo-overview.adoc} for usage examples.
@@ -109,7 +109,7 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      * @throws ClosedIllegalStateException    if the resource has been released or closed
      * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      *
-     * @implNote Implementations are typically branch-free and perform no allocations.
+     * <p> Implementations are typically branch-free and perform no allocations.
      */
     long applyAsLong(BytesStore<?, ?> bytes, long length) throws IllegalStateException, BufferUnderflowException;
 }

--- a/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
@@ -26,8 +26,15 @@ import java.util.function.ToLongFunction;
 
 /**
  * Represents a function that computes a 64-bit hash value from a {@link BytesStore}.
- * This interface provides static methods for computing 32-bit and 64-bit hash values,
- * using either optimized or vanilla implementations.
+ * Implementations provide fast, deterministic hashing based on little-endian
+ * variants of the Murmur3 algorithm.
+ * This interface also exposes static helpers for computing 32-bit and 64-bit
+ * hashes using the bundled implementations.
+ *
+ * @implSpec Implementations should avoid allocating memory and may assume that
+ * {@code length} bytes can be read without extra bounds checks.
+ *
+ * See {@code algo-overview.adoc} for usage examples.
  *
  * @param <B> the type of {@link BytesStore} that this function can compute hash values for.
  */
@@ -39,6 +46,8 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      *
      * @param b the {@link BytesStore} to compute the hash for.
      * @return the 64-bit hash value.
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      */
     static long hash(@NotNull BytesStore<?, ?> b) {
         return b.isDirectMemory()
@@ -52,9 +61,9 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      * @param b      the {@link BytesStore} to compute the hash for.
      * @param length the number of bytes to include in the hash computation.
      * @return the 64-bit hash value.
-     * @throws BufferUnderflowException If the length specified is greater than the available bytes.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @throws BufferUnderflowException       if the length specified is greater than the available bytes
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      */
     static long hash(@NotNull BytesStore<?, ?> b, @NonNegative long length) throws IllegalStateException, BufferUnderflowException {
         return b.isDirectMemory()
@@ -67,6 +76,8 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      *
      * @param b the {@link BytesStore} to compute the hash for.
      * @return the 32-bit hash value.
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      */
     static int hash32(BytesStore<?, ?> b) {
         long hash = hash(b);
@@ -79,9 +90,9 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      * @param b      the {@link BytesStore} to compute the hash for.
      * @param length the number of bytes to include in the hash computation.
      * @return the 32-bit hash value.
-     * @throws BufferUnderflowException If the length specified is greater than the available bytes.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @throws BufferUnderflowException       if the length specified is greater than the available bytes
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
      */
     static int hash32(@NotNull BytesStore<?, ?> b, @NonNegative int length) throws IllegalStateException, BufferUnderflowException {
         long hash = hash(b, length);
@@ -94,9 +105,11 @@ public interface BytesStoreHash<B extends BytesStore> extends ToLongFunction<B> 
      * @param bytes  the {@link BytesStore} to compute the hash for.
      * @param length the number of bytes to include in the hash computation.
      * @return the 64-bit hash value.
-     * @throws BufferUnderflowException If the length specified is greater than the available bytes.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @throws BufferUnderflowException       if the length specified is greater than the available bytes
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if this resource was accessed by multiple threads in an unsafe way
+     *
+     * @implNote Implementations are typically branch-free and perform no allocations.
      */
     long applyAsLong(BytesStore<?, ?> bytes, long length) throws IllegalStateException, BufferUnderflowException;
 }

--- a/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
@@ -63,7 +63,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      *
-     * @implNote This method is on the hot path for small direct {@link BytesStore} instances and allocates no objects.
+     * <p> This method is on the hot path for small direct {@link BytesStore} instances and allocates no objects.
      */
     static long applyAsLong1to7(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws IllegalStateException, BufferUnderflowException {
         final long address = store.addressForRead(store.readPosition());
@@ -80,7 +80,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      *
-     * @implNote Suitable for hot paths and performs no allocation.
+     * <p> Suitable for hot paths and performs no allocation.
      */
     static long applyAsLong8(@NotNull BytesStore<?, ?> store) throws IllegalStateException, BufferUnderflowException {
         final long address = store.addressForRead(store.readPosition());
@@ -117,7 +117,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
      *
-     * @implNote Handles medium sized payloads without allocation.
+     * <p> Handles medium sized payloads without allocation.
      */
     static long applyAsLong9to16(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -153,7 +153,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
      *
-     * @implNote Designed for medium payloads, free from allocation.
+     * <p> Designed for medium payloads, free from allocation.
      */
     static long applyAsLong17to32(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -189,7 +189,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
      *
-     * @implNote Intended for large direct {@link BytesStore} blocks.
+     * <p> Intended for large direct {@link BytesStore} blocks.
      */
     public static long applyAsLong32bytesMultiple(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -235,7 +235,7 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
      *
-     * @implNote Fallback for arbitrary lengths; still avoids allocation.
+     * <p> Fallback for arbitrary lengths; still avoids allocation.
      */
     public static long applyAsLongAny(@NotNull BytesStore<?, ?> store, @NonNegative long remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();

--- a/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
@@ -30,28 +30,40 @@ import java.nio.ByteOrder;
 import static net.openhft.chronicle.bytes.algo.VanillaBytesStoreHash.*;
 
 /**
- * Optimized hashing algorithm for BytesStore.
+ * Optimised hashing algorithm for BytesStore.
  * <p>
- * This enumeration implements BytesStoreHash for optimized hashing of BytesStore
- * depending on the size of the data and architecture of the system.
+ * This enumeration implements BytesStoreHash for optimised hashing of BytesStore
+ * depending on the data size and whether the {@code BytesStore} resides in direct memory,
+ * leveraging system architecture details like endianness for performance.
  */
 @SuppressWarnings("rawtypes")
 public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
     INSTANCE;
 
+    /**
+     * Provides access to low-level memory operations for optimised hashing.
+     */
     public static final Memory MEMORY = OS.memory();
+    /**
+     * Flag indicating if the native byte order of the system is little-endian.
+     */
     public static final boolean IS_LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+    /**
+     * Offset used to select the top four bytes of a long, dependent on system endianness.
+     */
     private static final int TOP_BYTES = IS_LITTLE_ENDIAN ? 4 : 0;
 
     /**
      * Computes a 64-bit hash value for the given BytesStore for data sizes between 1 to 7 bytes.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (between 1 and 7 inclusive).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     *
+     * @implNote This method is on the hot path for small direct {@link BytesStore} instances and allocates no objects.
      */
     static long applyAsLong1to7(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws IllegalStateException, BufferUnderflowException {
         final long address = store.addressForRead(store.readPosition());
@@ -67,6 +79,8 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * @throws BufferUnderflowException If there is not enough data.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     *
+     * @implNote Suitable for hot paths and performs no allocation.
      */
     static long applyAsLong8(@NotNull BytesStore<?, ?> store) throws IllegalStateException, BufferUnderflowException {
         final long address = store.addressForRead(store.readPosition());
@@ -99,9 +113,11 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * Computes a 64-bit hash value for the given BytesStore for data sizes between 9 to 16 bytes.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (between 9 and 16 inclusive).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
+     *
+     * @implNote Handles medium sized payloads without allocation.
      */
     static long applyAsLong9to16(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -133,9 +149,11 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * Computes a 64-bit hash value for the given BytesStore for data sizes between 17 to 32 bytes.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (between 17 and 32 inclusive).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
+     *
+     * @implNote Designed for medium payloads, free from allocation.
      */
     static long applyAsLong17to32(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -167,9 +185,11 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * Computes a 64-bit hash value for the given BytesStore for data sizes that are multiple of 32 bytes.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (must be a multiple of 32).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
+     *
+     * @implNote Intended for large direct {@link BytesStore} blocks.
      */
     public static long applyAsLong32bytesMultiple(@NotNull BytesStore<?, ?> store, @NonNegative int remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -211,9 +231,11 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * Computes a 64-bit hash value for the given BytesStore for any size of data.
      *
      * @param store     The {@link BytesStore} to compute the hash for.
-     * @param remaining The number of bytes to process.
+     * @param remaining The number of bytes to process (must be non-negative).
      * @return A 64-bit hash value.
      * @throws BufferUnderflowException If there is not enough data.
+     *
+     * @implNote Fallback for arbitrary lengths; still avoids allocation.
      */
     public static long applyAsLongAny(@NotNull BytesStore<?, ?> store, @NonNegative long remaining) throws BufferUnderflowException {
         @NotNull final BytesStore<?, ?> bytesStore = store.bytesStore();
@@ -297,9 +319,9 @@ public enum OptimisedBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      * it reads as many bytes as specified and converts them to a long.
      * Endianness is considered for reading bytes.
      *
-     * @param address the starting address of the memory to read from.
-     * @param len     the number of bytes to read (between 1 and 7, inclusive).
-     * @return the value read from memory converted to a {@code long}.
+     * @param address the starting address of the memory to read from
+     * @param len     the number of bytes to read (must be non-negative). Reads up to eight bytes
+     * @return the value read from memory converted to a {@code long}. Returns {@code 0} if {@code len} is 0 or negative
      */
     static long readIncompleteLong(long address, @NonNegative int len) {
         switch (len) {

--- a/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
@@ -39,22 +39,30 @@ public enum VanillaBytesStoreHash implements BytesStoreHash<BytesStore<?,?>> {
      */
     INSTANCE;
 
+    /** Mixing constant used in the hashing algorithm. */
     static final int K0 = 0x6d0f27bd;
+    /** Mixing constant used in the hashing algorithm. */
     static final int K1 = 0xc1f3bfc9;
+    /** Mixing constant used in the hashing algorithm. */
     static final int K2 = 0x6b192397;
+    /** Mixing constant used in the hashing algorithm. */
     static final int K3 = 0x6b915657;
+    /** Multiplicative constant used in the hashing algorithm. */
     static final int M0 = 0x5bc80bad;
+    /** Multiplicative constant used in the hashing algorithm. */
     static final int M1 = 0xea7585d7;
+    /** Multiplicative constant used in the hashing algorithm. */
     static final int M2 = 0x7a646e19;
+    /** Multiplicative constant used in the hashing algorithm. */
     static final int M3 = 0x855dd4db;
 
     /**
-     * Constant indicating the byte order for reading multi-byte values.
+     * Offset to select the higher four bytes of a long during hashing, dependent on system endianness.
      */
     private static final int HI_BYTES = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN ? 4 : 0;
 
     /**
-     * Agitates the given long value to generate a hash value.
+     * Applies a series of bitwise operations (XORs and rotations) to the given long value to improve its hash distribution.
      *
      * @param l The input value.
      * @return The agitated hash value.

--- a/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
@@ -35,10 +35,15 @@ import java.nio.BufferUnderflowException;
 @SuppressWarnings("rawtypes")
 public class XxHash implements BytesStoreHash<BytesStore<?, ?>> {
     // Primes if treated as unsigned
+    /** Prime constant used in xxHash. */
     private static final long P1 = -7046029288634856825L;
+    /** Prime constant used in xxHash. */
     private static final long P2 = -4417276706812531889L;
+    /** Prime constant used in xxHash. */
     private static final long P3 = 1609587929392839161L;
+    /** Prime constant used in xxHash. */
     private static final long P4 = -8796714831421723037L;
+    /** Prime constant used in xxHash. */
     private static final long P5 = 2870177450012600261L;
 
     /**
@@ -58,10 +63,10 @@ public class XxHash implements BytesStoreHash<BytesStore<?, ?>> {
     }
 
     /**
-     * Finalizes the hash calculation.
+     * Performs the final mixing steps of the xxHash algorithm on the accumulated hash value.
      *
-     * @param hash the hash to finalize.
-     * @return the finalized hash.
+     * @param hash the hash to finalise
+     * @return the finalised hash value
      */
     private static long finishUp(long hash) {
         hash ^= hash >>> 33;

--- a/src/main/java/net/openhft/chronicle/bytes/algo/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/package-info.java
@@ -1,21 +1,24 @@
 /**
- * Provides classes for hash computations on ByteStore objects.
+ * Provides classes for non-cryptographic hash computations on {@link net.openhft.chronicle.bytes.BytesStore} objects.
  * <p>
- * This package includes two hash implementations, {@link net.openhft.chronicle.bytes.algo.VanillaBytesStoreHash}
- * and {@link net.openhft.chronicle.bytes.algo.XxHash}. Both implement the {@link net.openhft.chronicle.bytes.algo.BytesStoreHash}
- * interface for the {@link net.openhft.chronicle.bytes.BytesStore} objects. These hashing algorithms are designed for
- * speed and effectiveness. VanillaBytesStoreHash provides a single instance of the hashing algorithm with constants
- * for faster computation, while XxHash is a more customizable hash implementation with seed support.
+ * The package offers three implementations:
+ * {@link net.openhft.chronicle.bytes.algo.VanillaBytesStoreHash},
+ * {@link net.openhft.chronicle.bytes.algo.XxHash} and
+ * {@link net.openhft.chronicle.bytes.algo.OptimisedBytesStoreHash}. They all
+ * implement {@link net.openhft.chronicle.bytes.algo.BytesStoreHash}.
+ * VanillaBytesStoreHash uses a fixed set of mixing constants for quick hashing
+ * while XxHash supports a seed. OptimisedBytesStoreHash chooses the most
+ * efficient strategy based on size and direct memory access.
  * <p>
- * Both classes feature the fetch and applyAsLong methods for fetching values from a byte store and computing their
- * hash respectively. Errors during execution are thrown as IllegalStateException and BufferUnderflowException.
+ * {@code XxHash} was migrated from the Zero-Allocation-Hashing project and is
+ * renowned for speed. These algorithms are deterministic across platforms but
+ * should not be used for security or privacy-sensitive computations.
  * <p>
- * {@code XxHash} is migrated from the Zero-Allocation-Hashing project, renowned for its speed.
- * <p>
- * Note: As these algorithms are non-cryptographic, they should not be used for any security or privacy sensitive
- * computations.
+ * See the AsciiDoc module overview {@code algo-overview.adoc} for examples and
+ * performance notes.
  *
  * @see net.openhft.chronicle.bytes.BytesStore
  * @see net.openhft.chronicle.bytes.algo.BytesStoreHash
+ * @see <a href="../../../../src/main/adoc/algo-overview.adoc">algo-overview.adoc</a>
  */
 package net.openhft.chronicle.bytes.algo;

--- a/src/main/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLock.java
+++ b/src/main/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLock.java
@@ -33,12 +33,15 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 /**
  * A way of acquiring exclusive locks on files in a re-entrant fashion.
  * <p>
- * It will prevent a single thread that uses this interface to acquire locks from causing
+ * It will prevent a single thread that uses the static {@link #lock(File, FileChannel)} or
+ * {@link #tryLock(File, FileChannel)} methods to acquire locks from causing
  * an {@link OverlappingFileLockException}. Separate threads will not be prevented from taking
  * overlapping file locks.
  * <p>
  * All the usual caveats around file locks apply, shared locks and locks for specific ranges are
  * not supported.
+ *
+ * See {@code domestic-overview.adoc} for usage notes.
  */
 public final class ReentrantFileLock extends FileLock {
 
@@ -108,6 +111,9 @@ public final class ReentrantFileLock extends FileLock {
 
     /**
      * Releases the lock.
+     *
+     * Decrements the re-entrance counter and only releases the underlying file lock
+     * when the counter reaches zero.
      *
      * @throws IOException If an I/O error occurs.
      */
@@ -191,7 +197,7 @@ public final class ReentrantFileLock extends FileLock {
     }
 
     /**
-     * Log an error if someone is passing around ReentrantFileLocks between threads
+     * Logs an error via {@link Jvm#error()} if a lock created by one thread is used on another.
      */
     private void checkThreadAccess() {
         @SuppressWarnings("deprecation")

--- a/src/main/java/net/openhft/chronicle/bytes/domestic/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/domestic/package-info.java
@@ -9,7 +9,5 @@
  * <p>
  * This package is a part of the open-source library Chronicle Bytes.
  * Please visit <a href="https://chronicle.software">chronicle.software</a> for more information.
- *
- * @see net.openhft.chronicle.bytes.domestic.ReentrantFileLock
  */
 package net.openhft.chronicle.bytes.domestic;

--- a/src/main/java/net/openhft/chronicle/bytes/domestic/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/domestic/package-info.java
@@ -1,13 +1,14 @@
 /**
- * The package contains classes related to handling bytes in a reentrant manner.
+ * Utilities used internally by Chronicle Bytes.
  * <p>
- * The primary class in this package is {@link net.openhft.chronicle.bytes.domestic.ReentrantFileLock},
- * a way of acquiring exclusive locks on files in a re-entrant fashion. This class ensures that
- * a single thread that uses this interface to acquire locks won't cause an
- * {@link java.nio.channels.OverlappingFileLockException}. Separate threads will not be
- * prevented from taking overlapping file locks.
+ * The primary class is {@link net.openhft.chronicle.bytes.domestic.ReentrantFileLock},
+ * which allows the same thread to acquire a {@link java.nio.channels.FileLock} multiple times
+ * without triggering {@link java.nio.channels.OverlappingFileLockException}. Other threads may
+ * still take overlapping locks.
  * <p>
- * This package is a part of the open-source library Chronicle Bytes.
- * Please visit <a href="https://chronicle.software">chronicle.software</a> for more information.
+ * This package is not considered a stable public API and binary compatibility is not
+ * guaranteed between releases.
+ * <p>
+ * See the AsciiDoc module overview {@code domestic-overview.adoc} for examples and further notes.
  */
 package net.openhft.chronicle.bytes.domestic;

--- a/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
+++ b/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
@@ -23,18 +23,17 @@ import net.openhft.chronicle.core.scoped.ScopedThreadLocal;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A thread-local pool of reusable {@link Bytes} instances.
+ * Provides factory methods for creating thread-local pools of reusable {@link Bytes} instances.
  * <p>
- * This class uses a {@link ThreadLocal} to store a single {@link Bytes} instance per thread,
- * which can be reused to avoid the overhead of creating a new instance every time bytes are
- * needed for operations.
- * <p>
- * This class is primarily meant to be used in high-performance environments where reducing
- * object creation is crucial.
+ * The {@link ScopedResourcePool} returned by {@link #createThreadLocal()} manages the lifecycle of
+ * {@link Bytes} objects per thread to minimise allocation overhead.
+ * See {@code pool-overview.adoc} for tuning guidelines.
  */
 public final class BytesPool {
 
-    private static final int DEFAULT_BYTES_POOL_SIZE_PER_THREAD = Jvm.getInteger("chronicle.bytesPool.instancesPerThread", 4);
+    /** Default number of {@link Bytes} instances cached per thread. */
+    private static final int DEFAULT_BYTES_POOL_SIZE_PER_THREAD =
+            Jvm.getInteger("chronicle.bytesPool.instancesPerThread", 4);
 
     /**
      * Create a scoped-thread-local pool of bytes resources
@@ -60,14 +59,13 @@ public final class BytesPool {
 
     /**
      * Thread-local variable that holds the {@link Bytes} instance for each thread.
+     * Used by legacy code paths that do not employ {@link ScopedResourcePool}.
      */
     final ThreadLocal<Bytes<?>> bytesTL = new ThreadLocal<>();
 
     /**
-     * Creates a new {@link Bytes} instance.
-     * <p>
-     * This method is called internally when there is no {@link Bytes} instance available
-     * in the thread-local pool for the current thread.
+     * Creates a new {@link Bytes} instance for use by the pool.
+     * Invoked when no cached instance is available for the current thread.
      *
      * @return A newly created {@link Bytes} instance.
      */

--- a/src/main/java/net/openhft/chronicle/bytes/pool/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/pool/package-info.java
@@ -1,9 +1,14 @@
 /**
  * This package provides a pool for managing {@link net.openhft.chronicle.bytes.Bytes} instances.
  * <p>
- * The {@link net.openhft.chronicle.bytes.pool.BytesPool} class is used for pooling {@link net.openhft.chronicle.bytes.Bytes}
- * instances to reduce the overhead of frequently creating new instances. It uses a {@link java.lang.ThreadLocal} storage to ensure
- * that each thread has its own instance of {@link net.openhft.chronicle.bytes.Bytes}.
- * 
+ * {@link net.openhft.chronicle.bytes.pool.BytesPool} exposes factory methods
+ * such as {@link net.openhft.chronicle.bytes.pool.BytesPool#createThreadLocal()}
+ * that create thread-local caches of {@link net.openhft.chronicle.bytes.Bytes}
+ * objects. Pooling helps reduce allocation churn even with modern garbage
+ * collectors when latencies of only a few micro-seconds are required.
+ * <p>
+ * See the AsciiDoc module overview {@code pool-overview.adoc} for configuration
+ * examples and tuning hints.
+ *
  */
 package net.openhft.chronicle.bytes.pool;


### PR DESCRIPTION
This PR is a *docs-focused refresh* that removes a dead reference and brings the
three internal packages (`net.openhft.chronicle.bytes.algo`,
`net.openhft.chronicle.bytes.domestic`, `net.openhft.chronicle.bytes.pool`) up
to Chronicle’s current documentation standards.

* **Dead code link** – `ReentrantFileLock` was referenced in
  `domestic/package-info.java` but already lives in the same package; the `@see`
  was redundant and rendered wrongly in aggregated Javadoc.
* **Discoverability** – hashing, file-locking and pooling are core features but
  were hard to find.  New AsciiDoc *module overviews* provide a landing page for
  each domain.
* **Consistency** – align Javadoc with Chronicle’s house rules (British English,
  ASCII-7, `<p>` for paragraph breaks, clear first-sentence summary, etc.).

| Patch | Summary |
|-------|---------|
| **1/6** | Remove obsolete `@see ReentrantFileLock` from `domestic/package-info.java`. |
| **2/6** | Add three AsciiDoc overview files and upgrade package/class Javadoc across *algo*, *domestic*, *pool*. |
| **3/6** | Flesh out `algo-overview.adoc` with API snippets, algorithm table and perf notes. |
| **4/6** | Expand `domestic-overview.adoc` with detailed `ReentrantFileLock` guide & examples. |
| **5/6** | Enrich `pool-overview.adoc` with configuration & usage via `ScopedResourcePool`. |
| **6/6** | Replace stray `@implNote`/`@implSpec` prose with proper `<p>` blocks to fix Javadoc formatting warnings. |

### 1. New /docs
* `src/main/adoc/algo-overview.adoc`
* `src/main/adoc/domestic-overview.adoc`
* `src/main/adoc/pool-overview.adoc`

### 2. Javadoc improvements
* Added **first-line summaries**, threading / allocation disclaimers and
  cross-links to the new AsciiDoc pages.
* Documented magic constants and endianness handling in hashing classes.
* Clarified re-entrance semantics in `ReentrantFileLock`.
* Explained pooling limits & system property `chronicle.bytesPool.instancesPerThread`.

### 3. Minor code comments / constants
No behavioural changes – only comment blocks and constant‐explanatory names.

## Backward-compatibility

* **Binary/API** – unchanged.
* **Runtime**     – no functional impact; unit-tests still green.
