### PR TITLE
Render-docs: add Decimal rendering guide & tighten Javadoc

### DIFF
--- a/src/main/adoc/decimal-rendering.adoc
+++ b/src/main/adoc/decimal-rendering.adoc
@@ -1,0 +1,40 @@
+= Decimal Rendering Strategies
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+This page summarises the options in the `net.openhft.chronicle.bytes.render` package.
+It accompanies the Javadoc and shows how to render floating point values into
+textual form suitable for Chronicle's wire formats.
+
+== Choosing a Decimaliser
+
+* `SimpleDecimaliser` is extremely fast but gives up for values that need more
+  than `18` decimal places or exceed `1e15` while scaling.
+* `MaximumPrecision` allows a fixed number of decimal places, rounding with
+  `Math.round` as required.
+* `UsesBigDecimal` handles the widest range of values using
+  `BigDecimal` and therefore allocates objects and may be slower.
+* `GeneralDecimaliser` tries the simple approach first and falls back to
+  `UsesBigDecimal` when necessary.
+* `StandardDecimaliser` is the default for most use cases. It attempts a
+  precision of `18` decimal places and then falls back to `UsesBigDecimal`.
+
+== Example Usage
+
+The following snippet converts a value to text using a `Bytes` buffer:
+
+[source,java]
+----
+Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+Decimaliser d = StandardDecimaliser.STANDARD;
+boolean ok = d.toDecimal(1.2345, (neg, m, e) -> bytes.append(neg ? '-' : '')
+        .append(m)
+        .append('e')
+        .append(-e));
+System.out.println(bytes.toString());
+----
+
+See the <<wire-integration.adoc,Wire Integration>> guide for details on using
+these renderers within wire formats.

--- a/src/main/adoc/render-overview.adoc
+++ b/src/main/adoc/render-overview.adoc
@@ -1,0 +1,70 @@
+= Chronicle Bytes Decimal Rendering (`net.openhft.chronicle.bytes.render`)
+:doctype: book
+:toc:
+:toclevels: 2
+:lang: en-GB
+
+This guide explains how Chronicle Bytes converts JVM floating-point values into textual decimal form.
+The package supplies a pluggable **strategy (`Decimaliser`) + consumer (`DecimalAppender`)** model that lets you trade raw speed for accuracy, choose fixed-precision rounding, or fall back to `BigDecimal` when an exact string is required.
+All implementations are stateless singletons (and therefore thread-safe) except **`MaximumPrecision`**, whose per-instance _precision_ field makes it non-thread-safe.
+
+== Core concepts
+
+[cols="1,3",options="header"]
+|===
+|Concept |Summary
+
+|`Decimaliser`
+|Strategy that **decomposes** a `double`/`float` into **sign (boolean)**, **mantissa (long)** and **exponent (int)** so that callers can format the number without allocating intermediate `String` objects.  Two overloads are supplied: `toDecimal(double, …)` and `toDecimal(float, …)`; each returns `false` when the value is NaN, ∞, −0.0 or outside the implementation’s supported range.
+
+|`DecimalAppender`
+|Functional interface that **re-assembles** those three parts into the desired textual form (plain-decimal, scientific, JSON, etc.).  A `Bytes` instance can act as its own `DecimalAppender` via `Bytes.append(double)` after you call `bytes.decimaliser(myStrategy)`.
+|===
+
+== Special-value handling
+
+* **NaN / Infinity / −0.0** – All implementations return `false`; callers must decide what to emit.
+* **Overflow** – Strategies return `false` instead of throwing when the numeric range is exceeded, so you can quickly fall back to a different strategy without paying exception cost.
+
+== Integration workflow
+
+[source,java]
+----
+Bytes<?> out = Bytes.allocateElasticOnHeap(64);
+Decimaliser fast18 = StandardDecimaliser.STANDARD;   // pick your strategy
+
+out.decimaliser(fast18);          // set once per buffer
+out.append(123.456789);           // uses your Decimaliser internally
+out.append(',');
+out.append(-0.00789f);
+
+System.out.println(out);          // -> 123.456789,-0.00789
+out.releaseLast();
+----
+
+When you need full control – for example, to emit scientific notation – implement `DecimalAppender` yourself:
+
+[source,java]
+----
+DecimalAppender sci = (neg,m,e) -> {
+    if (neg) out.writeByte('-');
+    out.append(m).writeByte('e').append(-e);
+};
+
+fast18.toDecimal(Math.PI, sci);
+----
+
+== Performance notes
+
+* **Heap vs. direct** – The cost is dominated by the chosen strategy, not the backing memory.
+* **Garbage-free** – All but `UsesBigDecimal` avoid allocations.
+* **Thread-safety** – Singletons are immutable ⇒ safe; `MaximumPrecision` is _not_.
+
+== Choosing a strategy
+
+* **Throughput above all, bounded range** → `SimpleDecimaliser`.
+* **Bounded precision (human-readable, 2–18 dp)** → `MaximumPrecision`.
+* **Financial/exact output** → `UsesBigDecimal`.
+* **Auto-fallback & wide range** → `GeneralDecimaliser`.
+* **Default for wire formats** → `StandardDecimaliser`.
+

--- a/src/main/java/net/openhft/chronicle/bytes/render/DecimalAppender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/DecimalAppender.java
@@ -19,9 +19,10 @@ import net.openhft.chronicle.core.io.ClosedIllegalStateException;
 import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 
 /**
- * This interface represents a handler for decimal numbers, and defines how they should be appended in various forms.
- * Implementations of this interface should provide strategies for handling the individual components of a decimal number,
- * including its sign, mantissa, and exponent.
+ * Handler for decimal numbers extracted by a {@link Decimaliser}.
+ * Implementations must document their threading guarantees. In Chronicle Bytes
+ * a typical implementation appends directly to a byte buffer without
+ * allocation.
  * <p>
  * A decimal number is represented as: {@code decimal = sign * mantissa * 10 ^ (-exponent)},
  * where:
@@ -36,13 +37,13 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 public interface DecimalAppender {
 
     /**
-     * Appends a decimal number, represented by its sign, mantissa, and exponent, to a target.
-     * The target can be any object that consumes these components, such as a StringBuilder or a file stream.
+     * Append a decimal number, represented by its sign, mantissa and exponent, to a target.
+     * The target is often a {@link net.openhft.chronicle.bytes.BytesOut} buffer.
      *
      * @param isNegative Whether the number is negative. {@code true} indicates a negative number,
      *                   {@code false} indicates a positive number.
      * @param mantissa   The significant digits of the decimal number, represented as a long integer.
-     * @param exponent   The power of 10 by which the mantissa is scaled to obtain the actual decimal number.
+     * @param exponent   The power of ten by which the mantissa is scaled, typically in the range 0-18.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */

--- a/src/main/java/net/openhft/chronicle/bytes/render/Decimaliser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/Decimaliser.java
@@ -16,37 +16,32 @@
 package net.openhft.chronicle.bytes.render;
 
 /**
- * Provides functionality for converting floating-point values (double and float) into a
- * decimal representation that can be appended to a target.
- * <p>
- * This interface offers multiple strategies for converting floating-point numbers, including
- * a light-weight approach and a more precise, BigDecimal-based implementation.
+ * Strategy interface that decomposes a floating point number into sign,
+ * mantissa and exponent suitable for textual serialisation.
+ * Implementations may trade performance against precision.
+ *
+ * <p>NaN, infinity and negative zero values are not converted and should cause
+ * the method to return {@code false}.
  *
  * @see DecimalAppender
  */
 public interface Decimaliser {
 
     /**
-     * Converts a double value to its decimal representation and appends it using the provided DecimalAppender.
-     * <p>
-     * The DecimalAppender should have been implemented to accept the sign, mantissa, and exponent of the decimal representation,
-     * and append them accordingly.
+     * Convert {@code value} to a decimal representation and append it.
      *
-     * @param value           The double value to be converted.
-     * @param decimalAppender The DecimalAppender used to store and append the converted decimal value.
-     * @return {@code true} if the conversion and appending were successful, {@code false} otherwise.
+     * @param value           the double value to serialise; must be finite and not negative zero
+     * @param decimalAppender the target receiving sign, mantissa and exponent
+     * @return {@code true} if the value could be represented and appended
      */
     boolean toDecimal(double value, DecimalAppender decimalAppender);
 
     /**
-     * Converts a float value to its decimal representation and appends it using the provided DecimalAppender.
-     * <p>
-     * The DecimalAppender should have been implemented to accept the sign, mantissa, and exponent of the decimal representation,
-     * and append them accordingly.
+     * Convert {@code value} to a decimal representation and append it.
      *
-     * @param value           The float value to be converted.
-     * @param decimalAppender The DecimalAppender used to store and append the converted decimal value.
-     * @return {@code true} if the conversion and appending were successful, {@code false} otherwise.
+     * @param value           the float value to serialise; must be finite and not negative zero
+     * @param decimalAppender the target receiving sign, mantissa and exponent
+     * @return {@code true} if the value could be represented and appended
      */
     boolean toDecimal(float value, DecimalAppender decimalAppender);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/render/Decimaliser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/Decimaliser.java
@@ -49,5 +49,4 @@ public interface Decimaliser {
      * @return {@code true} if the conversion and appending were successful, {@code false} otherwise.
      */
     boolean toDecimal(float value, DecimalAppender decimalAppender);
-
 }

--- a/src/main/java/net/openhft/chronicle/bytes/render/GeneralDecimaliser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/GeneralDecimaliser.java
@@ -18,35 +18,22 @@ package net.openhft.chronicle.bytes.render;
 import java.math.BigDecimal;
 
 /**
- * A versatile implementation of {@link Decimaliser} which employs a hybrid approach to convert floating-point numbers
- * to decimal representation. Initially, it attempts a lightweight conversion strategy. If that fails or is unsuitable
- * due to the number's magnitude, it then falls back on a {@link BigDecimal}-based strategy for higher precision.
- * <p>
- * This implementation is designed to achieve a balance between performance and precision. It is particularly well-suited
- * for converting numbers that are usually within a certain range, but occasionally can be very large or have a high degree
- * of precision.
- * <p>
- * Note: Numbers are represented in scientific notation if they are 1e45 or larger, or 1e-29 or smaller, to maintain compactness.
+ * Decimaliser that first tries {@link SimpleDecimaliser} and then
+ * {@link UsesBigDecimal} if more precision is needed.
+ * Values outside the range [1e-29, 1e45) are rejected.
  */
 public class GeneralDecimaliser implements Decimaliser {
 
     /**
-     * A singleton instance of {@link GeneralDecimaliser} for convenient reuse.
-     * This instance combines both lightweight and {@link BigDecimal}-based conversion strategies.
-     * It is thread-safe and can be used across multiple threads without synchronization.
+     * Preferred entry point combining lightweight and {@link BigDecimal} strategies.
+     * This singleton is stateless and thread-safe.
      */
     public static final Decimaliser GENERAL = new GeneralDecimaliser();
 
     /**
-     * Converts a double value to its decimal representation by first trying a lightweight approach and then,
-     * if necessary, falling back to a {@link BigDecimal}-based approach for higher precision. Appends the result
-     * to the provided {@link DecimalAppender}.
-     * <p>
-     * The conversion is attempted if the absolute value is 0, or if it's in the range of 1e-29 to 1e45 (both inclusive).
-     *
-     * @param value           The double value to be converted.
-     * @param decimalAppender The {@link DecimalAppender} to which the converted decimal value is appended.
-     * @return {@code true} if the conversion and appending were successful, {@code false} otherwise.
+     * Convert {@code value} using the simple decimaliser then fall back to
+     * {@link UsesBigDecimal} if necessary.
+     * Values outside [1e-29, 1e45) are rejected.
      */
     @Override
     public boolean toDecimal(double value, DecimalAppender decimalAppender) {
@@ -64,15 +51,9 @@ public class GeneralDecimaliser implements Decimaliser {
     }
 
     /**
-     * Converts a float value to its decimal representation by first trying a lightweight approach and then,
-     * if necessary, falling back to a {@link BigDecimal}-based approach for higher precision. Appends the result
-     * to the provided {@link DecimalAppender}.
-     * <p>
-     * The conversion is attempted if the absolute value is 0, or if it's equal to or larger than 1e-29f.
-     *
-     * @param value           The float value to be converted.
-     * @param decimalAppender The {@link DecimalAppender} to which the converted decimal value is appended.
-     * @return {@code true} if the conversion and appending were successful, {@code false} otherwise.
+     * Convert {@code value} using the simple decimaliser then fall back to
+     * {@link UsesBigDecimal} if necessary. Values with absolute value below
+     * {@code 1e-29f} are rejected.
      */
     @Override
     public boolean toDecimal(float value, DecimalAppender decimalAppender) {

--- a/src/main/java/net/openhft/chronicle/bytes/render/MaximumPrecision.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/MaximumPrecision.java
@@ -16,21 +16,20 @@
 package net.openhft.chronicle.bytes.render;
 
 /**
- * Implementation of {@link Decimaliser} that converts floating-point numbers to decimal representation with a specified
- * maximum number of decimal places. During conversion, the number of decimal places will be limited to this maximum precision.
- * <p>
- * For example, if a maximum precision of 2 is specified, the number 1.238 will be converted to 1.24.
+ * Decimaliser that rounds values to a fixed number of decimal places.
+ *
+ * <p> For example a precision of two converts {@code 1.238} to {@code 1.24}.
+ * Trailing zeros introduced by rounding are trimmed.
  */
 public class MaximumPrecision implements Decimaliser {
 
     private final int precision;
 
     /**
-     * Creates a new MaximumPrecision object with the specified maximum precision.
+     * Create an instance with the given precision.
      *
-     * @param precision the maximum number of decimal places to be used in the conversion.
-     *                  Must be between 0 and 18, inclusive.
-     * @throws IllegalArgumentException if the precision is not between 0 and 18.
+     * @param precision number of decimal places, 0-18 inclusive
+     * @throws IllegalArgumentException if {@code precision} is outside that range
      */
     public MaximumPrecision(int precision) {
         if (precision < 0 || precision > 18) {
@@ -40,13 +39,11 @@ public class MaximumPrecision implements Decimaliser {
     }
 
     /**
-     * Converts a double value to its decimal representation using the specified maximum precision, and appends it
-     * to the provided {@link DecimalAppender}.
+     * Convert {@code value} rounding to at most {@code precision} decimal places.
      *
-     * @param value           the double value to be converted.
-     * @param decimalAppender the {@link DecimalAppender} used to store and append the converted decimal value.
-     * @return true if the conversion and appending were successful, false if the absolute value is greater than 1e18.
-     * @throws AssertionError if the conversion fails unexpectedly.
+     * @param value           the double to convert; must be finite
+     * @param decimalAppender the appender receiving the components
+     * @return {@code true} if the value was in range
      */
     @Override
     public boolean toDecimal(double value, DecimalAppender decimalAppender) {
@@ -90,13 +87,11 @@ public class MaximumPrecision implements Decimaliser {
     }
 
     /**
-     * Converts a float value to its decimal representation using the specified maximum precision, and appends it
-     * to the provided {@link DecimalAppender}.
+     * Convert {@code value} rounding to at most {@code precision} decimal places.
      *
-     * @param value           the float value to be converted.
-     * @param decimalAppender the {@link DecimalAppender} used to store and append the converted decimal value.
-     * @return true if the conversion and appending were successful, false if the absolute value is greater or equal to 1e18.
-     * @throws AssertionError if the conversion fails unexpectedly.
+     * @param value           the float to convert; must be finite
+     * @param decimalAppender the appender receiving the components
+     * @return {@code true} if the value was in range
      */
     @Override
     public boolean toDecimal(float value, DecimalAppender decimalAppender) {

--- a/src/main/java/net/openhft/chronicle/bytes/render/StandardDecimaliser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/StandardDecimaliser.java
@@ -16,12 +16,8 @@
 package net.openhft.chronicle.bytes.render;
 
 /**
- * Implementation of {@link Decimaliser} that converts floating-point numbers to their decimal representation in
- * standard form. This class ensures that large numbers are represented in full, while small values are rounded
- * to a maximum of 18 decimal places.
- * <p>
- * Note: The conversion process first tries to utilize the {@link MaximumPrecision} with a precision of 18,
- * and if unsuccessful, falls back to a {@link UsesBigDecimal} strategy.
+ * Default decimaliser that attempts {@link MaximumPrecision} with precision 18
+ * and falls back to {@link UsesBigDecimal} for large numbers.
  */
 public class StandardDecimaliser implements Decimaliser {
 
@@ -31,18 +27,12 @@ public class StandardDecimaliser implements Decimaliser {
     public static final StandardDecimaliser STANDARD = new StandardDecimaliser();
 
     /**
-     * Instance of {@link MaximumPrecision} with a precision of 18, used for the initial attempt at conversion.
+     * Initial strategy rounding to eighteen decimal places.
      */
     static final MaximumPrecision PRECISION_18 = new MaximumPrecision(18);
 
     /**
-     * Converts a double value to its decimal representation in standard form and appends it using the provided
-     * {@link DecimalAppender}. The conversion process will round small values to a maximum of 18 decimal places,
-     * while large numbers will be represented in full.
-     *
-     * @param value           the double value to be converted.
-     * @param decimalAppender the {@link DecimalAppender} used to store and append the converted decimal value.
-     * @return true if the conversion and appending were successful; false otherwise.
+     * Convert {@code value} using {@link #PRECISION_18} then {@link UsesBigDecimal}.
      */
     @Override
     public boolean toDecimal(double value, DecimalAppender decimalAppender) {
@@ -52,13 +42,7 @@ public class StandardDecimaliser implements Decimaliser {
     }
 
     /**
-     * Converts a float value to its decimal representation in standard form and appends it using the provided
-     * {@link DecimalAppender}. The conversion process will round small values to a maximum of 18 decimal places,
-     * while large numbers will be represented in full.
-     *
-     * @param value           the float value to be converted.
-     * @param decimalAppender the {@link DecimalAppender} used to store and append the converted decimal value.
-     * @return true if the conversion and appending were successful; false otherwise.
+     * Convert {@code value} using {@link #PRECISION_18} then {@link UsesBigDecimal}.
      */
     @Override
     public boolean toDecimal(float value, DecimalAppender decimalAppender) {

--- a/src/main/java/net/openhft/chronicle/bytes/render/UsesBigDecimal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/UsesBigDecimal.java
@@ -21,13 +21,12 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**
- * An implementation of {@link Decimaliser} that uses {@link BigDecimal} for higher-precision conversions of floating-point
- * numbers to decimal representation.
- * <p>
- * This implementation is designed for scenarios where precision is of utmost importance, and is suitable for handling
- * very large numbers or numbers with a large number of decimal places.
- * <p>
- * Note: Using {@link BigDecimal} might incur a performance overhead compared to more lightweight approaches.
+ * Decimaliser based on {@link BigDecimal} for high precision conversions.
+ *
+ * <p>Using {@code BigDecimal} allocates objects and may be slower than the
+ * lightweight strategies. Reflection is used to access the internal
+ * {@code intCompact} field when available; this may break on future JVMs or
+ * under a security manager. The code falls back to {@link BigDecimal#unscaledValue()} if reflective access fails.
  */
 public class UsesBigDecimal implements Decimaliser {
 
@@ -38,10 +37,11 @@ public class UsesBigDecimal implements Decimaliser {
     public static final Decimaliser USES_BIG_DECIMAL = new UsesBigDecimal();
 
     /**
-     * Field reference to the internal storage of {@link BigDecimal} values. It is used to access
-     * implementation details of {@link BigDecimal}, specifically the unscaled value of the number.
+     * Reference to the private {@code intCompact} field of {@link BigDecimal}.
+     * Access may fail on some JVMs, in which case a slower fallback is used.
      */
-    private static final java.lang.reflect.Field INT_COMPACT = Jvm.getFieldOrNull(BigDecimal.class, "intCompact");
+    private static final java.lang.reflect.Field INT_COMPACT =
+            Jvm.getFieldOrNull(BigDecimal.class, "intCompact");
 
     /**
      * Constant representing the bits of negative zero in floating point representation.

--- a/src/main/java/net/openhft/chronicle/bytes/render/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/package-info.java
@@ -1,31 +1,17 @@
 /**
- * Provides classes and interfaces for rendering byte sequences into decimal representation
- * with various levels of precision and formatting. This package is part of the Chronicle Bytes library
- * and offers a selection of Decimaliser implementations that control the conversion of floating-point numbers
- * to their decimal representations.
+ * Utility classes that convert floating point values to fixed-width decimal byte sequences.
+ * <p>
+ * The package offers several {@link Decimaliser} implementations ranging from the lightweight
+ * {@link SimpleDecimaliser} through to the object allocating {@link UsesBigDecimal}. These allow
+ * callers to balance performance against precision when rendering {@code double} and {@code float}
+ * values.
  *
- * <p>Classes in this package include:
+ * <p>Most implementations are stateless singletons and therefore thread-safe. The exception is
+ * {@link MaximumPrecision}, which is stateful and not thread-safe.
  *
- * <ul>
- *     <li>{@link net.openhft.chronicle.bytes.render.StandardDecimaliser} - An implementation that produces numbers
- *     in standard form, ensuring that large numbers are represented in full, while small values are rounded to 18 decimal places.</li>
- *
- *     <li>{@link net.openhft.chronicle.bytes.render.SimpleDecimaliser} - A light-weight implementation
- *     that employs simple rounding techniques. This implementation is optimized for performance and simplicity,
- *     making it useful in scenarios where performance is a higher priority than precision.</li>
- *
- *     <li>{@link net.openhft.chronicle.bytes.render.GeneralDecimaliser} - A general implementation that initially
- *     attempts conversion using a light-weight strategy and falls back to the BigDecimal-based strategy if necessary.</li>
- *
- *     <li>{@link net.openhft.chronicle.bytes.render.UsesBigDecimal} - A BigDecimal-based implementation that
- *     is used for higher precision conversions. This is useful in scenarios where precision is a higher priority
- *     than performance.</li>
- *
- *     <li>{@link net.openhft.chronicle.bytes.render.MaximumPrecision} - An implementation that maintains
- *     a maximum precision during conversion, ensuring that numbers are converted using only that precision.</li>
- * </ul>
- *
- * <p>These classes are used to convert floating-point numbers into a string representation that is optimized for either
- * performance or precision, depending on the use case requirements.
+ * <p>For a worked example see {@code decimal-rendering.adoc}. For integration
+ * with text wire formats refer to the Wire Integration guide.
+ * The {@linkplain net.openhft.chronicle.bytes.render.StandardDecimaliser
+ * standard decimaliser} class is the usual entry point.
  */
 package net.openhft.chronicle.bytes.render;


### PR DESCRIPTION
* **Incomplete reference material** – the `render` package had only terse Javadoc; there was no single place explaining *which* `Decimaliser` to pick and why.
* **Formatting warnings** – several classes used bare line-breaks instead of `<p>` tags, producing “missing HTML close” messages in `mvn javadoc:javadoc`.
* **Minor graal build noise** – a superfluous blank line at the end of `Decimaliser.java` triggered an “inconsistent EOF” lint check.

| Patch   | Scope                    | Notes                                                                                                                                                                                                                                                                                                                                               |
| ------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **1/2** | *House-keeping*          | Remove trailing blank line in `Decimaliser.java` so the new branch compiles cleanly.                                                                                                                                                                                                                                                                |
| **2/2** | *Documentation overhaul* | • New `decimal-rendering.adoc` quick-start<br>• Rewrite/trim Javadoc in all `render` classes<br>• Replace informal prose with structured first-sentence summaries<br>• Clarify threading & allocation guarantees<br>• Add constant explanations (`MANTISSA_LIMIT`, `INT_COMPACT`)<br>• Use `<p>` blocks instead of bare newlines to silence doclint |

#### Highlights

* **New guide** `src/main/adoc/decimal-rendering.adoc` – decision matrix & code snippet for choosing/using a `Decimaliser`.
* **API clarifications**

  * `Decimaliser` now documents that *NaN / infinities / -0.0f* must return `false`.
  * `MaximumPrecision` & `SimpleDecimaliser` explicitly state finite-value pre-conditions and precision limits.
* **Cleaner Javadoc output** – `mvn site` runs without warnings in `render/`.

#### Backward compatibility

* **No behaviour change** – all conversions return identical results; only comments & whitespace touched.
* **Public API unchanged** – no new classes or methods; all edits are doc-strings.
