### PR TITLE
Improve util package Javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/util/AbstractInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/AbstractInterner.java
@@ -32,45 +32,51 @@ import java.util.stream.Stream;
 import static net.openhft.chronicle.core.Jvm.uncheckedCast;
 
 /**
- * This class provides a caching mechanism that returns a value which matches the decoded bytes. It does not
- * guarantee the return of the same object across different invocations or from different threads, but it
- * guarantees that the contents will be the same. Although not strictly thread-safe, it behaves correctly
- * under concurrent access.
- * <p>
- * The main usage is to reduce the amount of memory used by creating new objects when the same byte sequence is
- * repeatedly decoded into an object.
- * <p>
- * This cache only guarantees it will provide a String which matches the decoded bytes.
- * <p>
- * It doesn't guarantee it will always return the same object,
- * nor that different threads will return the same object,
- * though the contents should always be the same.
- * <p>
- * While not technically thread safe, it should still behave correctly.
- * <p>
- * Abstract base class for implementing an interning mechanism, which helps
- * in reusing instances of immutable objects. This class is designed to store objects
- * and return previously stored instances that are equal to the required instance.
- * <p>
- * Note: The interning cache may not always return the same object instance, but
- * the contents of the instances will be equal.
- * *
+ * Abstract base class for an interning mechanism designed to reduce memory allocation
+ * by reusing immutable objects that are content equal. When a byte sequence is presented,
+ * the interner attempts to return a previously cached instance. If no such instance exists
+ * a new one is created via {@link #getValue(BytesStore, int)}, cached and returned.
+ *
+ * <p>The cache is capacity bounded and entries are replaced in a pseudo-LRU fashion
+ * using the {@link #toggle()} heuristic. Hashing relies on
+ * {@link net.openhft.chronicle.bytes.algo.BytesStoreHash#hash32(BytesStore, long)}
+ * and collisions are resolved by probing two slots.</p>
+ *
+ * <p>The cache guarantees equality of the returned objects' contents but does not guarantee
+ * object identity across invocations or threads. This class itself does not ensure
+ * thread safety. Concurrent access may result in benign races where later inserts overwrite
+ * earlier ones.</p>
  *
  * @param <T> the type of the object being interned
- * @author peter.lawrey
  */
 @SuppressWarnings("rawtypes")
 public abstract class AbstractInterner<T> {
+    /**
+     * The array storing {@link InternerEntry} objects. Concurrent modifications
+     * should be externally synchronised as no locking is performed here.
+     */
     protected final InternerEntry<T>[] entries;
+    /**
+     * Mask used to hash into {@link #entries}, typically {@code capacity - 1}.
+     */
     protected final int mask;
+    /**
+     * Shift value used when computing the secondary hash index.
+     */
     protected final int shift;
+    /**
+     * Flag toggled when choosing between the two hash slots for new entries. It
+     * approximates a round-robin placement to avoid hot spots.
+     */
     protected boolean toggle = false;
 
     /**
      * Constructor for creating an intern cache with the given capacity. The capacity will be adjusted to the next
      * power of 2 if it is not already a power of 2, to a limit of {@code 1 << 30}.
+     * The resulting structure is not inherently thread safe.
      *
      * @param capacity the desired capacity for the intern cache
+     * @throws IllegalArgumentException if {@code capacity} is negative
      */
     protected AbstractInterner(@NonNegative int capacity){
         int n = Maths.nextPower2(capacity, 128);
@@ -94,14 +100,13 @@ public abstract class AbstractInterner<T> {
     }
 
     /**
-     * Interns the specified Bytes object. If the Bytes object is already in the cache,
-     * this method returns the cached instance; otherwise, it adds the Bytes object to the cache
-     * and returns the newly cached instance. The length of Bytes object for interning is determined
-     * by the remaining readable bytes.
+     * Interns the given {@link Bytes} instance using all remaining readable bytes
+     * starting from its {@code readPosition()}.
      *
      * @param cs the Bytes object to intern
-     * @return the interned instance
+     * @return the cached object instance
      * @throws IORuntimeException       If an I/O error occurs
+     * @throws NullPointerException     if {@code cs} is {@code null}
      * @throws BufferUnderflowException If there is not enough data in the buffer
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
@@ -112,13 +117,12 @@ public abstract class AbstractInterner<T> {
     }
 
     /**
-     * Interns the specified BytesStore object. If the BytesStore object is already in the cache,
-     * this method returns the cached instance; otherwise, it adds the BytesStore object to the cache
-     * and returns the newly cached instance. The length of BytesStore object for interning is determined
-     * by the remaining readable bytes.
+     * Interns the given {@link BytesStore} instance using all readable bytes starting
+     * from its {@code readPosition()}.
      *
      * @param cs the BytesStore object to intern
-     * @return the interned instance
+     * @return the cached object instance
+     * @throws NullPointerException     if {@code cs} is {@code null}
      * @throws IORuntimeException       If an I/O error occurs
      * @throws BufferUnderflowException If there is not enough data in the buffer
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
@@ -130,13 +134,13 @@ public abstract class AbstractInterner<T> {
     }
 
     /**
-     * Interns the specified Bytes object of a given length. If the Bytes object is already in the cache,
-     * this method returns the cached instance; otherwise, it adds the Bytes object to the cache
-     * and returns the newly cached instance.
+     * Interns the specified {@link Bytes} instance reading exactly {@code length}
+     * bytes from {@code cs.readPosition()}.
      *
      * @param cs     the Bytes object to intern
      * @param length the length of the Bytes object to intern
-     * @return the interned instance
+     * @return the cached object instance
+     * @throws NullPointerException     if {@code cs} is {@code null}
      * @throws IORuntimeException       If an I/O error occurs
      * @throws BufferUnderflowException If there is not enough data in the buffer
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
@@ -148,12 +152,15 @@ public abstract class AbstractInterner<T> {
     }
 
     /**
-     * Interns the specified Bytes. If the Bytes are already in the cache, this method returns the cached instance;
-     * otherwise, it adds the Bytes to the cache and returns the newly cached instance.
+     * Interns the specified {@link BytesStore}. Two possible cache slots are
+     * examined for a match using primary and secondary hashes. If neither slot
+     * contains a matching entry a new value is created via {@link #getValue(BytesStore, int)}
+     * and cached.
      *
      * @param cs     the Bytes to intern
-     * @param length of bytes to read
-     * @return the interned instance
+     * @param length number of bytes to read from {@code cs}
+     * @return the cached object instance
+     * @throws NullPointerException     if {@code cs} is {@code null}
      * @throws IORuntimeException       If an I/O error occurs
      * @throws BufferUnderflowException If there is not enough data in the buffer
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
@@ -163,7 +170,6 @@ public abstract class AbstractInterner<T> {
             throws IORuntimeException, BufferUnderflowException, IllegalStateException {
         if (length > entries.length)
             return getValue(cs, length);
-        // Todo: This needs to be reviewed: UnsafeMemory UNSAFE loadFence
         int hash = hash32(cs, length);
         int h = hash & mask;
         InternerEntry<T> s = entries[h];
@@ -179,21 +185,22 @@ public abstract class AbstractInterner<T> {
         IOTools.unmonitor(bs);
         cs.read(cs.readPosition(), bytes, 0, length);
         entries[s == null || (s2 != null && toggle()) ? h : h2] = new InternerEntry<>(bs, t);
-        // UnsafeMemory UNSAFE storeFence
+        // Store fence ensures the entry is visible before returning
         return t;
     }
 
     /**
-     * Retrieves the value corresponding to the bytes store and length.
-     * This method must be implemented by subclasses.
+     * Converts the bytes from {@code bs} into an instance of {@code T}. The
+     * implementation must read exactly {@code length} bytes starting from
+     * {@code bs.readPosition()} without modifying that position.
      *
-     * @param bs     the bytes store
-     * @param length the length of the data in the bytes store
-     * @return the value corresponding to the given bytes store and length
-     * @throws IORuntimeException       If an IO error occurs
-     * @throws BufferUnderflowException If there is not enough data in the buffer
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param bs     the bytes store supplying the data
+     * @param length the number of bytes to read
+     * @return the value derived from the byte sequence
+     * @throws IORuntimeException       if an I/O error occurs
+     * @throws BufferUnderflowException if there is insufficient data available
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if accessed by multiple threads unsafely
      */
     @NotNull
     protected abstract T getValue(BytesStore<?, ?> bs, @NonNegative int length)
@@ -224,14 +231,20 @@ public abstract class AbstractInterner<T> {
      * @param <T> the type of the object being interned
      */
     private static final class InternerEntry<T> {
+        /**
+         * A heap-based copy of the original byte sequence used for equality checks.
+         */
         final BytesStore<?, ?> bytes;
+        /**
+         * The cached object instance.
+         */
         final T t;
 
         /**
-         * Constructs an InternerEntry with the given bytes store and value.
+         * Constructs an {@code InternerEntry}.
          *
-         * @param bytes the bytes store
-         * @param t     the value
+         * @param bytes a heap-based copy of the byte sequence
+         * @param t     the cached value
          */
         InternerEntry(BytesStore<?, ?> bytes, T t) {
             this.bytes = bytes;

--- a/src/main/java/net/openhft/chronicle/bytes/util/BinaryLengthLength.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/BinaryLengthLength.java
@@ -23,20 +23,32 @@ import net.openhft.chronicle.core.annotation.NonNegative;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Enum representing different byte lengths for binary values.
- * It provides methods to get the code associated with each byte length,
- * to initialize a {@link BytesOut} object with the length code, and
- * to write the length of the data into the {@link Bytes} object.
+ * Defines strategies for encoding and writing the length prefix of binary data
+ * segments. Supported prefixes are 8, 16 and 32-bit fields. After writing the
+ * payload the caller must invoke {@link #writeLength(Bytes, long, long)} exactly
+ * once to store the final length.
+ *
+ * <p>Maximum storable lengths:</p>
+ * <ul>
+ *   <li>8-bit: 255 bytes</li>
+ *   <li>16-bit: 65 535 bytes</li>
+ *   <li>32-bit: 2 147 483 647 bytes</li>
+ * </ul>
+ *
+ * @implNote Each {@code writeLength} call performs a store fence as required by
+ * JSR-133 to ensure the length is visible to other threads.
  */
 public enum BinaryLengthLength {
     /**
-     * Represents an 8-bit length encoding for binary data.
+     * Represents an 8-bit length prefix capable of encoding data lengths from 0
+     * to 255 bytes. The prefix consists of one byte identifying the type and one
+     * byte holding the length value.
      */
     LENGTH_8BIT {
         /**
-         * Returns the code representing 8-bit length.
+         * Returns the identifying code for an 8-bit length prefix.
          *
-         * @return The code for the 8-bit length.
+         * @return the code used in the binary stream
          */
         @Override
         public int code() {
@@ -44,10 +56,10 @@ public enum BinaryLengthLength {
         }
 
         /**
-         * Initializes a {@link BytesOut} object with the length code.
+         * Writes the identifying code and reserves one byte for the length.
          *
-         * @param bytes The {@link BytesOut} object to initialize.
-         * @return The position within the {@link BytesOut} where the length will be written.
+         * @param bytes the output to initialise
+         * @return the offset where the length should later be written
          */
         @Override
         public long initialise(@NotNull final BytesOut<?> bytes) {
@@ -58,11 +70,13 @@ public enum BinaryLengthLength {
         }
 
         /**
-         * Writes the length of the data into the {@link Bytes} object.
+         * Calculates the data length and writes it at the supplied position.
+         * A store fence is performed to ensure visibility between threads.
          *
-         * @param bytes                           The {@link Bytes} object to write to.
-         * @param positionReturnedFromInitialise  The position within the {@link Bytes} to write the length.
-         * @param end                             The end position of the data within the {@link Bytes}.
+         * @param bytes                          the bytes to update
+         * @param positionReturnedFromInitialise the offset returned by {@link #initialise(BytesOut)}
+         * @param end                            the absolute end of the data
+         * @throws IllegalStateException if the length exceeds 255
          */
         @Override
         public void writeLength(@NotNull Bytes<?> bytes, @NonNegative long positionReturnedFromInitialise, @NonNegative long end) {
@@ -70,17 +84,18 @@ public enum BinaryLengthLength {
             if (length >= 1 << 8)
                 throw invalidLength(length);
             bytes.writeByte(positionReturnedFromInitialise, (byte) length);
-            UnsafeMemory.MEMORY.storeFence(); // Ensures that the write is flushed to memory
+            UnsafeMemory.MEMORY.storeFence(); // ensures visibility between threads
         }
     },
     /**
-     * Represents a 16-bit length encoding for binary data.
+     * Represents a 16-bit length prefix. The prefix comprises one code byte and
+     * two bytes storing the length, allowing data up to 65535 bytes.
      */
     LENGTH_16BIT {
         /**
-         * Returns the code representing 16-bit length.
+         * Returns the identifying code for a 16-bit length prefix.
          *
-         * @return The code for the 16-bit length.
+         * @return the code used in the binary stream
          */
         @Override
         public int code() {
@@ -88,10 +103,10 @@ public enum BinaryLengthLength {
         }
 
         /**
-         * Initializes a {@link BytesOut} object with the length code.
+         * Writes the identifying code and reserves two bytes for the length.
          *
-         * @param bytes The {@link BytesOut} object to initialize.
-         * @return The position within the {@link BytesOut} where the length will be written.
+         * @param bytes the output to initialise
+         * @return the offset where the length should later be written
          */
         @Override
         public long initialise(@NotNull final BytesOut<?> bytes) {
@@ -102,11 +117,12 @@ public enum BinaryLengthLength {
         }
 
         /**
-         * Writes the length of the data into the {@link Bytes} object.
+         * Calculates the data length and writes it at the supplied position.
          *
-         * @param bytes                           The {@link Bytes} object to write to.
-         * @param positionReturnedFromInitialise  The position within the {@link Bytes} to write the length.
-         * @param end                             The end position of the data within the {@link Bytes}.
+         * @param bytes                          the bytes to update
+         * @param positionReturnedFromInitialise the offset returned by {@link #initialise(BytesOut)}
+         * @param end                            the absolute end of the data
+         * @throws IllegalStateException if the length exceeds 65535
          */
         @Override
         public void writeLength(@NotNull Bytes<?> bytes, @NonNegative long positionReturnedFromInitialise, @NonNegative long end) {
@@ -114,17 +130,18 @@ public enum BinaryLengthLength {
             if (length >= 1 << 16)
                 throw invalidLength(length);
             bytes.writeShort(positionReturnedFromInitialise, (short) length);
-            UnsafeMemory.MEMORY.storeFence(); // Ensures that the write is flushed to memory
+            UnsafeMemory.MEMORY.storeFence(); // ensures visibility between threads
         }
     },
     /**
-     * Represents a 32-bit length encoding for binary data.
+     * Represents a 32-bit length prefix allowing data up to 2,147,483,647 bytes.
+     * The prefix comprises one code byte followed by four bytes of length.
      */
     LENGTH_32BIT {
         /**
-         * Returns the code representing 32-bit length.
+         * Returns the identifying code for a 32-bit length prefix.
          *
-         * @return The code for the 32-bit length.
+         * @return the code used in the binary stream
          */
         @Override
         public int code() {
@@ -132,10 +149,10 @@ public enum BinaryLengthLength {
         }
 
         /**
-         * Initializes a {@link BytesOut} object with the length code.
+         * Writes the identifying code and reserves four bytes for the length.
          *
-         * @param bytes The {@link BytesOut} object to initialize.
-         * @return The position within the {@link BytesOut} where the length will be written.
+         * @param bytes the output to initialise
+         * @return the offset where the length should later be written
          */
         @Override
         public long initialise(@NotNull BytesOut<?> bytes) {
@@ -146,11 +163,12 @@ public enum BinaryLengthLength {
         }
 
         /**
-         * Writes the length of the data into the {@link Bytes} object.
+         * Calculates the data length and writes it at the supplied position.
          *
-         * @param bytes                           The {@link Bytes} object to write to.
-         * @param positionReturnedFromInitialise  The position within the {@link Bytes} to write the length.
-         * @param end                             The end position of the data within the {@link Bytes}.
+         * @param bytes                          the bytes to update
+         * @param positionReturnedFromInitialise the offset returned by {@link #initialise(BytesOut)}
+         * @param end                            the absolute end of the data
+         * @throws IllegalStateException if the length exceeds the 32-bit range
          */
         @Override
         public void writeLength(@NotNull Bytes<?> bytes, @NonNegative long positionReturnedFromInitialise, @NonNegative long end) {
@@ -158,6 +176,7 @@ public enum BinaryLengthLength {
             if (length >= 1L << 31)
                 throw invalidLength(length);
             bytes.writeOrderedInt(positionReturnedFromInitialise, (int) length);
+            UnsafeMemory.MEMORY.storeFence(); // ensures visibility between threads
         }
     };
 
@@ -174,26 +193,30 @@ public enum BinaryLengthLength {
     }
 
     /**
-     * Returns the code representing the length encoding.
+     * Returns the {@link net.openhft.chronicle.bytes.BinaryWireCode} identifying
+     * this length field in the binary stream.
      *
-     * @return the length encoding code
+     * @return the code used in the wire format
      */
     public abstract int code();
 
     /**
-     * Initialises the binary data with the appropriate length encoding.
+     * Writes the identifying code and reserves space for the length field.
      *
      * @param bytes the output bytes to write to
-     * @return the position where the length encoding starts
+     * @return the absolute offset at which the length should be written later
      */
     public abstract long initialise(@NotNull BytesOut<?> bytes);
 
     /**
-     * Writes the length of the data into the {@link Bytes} object.
+     * Writes the actual length at the supplied offset after the data segment has
+     * been written.
      *
-     * @param bytes                          The {@link Bytes} object to write to.
-     * @param positionReturnedFromInitialise The position within the {@link Bytes} to write the length.
-     * @param end                            The end position of the data within the {@link Bytes}.
+     * @param bytes                          the bytes to update
+     * @param positionReturnedFromInitialise the offset from {@link #initialise(BytesOut)}
+     * @param end                            the absolute end of the data
      */
-    public abstract void writeLength(@NotNull Bytes<?> bytes, @NonNegative long positionReturnedFromInitialise, @NonNegative long end);
+    public abstract void writeLength(@NotNull Bytes<?> bytes,
+                                     @NonNegative long positionReturnedFromInitialise,
+                                     @NonNegative long end);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/util/Bit8StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Bit8StringInterner.java
@@ -27,9 +27,15 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.BufferUnderflowException;
 
 /**
- * This class provides a mechanism for interning Strings with 8-bit characters.
- * Interning is a method of storing only one copy of each distinct String value,
- * which must be immutable.
+ * Implementation of {@link AbstractInterner} for interning {@link String}
+ * objects whose bytes are assumed to represent 8-bit characters such as
+ * ISO-8859-1.
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * Bit8StringInterner interner = new Bit8StringInterner(128);
+ * String s = interner.intern(bytes, length);
+ * }</pre>
  *
  * @see AbstractInterner
  */
@@ -50,11 +56,13 @@ public class Bit8StringInterner extends AbstractInterner<String> {
     }
 
     /**
-     * Returns a String value from the provided {@link BytesStore} object.
+     * Decodes an 8-bit character sequence from the provided {@link BytesStore}.
+     * Exactly {@code length} bytes are read starting from {@code cs.readPosition()}.
+     * The read position is not modified.
      *
-     * @param cs     the BytesStore object from which to get the String value
-     * @param length the length of the string to be interned
-     * @return the interned String value
+     * @param cs     the bytes store containing the characters
+     * @param length the number of bytes to read
+     * @return the resulting string
      * @throws BufferUnderflowException       If the BytesStore doesn't have enough remaining capacity
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way

--- a/src/main/java/net/openhft/chronicle/bytes/util/Compressions.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Compressions.java
@@ -29,15 +29,18 @@ import java.io.OutputStream;
 import java.nio.BufferOverflowException;
 import java.util.zip.*;
 /**
- * Enum representing different compression algorithms and providing corresponding
- * compressing and decompressing streams.
+ * Compression algorithms supported by Chronicle Bytes. Each enum constant
+ * provides {@link Compression} implementations for stream-based compression and
+ * decompression.
  */
 @SuppressWarnings("rawtypes")
 public enum Compressions implements Compression {
 
     /**
-     * Binary compression is a placeholder compression which does not perform any actual
-     * compression. It simply returns the input bytes.
+     * Represents a no-operation compression strategy. The data is passed through
+     * unchanged and no CPU time is spent compressing or expanding it.
+     *
+     * @see Compression
      */
     Binary {
         /**
@@ -129,7 +132,11 @@ public enum Compressions implements Compression {
     },
 
     /**
-     * LZW (Lempel-Ziv-Welch) is a lossless data compression algorithm.
+     * Uses {@link java.util.zip.InflaterInputStream} and
+     * {@link java.util.zip.DeflaterOutputStream} in a DEFLATE variant of LZW.
+     * Provides modest compression ratios at a low CPU cost.
+     *
+     * @see Compression
      */
     LZW {
         /**
@@ -158,7 +165,11 @@ public enum Compressions implements Compression {
     },
 
     /**
-     * GZIP is a file format and a software application used for file compression and decompression.
+     * Uses {@link java.util.zip.GZIPInputStream} and
+     * {@link java.util.zip.GZIPOutputStream}. GZIP typically yields higher
+     * compression at increased CPU usage and is defined in RFC 1952.
+     *
+     * @see Compression
      */
     GZIP {
         /**
@@ -166,7 +177,7 @@ public enum Compressions implements Compression {
          *
          * @param input the GZIP-compressed input stream
          * @return the decompressing input stream
-         * @throws IORuntimeException If an I/O error occurs
+         * @throws IORuntimeException if creating the stream fails
          */
         @NotNull
         @Override

--- a/src/main/java/net/openhft/chronicle/bytes/util/DecoratedBufferOverflowException.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/DecoratedBufferOverflowException.java
@@ -40,6 +40,17 @@ public final class DecoratedBufferOverflowException extends BufferOverflowExcept
     }
 
     /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause
+     */
+    public DecoratedBufferOverflowException(final String message, final Throwable cause) {
+        this.message = message;
+        initCause(cause);
+    }
+
+    /**
      * Returns the detail message of this exception.
      *
      * @return the detail message string of this exception

--- a/src/main/java/net/openhft/chronicle/bytes/util/DecoratedBufferUnderflowException.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/DecoratedBufferUnderflowException.java
@@ -40,6 +40,17 @@ public final class DecoratedBufferUnderflowException extends BufferUnderflowExce
     }
 
     /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause
+     */
+    public DecoratedBufferUnderflowException(final String message, final Throwable cause) {
+        this.message = message;
+        initCause(cause);
+    }
+
+    /**
      * Returns the detail message of this exception.
      *
      * @return the detail message string of this exception

--- a/src/main/java/net/openhft/chronicle/bytes/util/EscapingStopCharTester.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/EscapingStopCharTester.java
@@ -18,9 +18,14 @@ package net.openhft.chronicle.bytes.util;
 import net.openhft.chronicle.bytes.StopCharTester;
 
 /**
- * This class implements a stop character tester that supports escape characters.
- * It decorates another {@link StopCharTester} by allowing characters to be escaped
- * using the backslash character ('\\').
+ * Implementation of {@link StopCharTester} where a backslash ('\\') escapes the
+ * following character. The tester delegates to another {@code StopCharTester}
+ * for actual stop character detection of non escaped characters.
+ * <p>
+ * The escape state persists for a single subsequent call to
+ * {@link #isStopChar(int)} on the same instance. Instances are therefore not
+ * thread safe. See also {@link EscapingStopCharsTester} for the two-argument
+ * variant.
  */
 public class EscapingStopCharTester implements StopCharTester {
 
@@ -30,9 +35,8 @@ public class EscapingStopCharTester implements StopCharTester {
     private boolean escaped = false;
 
     /**
-     * Constructs an EscapingStopCharTester with the given {@link StopCharTester}.
-     *
-     * @param sct the StopCharTester to be decorated with escape character functionality.
+     * @param sct the underlying {@link StopCharTester} used when the character
+     *            is not escaped
      */
     public EscapingStopCharTester(StopCharTester sct) {
         this.sct = sct;

--- a/src/main/java/net/openhft/chronicle/bytes/util/EscapingStopCharsTester.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/EscapingStopCharsTester.java
@@ -18,9 +18,14 @@ package net.openhft.chronicle.bytes.util;
 import net.openhft.chronicle.bytes.StopCharsTester;
 
 /**
- * A custom implementation of {@link StopCharsTester} that considers escape characters.
- * This tester allows escaping of characters using the backslash "\\" and will not treat
- * an escaped character as a stop character.
+ * Implementation of {@link StopCharsTester} that treats a backslash ('\\') as an
+ * escape character. The tester delegates to another {@code StopCharsTester} when
+ * a character is not escaped.
+ * <p>
+ * The escape state is held per instance: after seeing a backslash the next call
+ * to {@link #isStopChar(int, int)} ignores the character passed and clears the
+ * escaped state. Instances are therefore not thread safe. See also
+ * {@link EscapingStopCharTester} for the single-character variant.
  */
 public class EscapingStopCharsTester implements StopCharsTester {
 
@@ -29,9 +34,8 @@ public class EscapingStopCharsTester implements StopCharsTester {
     private boolean escaped = false;
 
     /**
-     * Constructs an EscapingStopCharsTester with the given {@link StopCharsTester}.
-     *
-     * @param sct the StopCharsTester to be decorated with escape character functionality.
+     * @param sct the underlying {@link StopCharsTester} to which non escaped
+     *            characters will be delegated
      */
     public EscapingStopCharsTester(StopCharsTester sct) {
         this.sct = sct;

--- a/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
@@ -23,24 +23,26 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Utility class for replacing tokens in strings with their corresponding property values.
- * <p>
- * The class provides methods to replace tokens in the format {@code ${property}} within strings,
- * with the corresponding property values from system properties or a given {@link Properties} object.
+ * Utility for substituting property placeholders in strings. Placeholders are
+ * expected in the form {@code ${propertyName}} where optional ASCII white space
+ * inside the braces is ignored.
+ * The class is stateless and therefore thread safe.
  */
 public enum PropertyReplacer {
     ; // No instances
 
-    // Pattern to find tokens in the format ${property}
+    // Pattern to find tokens in the format ${ property }
     private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{\\s*+([^}\\s]*+)\\s*+}");
 
     /**
      * Replaces tokens of the format {@code ${property}} in the given expression with their corresponding
-     * system property values.
+     * system property values. If a placeholder has no matching property an
+     * {@link IllegalArgumentException} is thrown.
      *
-     * @param expression the input string containing tokens to be replaced.
-     * @return a new string with tokens replaced by their corresponding system property values.
-     * @throws IllegalArgumentException if a token does not have a corresponding system property.
+     * @param expression the input string containing tokens to be replaced
+     * @return a new string with tokens replaced by system property values
+     * @throws IllegalArgumentException if a token has no matching system property
+     * @throws NullPointerException if {@code expression} is null
      */
     public static String replaceTokensWithProperties(String expression) throws IllegalArgumentException {
         StringBuilder result = new StringBuilder(expression.length());
@@ -69,12 +71,14 @@ public enum PropertyReplacer {
 
     /**
      * Replaces tokens of the format {@code ${property}} in the given expression with their corresponding
-     * values from the provided {@link Properties} object.
+     * values from the provided {@link Properties} object. Unresolved tokens result
+     * in an {@link IllegalArgumentException}.
      *
-     * @param expression the input string containing tokens to be replaced.
-     * @param properties the Properties object to retrieve property values from.
-     * @return a new string with tokens replaced by their corresponding property values from the given Properties object.
-     * @throws IllegalArgumentException if a token does not have a corresponding property in the given Properties object.
+     * @param expression the input string containing tokens to be replaced
+     * @param properties the property source used for substitutions
+     * @return a new string with tokens replaced by values from {@code properties}
+     * @throws IllegalArgumentException if a token has no corresponding property
+     * @throws NullPointerException if {@code expression} or {@code properties} is null
      */
     public static String replaceTokensWithProperties(String expression, Properties properties) throws IllegalArgumentException {
         StringBuilder result = new StringBuilder(expression.length());
@@ -102,7 +106,9 @@ public enum PropertyReplacer {
     }
 
     /**
-     * Converts the content of an {@link java.io.InputStream} to a String.
+     * Converts the content of an {@link java.io.InputStream} to a String. This
+     * helper is used instead of {@link java.io.InputStream#readAllBytes()} for
+     * compatibility with earlier Java versions.
      *
      * @param is the InputStream to be converted.
      * @return the content of the InputStream as a String.

--- a/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
@@ -30,8 +30,15 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.bytes.BytesUtil.toCharArray;
 
 /**
- * String interner optimized for Bytes. This class extends {@link StringInterner} and is specifically
- * designed to handle interning of strings represented in {@link Bytes} objects.
+ * {@link net.openhft.chronicle.core.pool.StringInterner} specialised for
+ * {@link Bytes} instances. Byte sequences are interpreted as 8-bit characters
+ * (for example ISO-8859-1) when forming {@link String} objects.
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * StringInternerBytes interner = new StringInternerBytes(64);
+ * String s = interner.intern(bytes, length);
+ * }</pre>
  */
 public class StringInternerBytes extends StringInterner {
 
@@ -63,15 +70,14 @@ public class StringInternerBytes extends StringInterner {
     }
 
     /**
-     * Converts the given bytes to an ISO-8859-1 encoded string, and interns it. The string ends
-     * either at the byte limit or the specified length, whichever comes first. If the string is
-     * already in the pool, the pooled instance is returned. Otherwise, the string is added to the
-     * pool.
+     * Reads {@code length} bytes from {@code bytes.readPosition()}, converts them
+     * using an 8-bit character encoding and interns the resulting {@link String}.
+     * The read position of {@code bytes} is advanced after the conversion.
      *
-     * @param bytes  the bytes to convert to a string.
-     * @param length specifies the maximum number of bytes to be converted, must be non-negative.
-     * @return the interned string representation of the bytes.
-     * @throws IllegalArgumentException If length is negative.
+     * @param bytes  the bytes to convert
+     * @param length the number of bytes to read from {@code bytes}
+     * @return the interned string
+     * @throws IllegalArgumentException if {@code length} is negative
      * @throws BufferUnderflowException If there are not enough bytes remaining to read.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way

--- a/src/main/java/net/openhft/chronicle/bytes/util/UTF8StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/UTF8StringInterner.java
@@ -29,10 +29,14 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.BufferUnderflowException;
 
 /**
- * A specialized interner for interning strings encoded in UTF-8.
- * <p>
- * This class extends {@link AbstractInterner} and overrides its getValue method to intern
- * strings encoded in UTF-8 format represented in {@link BytesStore}.
+ * {@link AbstractInterner} implementation for interning {@link String} objects
+ * decoded from UTF-8 byte sequences within a {@link BytesStore}.
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * UTF8StringInterner interner = new UTF8StringInterner(256);
+ * String s = interner.intern(store, length);
+ * }</pre>
  */
 public class UTF8StringInterner extends AbstractInterner<String> {
 
@@ -51,12 +55,13 @@ public class UTF8StringInterner extends AbstractInterner<String> {
     }
 
     /**
-     * Converts the bytes from a {@link BytesStore} into a UTF-8 encoded string.
-     * The bytes are assumed to be in UTF-8 format and are decoded accordingly.
+     * Decodes a UTF-8 string from the supplied {@link BytesStore}. Exactly
+     * {@code length} bytes are read starting from {@code cs.readPosition()} and
+     * the read position is left unchanged.
      *
-     * @param cs     the {@link BytesStore} containing the bytes to be converted
-     * @param length the number of bytes to read from the {@link BytesStore}
-     * @return the resulting UTF-8 encoded string
+     * @param cs     the bytes store containing UTF-8 data
+     * @param length the number of bytes to read
+     * @return the decoded string
      * @throws UTFDataFormatRuntimeException  If the bytes are not valid UTF-8 encoded characters
      * @throws BufferUnderflowException       If the buffer's limits are exceeded
      * @throws ClosedIllegalStateException    If the resource has been released or closed.

--- a/src/main/java/net/openhft/chronicle/bytes/util/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/package-info.java
@@ -1,25 +1,28 @@
 /**
- * Provides utility classes and interfaces for Chronicle Bytes.
+ * Internal helper classes and interfaces used by Chronicle Bytes.
  * <p>
- * This package contains classes and interfaces that are used to support the functionality
- * of Chronicle Bytes, which is a library for working with bytes, buffers and serialization.
- * Some of the features provided by this package include:
+ * These utilities follow Chronicle's zero-allocation, low-latency design philosophy
+ * and may change between minor releases. They live outside the public API and
+ * carry no binary-compatibility guarantees. Features include:
  * 
  * <ul>
- *     <li>Specialized exceptions for buffer overflow and underflow, allowing custom messages.</li>
+ *     <li>Specialised exceptions for buffer overflow and underflow, allowing custom messages.</li>
  *     <li>Interning utilities for strings in various character encodings, and utilities for
  *         interned objects in general, which help in reducing memory usage.</li>
  *     <li>Utilities for property replacement within strings based on property values.</li>
  *     <li>Support for escaping stop characters in character sequences, useful for parsing
- *         and tokenization tasks.</li>
+ *         and tokenisation tasks.</li>
  *     <li>Compression and decompression utilities for working with byte data.</li>
  * </ul>
  * <p>
- * This package is a part of the Chronicle Bytes library, which is an efficient and high-performance
- * library for working with bytes, used for low-level I/O operations, serialization, and data manipulation.
+ * This package forms part of Chronicle Bytes which is optimised for low level I/O,
+ * serialisation and data manipulation.
+ *
+ * @implNote Most classes are not thread safe unless stated otherwise.
  * 
  *
  * @see net.openhft.chronicle.bytes.Bytes
  * @see net.openhft.chronicle.bytes.BytesStore
+ * @see net.openhft.chronicle.bytes.render
  */
 package net.openhft.chronicle.bytes.util;


### PR DESCRIPTION
## Summary
- document util package in British English
- detail binary length limits and memory fences
- clarify compression API stream semantics
- note stateful escaping char testers
- add cause constructors for decorated exceptions

## Testing
- `mvn -q verify` *(fails: command not found)*