### PR TITLE
Improve Javadoc for bytes classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
@@ -32,7 +32,9 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * Utility class for working with Appendable objects such as StringBuilder and Bytes.
+ * Utility methods for manipulating {@link Appendable} implementations such as
+ * {@link StringBuilder} and {@link Bytes}. These helpers are used throughout
+ * the text parsing and formatting code paths.
  */
 @SuppressWarnings("rawtypes")
 public enum AppendableUtil {
@@ -42,13 +44,11 @@ public enum AppendableUtil {
     private static final String MALFORMED_INPUT_AROUND_BYTE = "malformed input around byte ";
 
     /**
-     * Sets a character at a specified index in the given Appendable.
+     * Writes {@code ch} at {@code index} in the supplied {@code Appendable}.
+     * Only {@link StringBuilder} and {@link Bytes} are supported.
      *
-     * @param sb    the Appendable to modify
-     * @param index the index at which to set the character
-     * @param ch    the character to set
-     * @throws IllegalArgumentException If the Appendable is not of type StringBuilder or Bytes
-     * @throws BufferOverflowException  If the index is larger than the buffer's capacity
+     * @throws IllegalArgumentException if {@code sb} is not a supported type
+     * @throws BufferOverflowException  if {@code index} exceeds the capacity of the target
      */
     public static void setCharAt(@NotNull Appendable sb, @NonNegative int index, char ch)
             throws IllegalArgumentException, BufferOverflowException {
@@ -61,15 +61,11 @@ public enum AppendableUtil {
     }
 
     /**
-     * Parses a UTF-8 BytesStore into a StringBuilder.
+     * Decodes {@code length} bytes from {@code bs} as either UTF-8 or ISO-8859-1
+     * and appends the text to {@code sb}.
      *
-     * @param bs     the BytesStore to parse
-     * @param sb     the StringBuilder to append to
-     * @param utf    whether to parse as UTF-8
-     * @param length the length of characters to parse
-     * @throws UTFDataFormatRuntimeException If invalid UTF-8 sequence is encountered
-     * @throws BufferUnderflowException      If the BytesStore doesn't contain enough data
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * @param utf when {@code true} treat the bytes as UTF-8, otherwise ISO-8859-1
+     * @throws UTFDataFormatRuntimeException if the data is malformed UTF-8
      */
     public static void parseUtf8(@NotNull BytesStore<?, ?> bs, StringBuilder sb, boolean utf, @NonNegative int length)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, ClosedIllegalStateException {
@@ -77,13 +73,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Sets the length of the given Appendable.
-     *
-     * @param sb        the Appendable to modify
-     * @param newLength the new length to set
-     * @throws IllegalArgumentException    If the Appendable is not of type StringBuilder or Bytes
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws BufferUnderflowException    If the new length is greater than the Bytes's capacity
+     * Adjusts the logical length of {@code sb}. For {@link Bytes} this moves the
+     * write position to {@code newLength}.
      */
     public static void setLength(@NotNull Appendable sb, @NonNegative int newLength)
             throws IllegalArgumentException, ClosedIllegalStateException, BufferUnderflowException {
@@ -97,13 +88,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Appends a double value to the given Appendable.
-     *
-     * @param sb    the Appendable to append to
-     * @param value the double value to append
-     * @throws IllegalArgumentException    If the Appendable is not of type StringBuilder or Bytes
-     * @throws BufferOverflowException     If there is not enough space in the Bytes to append the value
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Appends {@code value} to {@code sb}. For {@link Bytes} the configured
+     * {@link net.openhft.chronicle.bytes.render.Decimaliser} is used.
      */
     public static void append(@NotNull Appendable sb, double value)
             throws IllegalArgumentException, BufferOverflowException, ClosedIllegalStateException {
@@ -116,13 +102,7 @@ public enum AppendableUtil {
     }
 
     /**
-     * Appends a long value to the given Appendable.
-     *
-     * @param sb    the Appendable to append to
-     * @param value the long value to append
-     * @throws IllegalArgumentException    If the Appendable is not of type StringBuilder or Bytes
-     * @throws BufferOverflowException     If there is not enough space in the Bytes to append the value
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Appends {@code value} in decimal form to {@code sb}.
      */
     public static void append(@NotNull Appendable sb, long value)
             throws IllegalArgumentException, BufferOverflowException, ClosedIllegalStateException {
@@ -149,13 +129,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Reads an 8-bit character from a StreamingDataInput and appends it to a StringBuilder
-     * until a stop character as defined by the given StopCharsTester is encountered.
-     *
-     * @param bytes      the StreamingDataInput to read from
-     * @param appendable the StringBuilder to append to
-     * @param tester     the StopCharsTester defining the stop character
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Reads 8-bit characters from {@code bytes} appending each to
+     * {@code appendable} until {@code tester} signals a stop or the input ends.
      */
     public static void read8bitAndAppend(@NotNull StreamingDataInput bytes,
                                          @NotNull StringBuilder appendable,
@@ -172,14 +147,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Reads an 8-bit character from a StreamingDataInput and appends it to an Appendable
-     * until a stop character as defined by the given StopCharsTester is encountered.
-     *
-     * @param bytes      the StreamingDataInput to read from
-     * @param appendable the Appendable to append to
-     * @param tester     the StopCharsTester defining the stop character
-     * @throws BufferUnderflowException    If the StreamingDataInput is exhausted
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Reads 8-bit characters and appends them to {@code appendable} until
+     * {@code tester} requests a stop.
      */
     public static void readUTFAndAppend(@NotNull StreamingDataInput bytes,
                                         @NotNull Appendable appendable,
@@ -193,15 +162,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Reads a UTF-8 encoded character from a StreamingDataInput and appends it to an Appendable
-     * until a stop character as defined by the given StopCharsTester is encountered.
-     *
-     * @param bytes      the StreamingDataInput to read from
-     * @param appendable the Appendable to append to
-     * @param tester     the StopCharsTester defining the stop character
-     * @throws BufferUnderflowException    If the StreamingDataInput is exhausted
-     * @throws IOException                 If an I/O error occurs
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Reads UTF-8 characters from {@code bytes} and appends them to
+     * {@code appendable} until {@code tester} signals a stop or the input ends.
      */
     public static void readUtf8AndAppend(@NotNull StreamingDataInput bytes,
                                          @NotNull Appendable appendable,
@@ -366,11 +328,7 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a CharSequence in UTF-8 format.
-     *
-     * @param str the CharSequence to calculate the length of
-     * @return the length of the CharSequence in UTF-8
-     * @throws IndexOutOfBoundsException If the CharSequence has invalid indices
+     * Determines how many bytes {@code str} will occupy when encoded as UTF-8.
      */
     public static long findUtf8Length(@NotNull CharSequence str)
             throws IndexOutOfBoundsException {
@@ -387,11 +345,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a byte array in UTF-8 format.
-     *
-     * @param bytes the byte array to calculate the length of
-     * @param coder a coder indicating the type of the content
-     * @return the length of the byte array in UTF-8
+     * Returns the number of bytes required to UTF-8 encode the supplied
+     * {@code bytes} using the given {@code coder} representation.
      */
     @Java9
     public static long findUtf8Length(byte[] bytes, byte coder) {
@@ -431,10 +386,7 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a byte array in UTF-8 format.
-     *
-     * @param chars the byte array to calculate the length of
-     * @return the length of the byte array in UTF-8
+     * Computes the UTF-8 byte length of the provided 8-bit encoded character array.
      */
     @Java9
     public static long findUtf8Length(byte[] chars) {
@@ -464,12 +416,7 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a character array in UTF-8 format, from a given offset up to the specified length.
-     *
-     * @param chars  the character array to calculate the length of
-     * @param offset the starting index in the character array
-     * @param length the number of characters to include in the calculation
-     * @return the length of the specified segment of the character array in UTF-8
+     * Returns the UTF-8 byte length of a portion of {@code chars}.
      */
     public static long findUtf8Length(char[] chars, @NonNegative int offset, @NonNegative int length) {
         requireNonNull(chars);
@@ -489,10 +436,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a character array in UTF-8 format.
-     *
-     * @param chars the character array to calculate the length of
-     * @return the length of the character array in UTF-8
+     * Convenience overload of {@link #findUtf8Length(char[], int, int)} for the
+     * whole array.
      */
     public static long findUtf8Length(char[] chars) {
         return findUtf8Length(chars, 0, chars.length);

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
@@ -27,9 +27,9 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Invocation handler that encodes method invocations as binary data written to a {@link BytesOut}.
- * This class is typically used in conjunction with a proxy to provide a binary "wire" protocol representation
- * of calls to an interface's methods.
+ * {@link java.lang.reflect.InvocationHandler} that serialises method calls to a
+ * {@link BytesOut} using a {@link MethodEncoder} per method. Intended for proxy
+ * based one-way messaging.
  */
 public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocationHandler implements BytesMethodWriterInvocationHandler {
     private final Function<Method, MethodEncoder> methodToId;
@@ -37,11 +37,11 @@ public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocation
     private final Map<Method, MethodEncoder> methodToIdMap = new LinkedHashMap<>();
 
     /**
-     * Create a new invocation handler.
+     * Creates an instance for the supplied interface.
      *
-     * @param tClass     The type of the interface to be handled.
-     * @param methodToId A function mapping Methods to corresponding {@link MethodEncoder} instances.
-     * @param out        The output stream to which encoded invocations should be written.
+     * @param tClass     interface being proxied
+     * @param methodToId lookup supplying a {@link MethodEncoder} per method
+     * @param out        target stream for the encoded calls
      */
     public BinaryBytesMethodWriterInvocationHandler(Class<?> tClass, Function<Method, MethodEncoder> methodToId, BytesOut<?> out) {
         super(tClass);
@@ -50,18 +50,8 @@ public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocation
     }
 
     /**
-     * Handle a method invocation on a proxy instance. The method invocation is encoded and written to the {@link BytesOut}.
-     *
-     * @param proxy  The proxy instance on which the method was invoked.
-     * @param method The method that was invoked.
-     * @param args   The arguments provided to the method.
-     * @return Always null.
-     * @throws IllegalStateException        if the underlying bytes store is closed.
-     * @throws BufferOverflowException      if there isn't enough space in the {@link BytesOut} to write the value.
-     * @throws BufferUnderflowException     if the underlying bytes store cannot provide enough data.
-     * @throws IllegalArgumentException     if the arguments don't match the method's requirements.
-     * @throws ArithmeticException          if numeric values overflow or underflow.
-     * @throws InvalidMarshallableException if a marshalling error occurs.
+     * Encodes the invocation and writes it to {@link #out}. On failure the
+     * write position is rolled back to preserve stream integrity.
      */
     @Override
     protected Object doInvoke(Object proxy, Method method, Object[] args)

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryWireCode.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryWireCode.java
@@ -20,289 +20,166 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * The BinaryWireCode interface contains constants for various types of data expected
- * in a binary wire protocol. These constants correspond to specific codes or ranges
- * used in the decoding process.
- * <p>
- * The constants are categorized into different types:
- * BYTES_LENGTH8, BYTES_LENGTH16, and BYTES_LENGTH32 correspond to sequences of length
- * 0 - 255, 0 - 2^16-1, and 0 - 2^32-1 respectively,
- * FIELD_ANCHOR, ANCHOR, and UPDATED_ALIAS are used for field anchoring purposes,
- * U8_ARRAY represents an array of unsigned bytes,
- * I64_ARRAY represents an array of 64-bit integer values,
- * PADDING32 and PADDING are used for padding purposes,
- * FLOAT32, FLOAT64, FLOAT_STOP_2, FLOAT_STOP_4, FLOAT_STOP_6, FLOAT_SET_LOW_0,
- * FLOAT_SET_LOW_2, FLOAT_SET_LOW_4 are used for various floating point number operations,
- * UUID, UINT8, UINT16, UINT32, INT8, INT16, INT32, INT64, SET_LOW_INT8, SET_LOW_INT16,
- * STOP_BIT, INT64_0x are used for various integer operations and UUID representation,
- * FALSE, TRUE, TIME, DATE, DATE_TIME, ZONED_DATE_TIME, TYPE_PREFIX, FIELD_NAME_ANY,
- * STRING_ANY, EVENT_NAME, FIELD_NUMBER, NULL, TYPE_LITERAL, EVENT_OBJECT, COMMENT, HINT
- * are used for various data type representations and operations,
- * FIELD_NAME0 to FIELD_NAME31 are used to represent field names,
- * STRING_0 to STRING_31 are used to represent strings.
+ * Defines byte codes used by Chronicle's binary wire protocol. Each constant
+ * indicates the type or structure of the data that follows in the stream.
  */
 public interface BinaryWireCode {
 
-    /**
-     * Represents a sequence of length 0 - 255 bytes.
-     */
+    /** Code for a byte sequence with a length in the following one byte. */
     int BYTES_LENGTH8 = 0x80;
 
-    /**
-     * Represents a sequence of length 0 - 2^16-1 bytes.
-     */
+    /** Code for a byte sequence with a 2 byte length prefix. */
     int BYTES_LENGTH16 = 0x81;
 
-    /**
-     * Represents a sequence of length 0 - 2^32-1.
-     */
+    /** Code for a byte sequence with a 4 byte length prefix. */
     int BYTES_LENGTH32 = 0x82;
 
-    /**
-     * Denotes a field anchor.
-     */
+    /** Code referencing a previously written field. */
     int FIELD_ANCHOR = 0x87;
 
-    /**
-     * Represents an anchor.
-     */
+    /** Anchor for cyclic references. */
     int ANCHOR = 0x88;
 
-    /**
-     * Represents an updated alias.
-     */
+    /** Indicates an alias update. */
     int UPDATED_ALIAS = 0x89;
 
-    /**
-     * Represents an array of unsigned bytes.
-     */
+    /** Code for an array of unsigned bytes. */
     int U8_ARRAY = 0x8A;
-    /**
-     * Represents an array of signed long.
-     */
+    /** Code for an array of signed 64-bit integers. */
     int I64_ARRAY = 0x8D;
 
-    /**
-     * Represents 32-bit padding.
-     */
+    /** 32-bit padding marker. */
     int PADDING32 = 0x8E;
 
-    /**
-     * Represents padding.
-     */
+    /** Generic padding marker. */
     int PADDING = 0x8F;
 
-    /**
-     * Represents a 32-bit floating-point number.
-     */
+    /** 32-bit float value. */
     int FLOAT32 = 0x90;
 
-    /**
-     * Represents a 64-bit floating-point number.
-     */
+    /** 64-bit float value. */
     int FLOAT64 = 0x91;
-    /**
-     * Represents floating-point stop bit encoded * 10^2.
-     */
+    /** Float encoded with 2 decimal places using stop bits. */
     int FLOAT_STOP_2 = 0x92;
 
-    /**
-     * Represents floating-point stop 4.
-     */
+    /** Float encoded with 4 decimal places. */
     int FLOAT_STOP_4 = 0x94;
 
-    /**
-     * Represents floating-point stop 6.
-     */
+    /** Float encoded with 6 decimal places. */
     int FLOAT_STOP_6 = 0x96;
 
-    /**
-     * Represents floating-point set low 0.
-     */
+    /** Float value scaled by 1. */
     int FLOAT_SET_LOW_0 = 0x9A;
 
-    /**
-     * Represents floating-point set low 2.
-     */
+    /** Float value scaled by 10^2. */
     int FLOAT_SET_LOW_2 = 0x9B;
 
-    /**
-     * Represents floating-point set low 4.
-     */
+    /** Float value scaled by 10^4. */
     int FLOAT_SET_LOW_4 = 0x9C;
     // 0x98 - 0x9F
 
-    /**
-     * Represents a UUID.
-     */
+    /** Universally unique identifier. */
     int UUID = 0xA0;
 
-    /**
-     * Represents an 8-bit unsigned integer.
-     */
+    /** Unsigned 8-bit integer value. */
     int UINT8 = 0xA1;
 
-    /**
-     * Represents a 16-bit unsigned integer.
-     */
+    /** Unsigned 16-bit integer value. */
     int UINT16 = 0xA2;
 
-    /**
-     * Represents a 32-bit unsigned integer.
-     */
+    /** Unsigned 32-bit integer value. */
     int UINT32 = 0xA3;
 
-    /**
-     * Represents an 8-bit integer.
-     */
+    /** Signed 8-bit integer value. */
     int INT8 = 0xA4;
 
-    /**
-     * Represents a 16-bit integer.
-     */
+    /** Signed 16-bit integer value. */
     int INT16 = 0xA5;
 
-    /**
-     * Represents a 32-bit integer.
-     */
+    /** Signed 32-bit integer value. */
     int INT32 = 0xA6;
 
-    /**
-     * Represents a 64-bit integer.
-     */
+    /** Signed 64-bit integer value. */
     int INT64 = 0xA7;
 
-    /**
-     * Represents a set low 8-bit integer.
-     */
+    /** Set low 8-bit integer value. */
     int SET_LOW_INT8 = 0xA8;
 
-    /**
-     * Represents a set low 16-bit integer.
-     */
+    /** Set low 16-bit integer value. */
     int SET_LOW_INT16 = 0xA9;
 
-    /**
-     * Represents a stop bit.
-     */
+    /** Stop bit encoded integer. */
     int STOP_BIT = 0xAE;
 
-    /**
-     * Represents a 64-bit integer with a hexadecimal prefix.
-     */
+    /** 64-bit integer formatted as hexadecimal. */
     int INT64_0x = 0xAF;
 
-    /**
-     * Represents a boolean false value.
-     */
+    /** Boolean false value. */
     int FALSE = 0xB0;
 
-    /**
-     * Represents a boolean true value.
-     */
+    /** Boolean true value. */
     int TRUE = 0xB1;
 
-    /**
-     * Represents a time.
-     */
+    /** Millisecond time of day. */
     int TIME = 0xB2;
 
-    /**
-     * Represents a date.
-     */
+    /** Date (days since epoch). */
     int DATE = 0xB3;
 
-    /**
-     * Represents a date and time.
-     */
+    /** Date and time without zone. */
     int DATE_TIME = 0xB4;
 
-    /**
-     * Represents a zoned date and time.
-     */
+    /** Zoned date and time. */
     int ZONED_DATE_TIME = 0xB5;
 
-    /**
-     * Represents a type prefix.
-     */
+    /** Type prefix marker. */
     int TYPE_PREFIX = 0xB6;
 
-    /**
-     * Represents a field name that can be any string.
-     */
+    /** Field name encoded as text. */
     int FIELD_NAME_ANY = 0xB7;
 
-    /**
-     * Represents a string that can be any string.
-     */
+    /** Arbitrary string value. */
     int STRING_ANY = 0xB8;
 
-    /**
-     * Represents an event name.
-     */
+    /** Event name string. */
     int EVENT_NAME = 0xB9;
 
-    /**
-     * Represents a field number.
-     */
+    /** Field number encoded as stop bit. */
     int FIELD_NUMBER = 0xBA;
 
-    /**
-     * Represents a null value.
-     */
+    /** Null marker. */
     int NULL = 0xBB;
 
-    /**
-     * Represents a type literal.
-     */
+    /** Type literal string. */
     int TYPE_LITERAL = 0xBC;
 
-    /**
-     * Represents an event object.
-     */
+    /** Event object encoded in binary. */
     int EVENT_OBJECT = 0xBD;
 
-    /**
-     * Represents a comment.
-     */
+    /** Comment text. */
     int COMMENT = 0xBE;
 
-    /**
-     * Represents a hint.
-     */
+    /** Hint for optimisation. */
     int HINT = 0xBF;
 
-    /**
-     * Represents the field name of length 0.
-     */
+    /** Field name with zero length. */
     int FIELD_NAME0 = 0xC0;
     // ...
 
-    /**
-     * Represents the field name of length 31 bytes.
-     */
+    /** Field name exactly 31 bytes long. */
     int FIELD_NAME31 = 0xDF;
 
-    /**
-     * Represents the string of length 0.
-     */
+    /** String of length zero. */
     int STRING_0 = 0xE0;
     // ...
-    /**
-     * Represents the string of length 31 bytes.
-     */
+    /** String exactly 31 bytes long. */
     int STRING_31 = 0xFF;
 
-    /**
-     * Maps each code in the interface to its corresponding string representation.
-     */
+    /** Lookup table mapping codes to their textual name, useful for debugging. */
     String[] STRING_FOR_CODE = _stringForCode(BinaryWireCode.class);
 
     /**
-     * Helper method for generating a text representation all the codes
-     *
-     * @param clazz to search for constants to extract
-     * @return an array of Strings for each code
+     * Builds {@link #STRING_FOR_CODE} by reflecting over constant fields.
      */
     static String[] _stringForCode(Class<?> clazz) {
         String[] stringForCode = new String[256];

--- a/src/main/java/net/openhft/chronicle/bytes/Byteable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Byteable.java
@@ -27,55 +27,47 @@ import java.nio.BufferUnderflowException;
 import java.nio.channels.FileLock;
 
 /**
- * An interface for a reference to off-heap memory, acting as a proxy for memory residing outside the heap.
- * This allows the reference to be reassigned, facilitating dynamic memory management.
+ * Allows a Java object to view a slice of a {@link BytesStore}. Implementations
+ * may be remapped to different offsets to avoid copying.
  */
 public interface Byteable {
     /**
-     * Sets the reference to a data type that points to the underlying ByteStore.
+     * Map this object onto a region of {@code bytesStore}.
      *
-     * @param bytesStore the fixed-point ByteStore
-     * @param offset     the offset within the ByteStore, indicating the starting point of the memory section
-     * @param length     the length of the memory section within the ByteStore
-     * @throws IllegalArgumentException       If the provided arguments are invalid
-     * @throws BufferOverflowException        If the new memory section extends beyond the end of the ByteStore
-     * @throws BufferUnderflowException       If the new memory section starts before the start of the ByteStore
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param bytesStore backing store
+     * @param offset     non-negative offset
+     * @param length     non-negative length which should match {@link #maxSize()}
+     * @throws IllegalArgumentException       if parameters are out of range
+     * @throws BufferOverflowException        if the region would extend past the end of the store
+     * @throws BufferUnderflowException       if the region would start before {@code 0}
+     * @throws ClosedIllegalStateException    if the store is closed
+     * @throws ThreadingIllegalStateException if accessed from the wrong thread
      */
     @SuppressWarnings("rawtypes")
     void bytesStore(@NotNull BytesStore bytesStore, @NonNegative long offset, @NonNegative long length)
             throws ClosedIllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException, ThreadingIllegalStateException;
 
     /**
-     * Returns the ByteStore to which this object currently points.
-     *
-     * @return the ByteStore or null if it's not set
+     * @return current backing {@link BytesStore} or {@code null} if unmapped
      */
     @Nullable
     BytesStore<?, ?> bytesStore();
 
     /**
-     * Returns the offset within the ByteStore to which this object currently points.
-     *
-     * @return the offset within the ByteStore (not the physical memory address)
+     * @return offset within the current {@link BytesStore}
      */
     long offset();
 
     /**
-     * Returns the absolute address in the memory to which this object currently points.
-     *
-     * @return the absolute address in the memory
-     * @throws UnsupportedOperationException If the address is not set or the underlying ByteStore isn't native
+     * @return absolute address of the mapped data if supported
+     * @throws UnsupportedOperationException if not backed by native memory
      */
     default long address() throws UnsupportedOperationException {
         return bytesStore().addressForRead(offset());
     }
 
     /**
-     * Returns the maximum size in bytes that this reference can point to.
-     *
-     * @return the maximum size in bytes for this reference
+     * @return fixed byte size represented by this object
      */
     long maxSize();
 

--- a/src/main/java/net/openhft/chronicle/bytes/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/package-info.java
@@ -1,38 +1,24 @@
 /**
- * The Chronicle Bytes package provides low-level memory access wrappers with functionalities
- * akin to Java NIO's ByteBuffer. The API supports UTF-8 and ISO-8859-1 encoded strings,
- * thread-safe off-heap memory operations, deterministic release of resources via reference
- * counting, and more.
- * <p>
- * The main classes in this package are:
- * <p>
- * {@link net.openhft.chronicle.bytes.Bytes}: A class for managing byte arrays, including
- * operations for reading and writing data. It extends if you write data into it which is
- * larger than its real capacity. It provides access to the cursors for reading and writing
- * data at desired indices.
- * <p>
- * {@link net.openhft.chronicle.bytes.BytesStore}: A block of memory with fixed size into
- * which you can write data and later read. You cannot use the cursors with a BytesStore,
- * unlike Bytes.
- * <p>
- * {@link net.openhft.chronicle.bytes.BytesIn}: Interface that provides a range of methods
- * for reading data from bytes.
- * <p>
- * {@link net.openhft.chronicle.bytes.BytesOut}: Interface that provides a range of methods
- * for writing data to bytes.
- * <p>
- * {@link net.openhft.chronicle.bytes.ByteStringParser}: An interface for parsing byte strings.
- * <p>
- * {@link net.openhft.chronicle.bytes.ByteStringAppender}: An interface for appending byte strings.
- * <p>
- * {@link net.openhft.chronicle.bytes.RandomDataInput}: An interface that extends the {@link net.openhft.chronicle.bytes.StreamingDataInput}.
- * <p>
- * {@link net.openhft.chronicle.bytes.RandomDataOutput}: An interface that extends the {@link net.openhft.chronicle.bytes.StreamingDataOutput}.
- * <p>
- * {@link net.openhft.chronicle.bytes.StreamingDataInput}: An interface for reading data from a stream.
- * <p>
- * {@link net.openhft.chronicle.bytes.StreamingDataOutput}: An interface for writing data to a stream.
- * <p>
- * For more information, please refer to each class documentation.
+ * Provides versatile, high-performance access to contiguous regions of memory.
+ * Implementations cover on-heap arrays, native memory and memory-mapped files.
+ * The API forms a building block for other Chronicle libraries.
+ *
+ * <p>Key features:
+ * <ul>
+ * <li>Support for 63-bit addressing for large structures.</li>
+ * <li>Efficient encoding and decoding for UTF-8 and ISO-8859-1 strings.</li>
+ * <li>Thread-safe atomic operations via {@link net.openhft.chronicle.bytes.BytesStore BytesStore}.</li>
+ * <li>Deterministic resource management using
+ * {@link net.openhft.chronicle.core.io.ReferenceCounted ReferenceCounted}.</li>
+ * <li>Elastic buffers such as {@link net.openhft.chronicle.bytes.Bytes#allocateElasticDirect()}.</li>
+ * <li>Direct number parsing and formatting to and from byte sequences.</li>
+ * </ul>
+ *
+ * Core abstractions:
+ * <ul>
+ * <li>{@link net.openhft.chronicle.bytes.BytesStore BytesStore} &ndash; a fixed-size region of memory.</li>
+ * <li>{@link net.openhft.chronicle.bytes.Bytes Bytes} &ndash; a mutable view with independent
+ * read and write cursors.</li>
+ * </ul>
  */
 package net.openhft.chronicle.bytes;


### PR DESCRIPTION
## Summary
- expand package overview for Chronicle Bytes
- clarify behaviour and configuration points in AbstractBytes
- document Appendable utilities and parsing helpers
- describe binary method writer handler
- document binary wire codes
- explain how `Byteable` maps objects to `BytesStore`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*