### PR TITLE
Improve Javadoc for bytes classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
@@ -32,7 +32,9 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * Utility class for working with Appendable objects such as StringBuilder and Bytes.
+ * Utility methods for manipulating {@link Appendable} implementations such as
+ * {@link StringBuilder} and {@link Bytes}. These helpers are used throughout
+ * the text parsing and formatting code paths.
  */
 @SuppressWarnings("rawtypes")
 public enum AppendableUtil {
@@ -42,13 +44,11 @@ public enum AppendableUtil {
     private static final String MALFORMED_INPUT_AROUND_BYTE = "malformed input around byte ";
 
     /**
-     * Sets a character at a specified index in the given Appendable.
+     * Writes {@code ch} at {@code index} in the supplied {@code Appendable}.
+     * Only {@link StringBuilder} and {@link Bytes} are supported.
      *
-     * @param sb    the Appendable to modify
-     * @param index the index at which to set the character
-     * @param ch    the character to set
-     * @throws IllegalArgumentException If the Appendable is not of type StringBuilder or Bytes
-     * @throws BufferOverflowException  If the index is larger than the buffer's capacity
+     * @throws IllegalArgumentException if {@code sb} is not a supported type
+     * @throws BufferOverflowException  if {@code index} exceeds the capacity of the target
      */
     public static void setCharAt(@NotNull Appendable sb, @NonNegative int index, char ch)
             throws IllegalArgumentException, BufferOverflowException {
@@ -61,15 +61,11 @@ public enum AppendableUtil {
     }
 
     /**
-     * Parses a UTF-8 BytesStore into a StringBuilder.
+     * Decodes {@code length} bytes from {@code bs} as either UTF-8 or ISO-8859-1
+     * and appends the text to {@code sb}.
      *
-     * @param bs     the BytesStore to parse
-     * @param sb     the StringBuilder to append to
-     * @param utf    whether to parse as UTF-8
-     * @param length the length of characters to parse
-     * @throws UTFDataFormatRuntimeException If invalid UTF-8 sequence is encountered
-     * @throws BufferUnderflowException      If the BytesStore doesn't contain enough data
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * @param utf when {@code true} treat the bytes as UTF-8, otherwise ISO-8859-1
+     * @throws UTFDataFormatRuntimeException if the data is malformed UTF-8
      */
     public static void parseUtf8(@NotNull BytesStore<?, ?> bs, StringBuilder sb, boolean utf, @NonNegative int length)
             throws UTFDataFormatRuntimeException, BufferUnderflowException, ClosedIllegalStateException {
@@ -77,13 +73,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Sets the length of the given Appendable.
-     *
-     * @param sb        the Appendable to modify
-     * @param newLength the new length to set
-     * @throws IllegalArgumentException    If the Appendable is not of type StringBuilder or Bytes
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws BufferUnderflowException    If the new length is greater than the Bytes's capacity
+     * Adjusts the logical length of {@code sb}. For {@link Bytes} this moves the
+     * write position to {@code newLength}.
      */
     public static void setLength(@NotNull Appendable sb, @NonNegative int newLength)
             throws IllegalArgumentException, ClosedIllegalStateException, BufferUnderflowException {
@@ -97,13 +88,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Appends a double value to the given Appendable.
-     *
-     * @param sb    the Appendable to append to
-     * @param value the double value to append
-     * @throws IllegalArgumentException    If the Appendable is not of type StringBuilder or Bytes
-     * @throws BufferOverflowException     If there is not enough space in the Bytes to append the value
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Appends {@code value} to {@code sb}. For {@link Bytes} the configured
+     * {@link net.openhft.chronicle.bytes.render.Decimaliser} is used.
      */
     public static void append(@NotNull Appendable sb, double value)
             throws IllegalArgumentException, BufferOverflowException, ClosedIllegalStateException {
@@ -116,13 +102,7 @@ public enum AppendableUtil {
     }
 
     /**
-     * Appends a long value to the given Appendable.
-     *
-     * @param sb    the Appendable to append to
-     * @param value the long value to append
-     * @throws IllegalArgumentException    If the Appendable is not of type StringBuilder or Bytes
-     * @throws BufferOverflowException     If there is not enough space in the Bytes to append the value
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Appends {@code value} in decimal form to {@code sb}.
      */
     public static void append(@NotNull Appendable sb, long value)
             throws IllegalArgumentException, BufferOverflowException, ClosedIllegalStateException {
@@ -149,13 +129,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Reads an 8-bit character from a StreamingDataInput and appends it to a StringBuilder
-     * until a stop character as defined by the given StopCharsTester is encountered.
-     *
-     * @param bytes      the StreamingDataInput to read from
-     * @param appendable the StringBuilder to append to
-     * @param tester     the StopCharsTester defining the stop character
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Reads 8-bit characters from {@code bytes} appending each to
+     * {@code appendable} until {@code tester} signals a stop or the input ends.
      */
     public static void read8bitAndAppend(@NotNull StreamingDataInput bytes,
                                          @NotNull StringBuilder appendable,
@@ -172,14 +147,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Reads an 8-bit character from a StreamingDataInput and appends it to an Appendable
-     * until a stop character as defined by the given StopCharsTester is encountered.
-     *
-     * @param bytes      the StreamingDataInput to read from
-     * @param appendable the Appendable to append to
-     * @param tester     the StopCharsTester defining the stop character
-     * @throws BufferUnderflowException    If the StreamingDataInput is exhausted
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Reads 8-bit characters and appends them to {@code appendable} until
+     * {@code tester} requests a stop.
      */
     public static void readUTFAndAppend(@NotNull StreamingDataInput bytes,
                                         @NotNull Appendable appendable,
@@ -193,15 +162,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Reads a UTF-8 encoded character from a StreamingDataInput and appends it to an Appendable
-     * until a stop character as defined by the given StopCharsTester is encountered.
-     *
-     * @param bytes      the StreamingDataInput to read from
-     * @param appendable the Appendable to append to
-     * @param tester     the StopCharsTester defining the stop character
-     * @throws BufferUnderflowException    If the StreamingDataInput is exhausted
-     * @throws IOException                 If an I/O error occurs
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Reads UTF-8 characters from {@code bytes} and appends them to
+     * {@code appendable} until {@code tester} signals a stop or the input ends.
      */
     public static void readUtf8AndAppend(@NotNull StreamingDataInput bytes,
                                          @NotNull Appendable appendable,
@@ -366,11 +328,7 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a CharSequence in UTF-8 format.
-     *
-     * @param str the CharSequence to calculate the length of
-     * @return the length of the CharSequence in UTF-8
-     * @throws IndexOutOfBoundsException If the CharSequence has invalid indices
+     * Determines how many bytes {@code str} will occupy when encoded as UTF-8.
      */
     public static long findUtf8Length(@NotNull CharSequence str)
             throws IndexOutOfBoundsException {
@@ -387,11 +345,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a byte array in UTF-8 format.
-     *
-     * @param bytes the byte array to calculate the length of
-     * @param coder a coder indicating the type of the content
-     * @return the length of the byte array in UTF-8
+     * Returns the number of bytes required to UTF-8 encode the supplied
+     * {@code bytes} using the given {@code coder} representation.
      */
     @Java9
     public static long findUtf8Length(byte[] bytes, byte coder) {
@@ -431,10 +386,7 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a byte array in UTF-8 format.
-     *
-     * @param chars the byte array to calculate the length of
-     * @return the length of the byte array in UTF-8
+     * Computes the UTF-8 byte length of the provided 8-bit encoded character array.
      */
     @Java9
     public static long findUtf8Length(byte[] chars) {
@@ -464,12 +416,7 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a character array in UTF-8 format, from a given offset up to the specified length.
-     *
-     * @param chars  the character array to calculate the length of
-     * @param offset the starting index in the character array
-     * @param length the number of characters to include in the calculation
-     * @return the length of the specified segment of the character array in UTF-8
+     * Returns the UTF-8 byte length of a portion of {@code chars}.
      */
     public static long findUtf8Length(char[] chars, @NonNegative int offset, @NonNegative int length) {
         requireNonNull(chars);
@@ -489,10 +436,8 @@ public enum AppendableUtil {
     }
 
     /**
-     * Calculates the length of a character array in UTF-8 format.
-     *
-     * @param chars the character array to calculate the length of
-     * @return the length of the character array in UTF-8
+     * Convenience overload of {@link #findUtf8Length(char[], int, int)} for the
+     * whole array.
      */
     public static long findUtf8Length(char[] chars) {
         return findUtf8Length(chars, 0, chars.length);

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
@@ -27,9 +27,9 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Invocation handler that encodes method invocations as binary data written to a {@link BytesOut}.
- * This class is typically used in conjunction with a proxy to provide a binary "wire" protocol representation
- * of calls to an interface's methods.
+ * {@link java.lang.reflect.InvocationHandler} that serialises method calls to a
+ * {@link BytesOut} using a {@link MethodEncoder} per method. Intended for proxy
+ * based one-way messaging.
  */
 public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocationHandler implements BytesMethodWriterInvocationHandler {
     private final Function<Method, MethodEncoder> methodToId;
@@ -37,11 +37,11 @@ public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocation
     private final Map<Method, MethodEncoder> methodToIdMap = new LinkedHashMap<>();
 
     /**
-     * Create a new invocation handler.
+     * Creates an instance for the supplied interface.
      *
-     * @param tClass     The type of the interface to be handled.
-     * @param methodToId A function mapping Methods to corresponding {@link MethodEncoder} instances.
-     * @param out        The output stream to which encoded invocations should be written.
+     * @param tClass     interface being proxied
+     * @param methodToId lookup supplying a {@link MethodEncoder} per method
+     * @param out        target stream for the encoded calls
      */
     public BinaryBytesMethodWriterInvocationHandler(Class<?> tClass, Function<Method, MethodEncoder> methodToId, BytesOut<?> out) {
         super(tClass);
@@ -50,18 +50,8 @@ public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocation
     }
 
     /**
-     * Handle a method invocation on a proxy instance. The method invocation is encoded and written to the {@link BytesOut}.
-     *
-     * @param proxy  The proxy instance on which the method was invoked.
-     * @param method The method that was invoked.
-     * @param args   The arguments provided to the method.
-     * @return Always null.
-     * @throws IllegalStateException        if the underlying bytes store is closed.
-     * @throws BufferOverflowException      if there isn't enough space in the {@link BytesOut} to write the value.
-     * @throws BufferUnderflowException     if the underlying bytes store cannot provide enough data.
-     * @throws IllegalArgumentException     if the arguments don't match the method's requirements.
-     * @throws ArithmeticException          if numeric values overflow or underflow.
-     * @throws InvalidMarshallableException if a marshalling error occurs.
+     * Encodes the invocation and writes it to {@link #out}. On failure the
+     * write position is rolled back to preserve stream integrity.
      */
     @Override
     protected Object doInvoke(Object proxy, Method method, Object[] args)

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryWireCode.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryWireCode.java
@@ -20,289 +20,166 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * The BinaryWireCode interface contains constants for various types of data expected
- * in a binary wire protocol. These constants correspond to specific codes or ranges
- * used in the decoding process.
- * <p>
- * The constants are categorized into different types:
- * BYTES_LENGTH8, BYTES_LENGTH16, and BYTES_LENGTH32 correspond to sequences of length
- * 0 - 255, 0 - 2^16-1, and 0 - 2^32-1 respectively,
- * FIELD_ANCHOR, ANCHOR, and UPDATED_ALIAS are used for field anchoring purposes,
- * U8_ARRAY represents an array of unsigned bytes,
- * I64_ARRAY represents an array of 64-bit integer values,
- * PADDING32 and PADDING are used for padding purposes,
- * FLOAT32, FLOAT64, FLOAT_STOP_2, FLOAT_STOP_4, FLOAT_STOP_6, FLOAT_SET_LOW_0,
- * FLOAT_SET_LOW_2, FLOAT_SET_LOW_4 are used for various floating point number operations,
- * UUID, UINT8, UINT16, UINT32, INT8, INT16, INT32, INT64, SET_LOW_INT8, SET_LOW_INT16,
- * STOP_BIT, INT64_0x are used for various integer operations and UUID representation,
- * FALSE, TRUE, TIME, DATE, DATE_TIME, ZONED_DATE_TIME, TYPE_PREFIX, FIELD_NAME_ANY,
- * STRING_ANY, EVENT_NAME, FIELD_NUMBER, NULL, TYPE_LITERAL, EVENT_OBJECT, COMMENT, HINT
- * are used for various data type representations and operations,
- * FIELD_NAME0 to FIELD_NAME31 are used to represent field names,
- * STRING_0 to STRING_31 are used to represent strings.
+ * Defines byte codes used by Chronicle's binary wire protocol. Each constant
+ * indicates the type or structure of the data that follows in the stream.
  */
 public interface BinaryWireCode {
 
-    /**
-     * Represents a sequence of length 0 - 255 bytes.
-     */
+    /** Code for a byte sequence with a length in the following one byte. */
     int BYTES_LENGTH8 = 0x80;
 
-    /**
-     * Represents a sequence of length 0 - 2^16-1 bytes.
-     */
+    /** Code for a byte sequence with a 2 byte length prefix. */
     int BYTES_LENGTH16 = 0x81;
 
-    /**
-     * Represents a sequence of length 0 - 2^32-1.
-     */
+    /** Code for a byte sequence with a 4 byte length prefix. */
     int BYTES_LENGTH32 = 0x82;
 
-    /**
-     * Denotes a field anchor.
-     */
+    /** Code referencing a previously written field. */
     int FIELD_ANCHOR = 0x87;
 
-    /**
-     * Represents an anchor.
-     */
+    /** Anchor for cyclic references. */
     int ANCHOR = 0x88;
 
-    /**
-     * Represents an updated alias.
-     */
+    /** Indicates an alias update. */
     int UPDATED_ALIAS = 0x89;
 
-    /**
-     * Represents an array of unsigned bytes.
-     */
+    /** Code for an array of unsigned bytes. */
     int U8_ARRAY = 0x8A;
-    /**
-     * Represents an array of signed long.
-     */
+    /** Code for an array of signed 64-bit integers. */
     int I64_ARRAY = 0x8D;
 
-    /**
-     * Represents 32-bit padding.
-     */
+    /** 32-bit padding marker. */
     int PADDING32 = 0x8E;
 
-    /**
-     * Represents padding.
-     */
+    /** Generic padding marker. */
     int PADDING = 0x8F;
 
-    /**
-     * Represents a 32-bit floating-point number.
-     */
+    /** 32-bit float value. */
     int FLOAT32 = 0x90;
 
-    /**
-     * Represents a 64-bit floating-point number.
-     */
+    /** 64-bit float value. */
     int FLOAT64 = 0x91;
-    /**
-     * Represents floating-point stop bit encoded * 10^2.
-     */
+    /** Float encoded with 2 decimal places using stop bits. */
     int FLOAT_STOP_2 = 0x92;
 
-    /**
-     * Represents floating-point stop 4.
-     */
+    /** Float encoded with 4 decimal places. */
     int FLOAT_STOP_4 = 0x94;
 
-    /**
-     * Represents floating-point stop 6.
-     */
+    /** Float encoded with 6 decimal places. */
     int FLOAT_STOP_6 = 0x96;
 
-    /**
-     * Represents floating-point set low 0.
-     */
+    /** Float value scaled by 1. */
     int FLOAT_SET_LOW_0 = 0x9A;
 
-    /**
-     * Represents floating-point set low 2.
-     */
+    /** Float value scaled by 10^2. */
     int FLOAT_SET_LOW_2 = 0x9B;
 
-    /**
-     * Represents floating-point set low 4.
-     */
+    /** Float value scaled by 10^4. */
     int FLOAT_SET_LOW_4 = 0x9C;
     // 0x98 - 0x9F
 
-    /**
-     * Represents a UUID.
-     */
+    /** Universally unique identifier. */
     int UUID = 0xA0;
 
-    /**
-     * Represents an 8-bit unsigned integer.
-     */
+    /** Unsigned 8-bit integer value. */
     int UINT8 = 0xA1;
 
-    /**
-     * Represents a 16-bit unsigned integer.
-     */
+    /** Unsigned 16-bit integer value. */
     int UINT16 = 0xA2;
 
-    /**
-     * Represents a 32-bit unsigned integer.
-     */
+    /** Unsigned 32-bit integer value. */
     int UINT32 = 0xA3;
 
-    /**
-     * Represents an 8-bit integer.
-     */
+    /** Signed 8-bit integer value. */
     int INT8 = 0xA4;
 
-    /**
-     * Represents a 16-bit integer.
-     */
+    /** Signed 16-bit integer value. */
     int INT16 = 0xA5;
 
-    /**
-     * Represents a 32-bit integer.
-     */
+    /** Signed 32-bit integer value. */
     int INT32 = 0xA6;
 
-    /**
-     * Represents a 64-bit integer.
-     */
+    /** Signed 64-bit integer value. */
     int INT64 = 0xA7;
 
-    /**
-     * Represents a set low 8-bit integer.
-     */
+    /** Set low 8-bit integer value. */
     int SET_LOW_INT8 = 0xA8;
 
-    /**
-     * Represents a set low 16-bit integer.
-     */
+    /** Set low 16-bit integer value. */
     int SET_LOW_INT16 = 0xA9;
 
-    /**
-     * Represents a stop bit.
-     */
+    /** Stop bit encoded integer. */
     int STOP_BIT = 0xAE;
 
-    /**
-     * Represents a 64-bit integer with a hexadecimal prefix.
-     */
+    /** 64-bit integer formatted as hexadecimal. */
     int INT64_0x = 0xAF;
 
-    /**
-     * Represents a boolean false value.
-     */
+    /** Boolean false value. */
     int FALSE = 0xB0;
 
-    /**
-     * Represents a boolean true value.
-     */
+    /** Boolean true value. */
     int TRUE = 0xB1;
 
-    /**
-     * Represents a time.
-     */
+    /** Millisecond time of day. */
     int TIME = 0xB2;
 
-    /**
-     * Represents a date.
-     */
+    /** Date (days since epoch). */
     int DATE = 0xB3;
 
-    /**
-     * Represents a date and time.
-     */
+    /** Date and time without zone. */
     int DATE_TIME = 0xB4;
 
-    /**
-     * Represents a zoned date and time.
-     */
+    /** Zoned date and time. */
     int ZONED_DATE_TIME = 0xB5;
 
-    /**
-     * Represents a type prefix.
-     */
+    /** Type prefix marker. */
     int TYPE_PREFIX = 0xB6;
 
-    /**
-     * Represents a field name that can be any string.
-     */
+    /** Field name encoded as text. */
     int FIELD_NAME_ANY = 0xB7;
 
-    /**
-     * Represents a string that can be any string.
-     */
+    /** Arbitrary string value. */
     int STRING_ANY = 0xB8;
 
-    /**
-     * Represents an event name.
-     */
+    /** Event name string. */
     int EVENT_NAME = 0xB9;
 
-    /**
-     * Represents a field number.
-     */
+    /** Field number encoded as stop bit. */
     int FIELD_NUMBER = 0xBA;
 
-    /**
-     * Represents a null value.
-     */
+    /** Null marker. */
     int NULL = 0xBB;
 
-    /**
-     * Represents a type literal.
-     */
+    /** Type literal string. */
     int TYPE_LITERAL = 0xBC;
 
-    /**
-     * Represents an event object.
-     */
+    /** Event object encoded in binary. */
     int EVENT_OBJECT = 0xBD;
 
-    /**
-     * Represents a comment.
-     */
+    /** Comment text. */
     int COMMENT = 0xBE;
 
-    /**
-     * Represents a hint.
-     */
+    /** Hint for optimisation. */
     int HINT = 0xBF;
 
-    /**
-     * Represents the field name of length 0.
-     */
+    /** Field name with zero length. */
     int FIELD_NAME0 = 0xC0;
     // ...
 
-    /**
-     * Represents the field name of length 31 bytes.
-     */
+    /** Field name exactly 31 bytes long. */
     int FIELD_NAME31 = 0xDF;
 
-    /**
-     * Represents the string of length 0.
-     */
+    /** String of length zero. */
     int STRING_0 = 0xE0;
     // ...
-    /**
-     * Represents the string of length 31 bytes.
-     */
+    /** String exactly 31 bytes long. */
     int STRING_31 = 0xFF;
 
-    /**
-     * Maps each code in the interface to its corresponding string representation.
-     */
+    /** Lookup table mapping codes to their textual name, useful for debugging. */
     String[] STRING_FOR_CODE = _stringForCode(BinaryWireCode.class);
 
     /**
-     * Helper method for generating a text representation all the codes
-     *
-     * @param clazz to search for constants to extract
-     * @return an array of Strings for each code
+     * Builds {@link #STRING_FOR_CODE} by reflecting over constant fields.
      */
     static String[] _stringForCode(Class<?> clazz) {
         String[] stringForCode = new String[256];

--- a/src/main/java/net/openhft/chronicle/bytes/Byteable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Byteable.java
@@ -27,55 +27,47 @@ import java.nio.BufferUnderflowException;
 import java.nio.channels.FileLock;
 
 /**
- * An interface for a reference to off-heap memory, acting as a proxy for memory residing outside the heap.
- * This allows the reference to be reassigned, facilitating dynamic memory management.
+ * Allows a Java object to view a slice of a {@link BytesStore}. Implementations
+ * may be remapped to different offsets to avoid copying.
  */
 public interface Byteable {
     /**
-     * Sets the reference to a data type that points to the underlying ByteStore.
+     * Map this object onto a region of {@code bytesStore}.
      *
-     * @param bytesStore the fixed-point ByteStore
-     * @param offset     the offset within the ByteStore, indicating the starting point of the memory section
-     * @param length     the length of the memory section within the ByteStore
-     * @throws IllegalArgumentException       If the provided arguments are invalid
-     * @throws BufferOverflowException        If the new memory section extends beyond the end of the ByteStore
-     * @throws BufferUnderflowException       If the new memory section starts before the start of the ByteStore
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param bytesStore backing store
+     * @param offset     non-negative offset
+     * @param length     non-negative length which should match {@link #maxSize()}
+     * @throws IllegalArgumentException       if parameters are out of range
+     * @throws BufferOverflowException        if the region would extend past the end of the store
+     * @throws BufferUnderflowException       if the region would start before {@code 0}
+     * @throws ClosedIllegalStateException    if the store is closed
+     * @throws ThreadingIllegalStateException if accessed from the wrong thread
      */
     @SuppressWarnings("rawtypes")
     void bytesStore(@NotNull BytesStore bytesStore, @NonNegative long offset, @NonNegative long length)
             throws ClosedIllegalStateException, IllegalArgumentException, BufferOverflowException, BufferUnderflowException, ThreadingIllegalStateException;
 
     /**
-     * Returns the ByteStore to which this object currently points.
-     *
-     * @return the ByteStore or null if it's not set
+     * @return current backing {@link BytesStore} or {@code null} if unmapped
      */
     @Nullable
     BytesStore<?, ?> bytesStore();
 
     /**
-     * Returns the offset within the ByteStore to which this object currently points.
-     *
-     * @return the offset within the ByteStore (not the physical memory address)
+     * @return offset within the current {@link BytesStore}
      */
     long offset();
 
     /**
-     * Returns the absolute address in the memory to which this object currently points.
-     *
-     * @return the absolute address in the memory
-     * @throws UnsupportedOperationException If the address is not set or the underlying ByteStore isn't native
+     * @return absolute address of the mapped data if supported
+     * @throws UnsupportedOperationException if not backed by native memory
      */
     default long address() throws UnsupportedOperationException {
         return bytesStore().addressForRead(offset());
     }
 
     /**
-     * Returns the maximum size in bytes that this reference can point to.
-     *
-     * @return the maximum size in bytes for this reference
+     * @return fixed byte size represented by this object
      */
     long maxSize();
 

--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -41,53 +41,12 @@ import static net.openhft.chronicle.core.util.Longs.requireNonNegative;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * The {@code Bytes} class is a versatile container for raw byte data, providing rich functionality to read and write
- * data in various formats including integers, longs, floating-point values, strings, and more. It also supports
- * advanced operations such as seeking, slicing, and copying.
- * <p>
- * This class serves as an abstraction layer over a ByteBuffer, byte[], POJO, or native memory
+ * Mutable buffer for raw byte data with separate 63‑bit read and write cursors.
+ * A {@code Bytes} wraps a {@link BytesStore} which may reside on‑heap, in
+ * native memory or in a memory‑mapped file. Instances may be elastic and are
+ * {@link ReferenceCounted}. They are not thread‑safe.
  *
- * <p>
- * Besides basic primitive types, {@code Bytes} can serialize and deserialize more complex structures,
- * including custom user-defined objects that implement {@code ReadBytesMarshallable} or {@code WriteBytesMarshallable}.
- *
- * <p>
- * {@code Bytes} can be used for a variety of purposes such as:
- * <ul>
- *     <li>Reading and writing binary data to and from files</li>
- *     <li>Bytes level serialization and deserialization of objects</li>
- *     <li>Performing low-level binary manipulation for networking applications</li>
- *     <li>Temporary storage (in-memory) of binary data</li>
- *     <li>Shared memory in memory mapped files</li>
- * </ul>
- *
- * <p>
- * {@code Bytes} is essentially a view of a region within a {@link BytesStore} and is equipped with separate read and
- * write cursors, boasting a 63-bit addressing capacity (approximately 8 EiB), as opposed to Java's built-in
- * {@link ByteBuffer}, which only supports 31-bit addressing with a single cursor.
- *
- * <p>
- * A {@code Bytes} instance can represent either a fixed region of memory or an elastic buffer that dynamically
- * resizes as needed. It is mutable and designed for single-threaded use as it is not thread-safe.
- *
- * <p>
- * The cursors within Bytes consist of a write-position and a read-position, which must adhere to these constraints:
- * <ul>
- *     <li>{@code start() <= readPosition() <= writePosition() <= writeLimit() <= capacity()}</li>
- *     <li>{@code readLimit() == writePosition() && readPosition() <= safeLimit()}</li>
- * </ul>
- * <p>
- * It is important to note that a Bytes object is a resource that is ReferenceCounted. Operations on a Bytes
- * object that has been released may result in an {@link IllegalStateException}.
- * <p>
- * Note: Some operations on {@code Bytes} may throw {@code IllegalStateException} if the underlying storage has been released.
- * Always ensure proper release of resources when finished with a {@code Bytes} instance, especially if it's backed by system resources
- * like file handles or network sockets.
- *
- * @param <U> The type of the {@link BytesStore} that backs this {@code Bytes} instance.
- * @see BytesStore
- * @see ReadBytesMarshallable
- * @see WriteBytesMarshallable
+ * @param <U> underlying store type
  */
 @SingleThreaded
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -98,18 +57,16 @@ public interface Bytes<U> extends
         SingleThreadedChecked {
 
     /**
-     * The maximum capacity a Bytes object can have, approximately 8 EiB (Exbibytes) minus 16 bytes.
+     * Maximum supported capacity – roughly eight exbibytes.
      */
     long MAX_CAPACITY = Long.MAX_VALUE & ~0xF;
 
     /**
-     * The maximum capacity a Bytes object can have if it is allocated on the heap, which is 2 GiB (Gibibytes) minus 16 bytes.
+     * Practical limit for heap‑backed {@code Bytes} instances.
      */
     int MAX_HEAP_CAPACITY = Integer.MAX_VALUE & ~0xF;
 
-    /**
-     * The default initial size of an elastic Bytes object backed by a ByteBuffer, which is 256 bytes.
-     */
+    /** Default initial capacity for elastic direct buffers. */
     int DEFAULT_BYTE_BUFFER_CAPACITY = 256;
 
     /**
@@ -880,15 +837,8 @@ public interface Bytes<U> extends
     }
 
     /**
-     * Creates and returns a new slice of this Bytes object with its start position set to the current
-     * read position and its capacity determined by the current limit.
-     * <p>
-     * Note that the slice is a subsection of this Bytes object and will not be elastic regardless of
-     * the elasticity of the parent Bytes object.
-     *
-     * @return A new slice of this Bytes object.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * Returns a view of the readable bytes from {@link #readPosition()} to
+     * {@link #readLimit()}.
      */
     @NotNull
     @Override
@@ -904,14 +854,8 @@ public interface Bytes<U> extends
     }
 
     /**
-     * Creates and returns a Bytes object that wraps the bytesStore of this Bytes object,
-     * ranging from the {@code start} position to the {@code realCapacity}.
-     * <p>
-     * The returned Bytes object is non-elastic and supports both read and write operations using cursors.
-     *
-     * @return A Bytes object wrapping the bytesStore of this Bytes object.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * Returns a view of the writable region from {@link #writePosition()} to
+     * {@link #writeLimit()}.
      */
     @Override
     @NotNull
@@ -937,16 +881,7 @@ public interface Bytes<U> extends
     BytesStore<?, U> bytesStore();
 
     /**
-     * Compares the contents of this Bytes object with the provided {@code other} string for equality.
-     * <p>
-     * This method returns {@code true} if the contents of this Bytes object is equal to the contents
-     * of the {@code other} string. Otherwise, it returns {@code false}.
-     *
-     * @param other The string to compare with the contents of this Bytes object, can be null.
-     * @return {@code true} if the contents of this Bytes object equals the contents of the provided
-     * {@code other} string; {@code false} otherwise.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * Compares the readable bytes with {@code other} using ISO‑8959‑1 encoding.
      */
     default boolean isEqual(@Nullable String other)
             throws IllegalStateException {

--- a/src/main/java/net/openhft/chronicle/bytes/BytesConsumer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesConsumer.java
@@ -18,20 +18,18 @@ package net.openhft.chronicle.bytes;
 import java.nio.BufferOverflowException;
 
 /**
- * A functional interface for consuming bytes.
- * The interface defines a single method {@code read} for retrieving and removing the head of a queue into a given {@code BytesOut} object.
+ * Consumes bytes from a source and writes them to a {@link BytesOut} instance.
+ * Implementations typically pull data from a queue or ring buffer.
  */
 @FunctionalInterface
 public interface BytesConsumer {
 
     /**
-     * Retrieves and removes the head of this queue, or returns {@code false} if this queue is
-     * empty.
+     * Attempts to pull data from the source into {@code bytes}.
      *
-     * @param bytes the {@code BytesOut} object to read into.
-     * @return {@code false} if this queue is empty, {@code true} otherwise.
-     * @throws BufferOverflowException if there is insufficient space left in the buffer.
+     * @param bytes destination for the consumed data, positioned for writing
+     * @return {@code true} if bytes were written, {@code false} if no data was available
+     * @throws BufferOverflowException if {@code bytes} lacks capacity for the read data
      */
-    boolean read(BytesOut<?> bytes)
-            throws BufferOverflowException;
+    boolean read(BytesOut<?> bytes) throws BufferOverflowException;
 }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesContext.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesContext.java
@@ -18,31 +18,24 @@ package net.openhft.chronicle.bytes;
 import net.openhft.chronicle.core.io.Closeable;
 
 /**
- * Defines a context for operating with bytes. This interface provides methods to retrieve bytes
- * and keys. It also provides utility methods to check if the context is closed and to perform
- * a rollback on close.
+ * Holds a {@link Bytes} buffer and optional key for a unit of work. Implementations
+ * may support rollback of writes when the context is closed.
  */
 public interface BytesContext extends Closeable {
 
     /**
-     * Retrieves the bytes to be written.
-     *
-     * @return the {@link Bytes} object to be written to.
+     * Returns the buffer associated with this context.
      */
     Bytes<?> bytes();
 
     /**
-     * Retrieves the key to be written.
-     *
-     * @return the key to be written.
+     * Provides a context-dependent key, such as a message type.
      */
     int key();
 
     /**
-     * Checks whether the context is closed.
-     *
-     * @return {@code true} if the context is closed, {@code false} otherwise.
-     * @throws UnsupportedOperationException if the method is not overridden.
+     * Indicates whether this context has been closed. The default implementation
+     * throws {@link UnsupportedOperationException} and should be overridden.
      */
     @Override
     default boolean isClosed() {
@@ -50,8 +43,7 @@ public interface BytesContext extends Closeable {
     }
 
     /**
-     * Performs a rollback operation when the context is closed. The exact behavior of this
-     * method is left to the implementing class.
+     * Marks this context to roll back any writes when {@link #close()} is called.
      */
     default void rollbackOnClose() {
     }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMarshallable.java
@@ -22,29 +22,16 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 /**
- * An interface for objects that can be read from and written to bytes in a streaming manner.
- * The object's internal state can be directly serialized and deserialized from a BytesIn
- * or BytesOut object. This interface extends the ReadBytesMarshallable and
- * WriteBytesMarshallable interfaces, which provide methods for reading and writing
- * Marshallable objects, respectively.
- * <p>
- * Classes implementing this interface should override the methods to provide their own
- * custom serialization and deserialization logic. If not overridden, the default methods
- * use the BytesUtil's methods for reading and writing Marshallable objects.
- * <p>
- * The $toString method provides a default implementation for creating a string
- * representation of the object in a hexadecimal format.
- *
- * <p>Implementations of this interface must not be chained as suggested by the {@code DontChain} annotation.
+ * Serialisable object that reads and writes its state directly to a
+ * {@link Bytes} stream. Default implementations delegate to
+ * {@link BytesUtil} utilities. The interface is marked with
+ * {@link DontChain} to discourage chaining of implementations.
  */
 @DontChain
 public interface BytesMarshallable extends ReadBytesMarshallable, WriteBytesMarshallable {
 
     /**
-     * Indicates whether the object uses self-describing messages for serialization.
-     * By default, this method returns false.
-     *
-     * @return false by default.
+     * {@inheritDoc}
      */
     @Override
     default boolean usesSelfDescribingMessage() {
@@ -52,14 +39,7 @@ public interface BytesMarshallable extends ReadBytesMarshallable, WriteBytesMars
     }
 
     /**
-     * Reads the state of this object from the bytes.
-     *
-     * @param bytes the BytesIn object to read from.
-     * @throws IORuntimeException             If an I/O error occurs.
-     * @throws BufferUnderflowException       If there is not enough data available in the buffer.
-     * @throws InvalidMarshallableException   If the object cannot be read due to invalid data.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * {@inheritDoc}
      */
     @Override
     default void readMarshallable(BytesIn<?> bytes)
@@ -69,15 +49,7 @@ public interface BytesMarshallable extends ReadBytesMarshallable, WriteBytesMars
     }
 
     /**
-     * Writes the state of this object to the bytes.
-     *
-     * @param bytes the BytesOut object to write to.
-     * @throws BufferOverflowException        If there is not enough space in the buffer.
-     * @throws BufferUnderflowException       If there is not enough data available in the buffer.
-     * @throws ArithmeticException            If there is an arithmetic error.
-     * @throws InvalidMarshallableException   If the object cannot be written due to invalid data.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * {@inheritDoc}
      */
     @Override
     default void writeMarshallable(BytesOut<?> bytes)
@@ -87,9 +59,7 @@ public interface BytesMarshallable extends ReadBytesMarshallable, WriteBytesMars
     }
 
     /**
-     * Provides a string representation of this object in a hexadecimal format.
-     *
-     * @return the hexadecimal string representation of this object.
+     * Dumps the binary form of this object as a hex string for debugging.
      */
     default String $toString() {
         ValidatableUtil.startValidateDisabled();

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
@@ -33,19 +33,11 @@ import java.util.function.Supplier;
 import static net.openhft.chronicle.core.Jvm.uncheckedCast;
 
 /**
- * This class is used to marshal objects into bytes and unmarshal them from bytes.
- * The object's fields are read and written in a streaming manner, with the ability
- * to handle different types of fields. It uses a map to track the fields of the class
- * and their corresponding values. This class makes use of the {@link FieldAccess} for
- * actual field value extraction and setting.
+ * Reflection‑based marshaller for simple objects. It inspects the fields of a
+ * class and serialises/deserialises them sequentially using {@link FieldAccess}
+ * helpers. This approach is generic but slower than hand‑written marshalling.
  *
- * <p>This class also provides a method for extracting all fields from a class and its
- * superclasses (except transient and static fields). All the fields are made accessible
- * even if they are private, and are then stored in a map for future access.
- *
- * <p>Note: This class suppresses rawtypes and unchecked warnings.
- *
- * @param <T> the type of the object to be marshaled.
+ * @param <T> type being marshalled
  */
 @SuppressWarnings("rawtypes")
 public class BytesMarshaller<T> {
@@ -89,11 +81,7 @@ public class BytesMarshaller<T> {
     }
 
     /**
-     * Reads the state of the given ReadBytesMarshallable object from the specified BytesIn.
-     *
-     * @param t  the object to read into.
-     * @param in the BytesIn from which to read.
-     * @throws InvalidMarshallableException If the object cannot be read due to invalid data.
+     * Populates {@code t} by reading each field from {@code in} using reflection.
      */
     public void readMarshallable(ReadBytesMarshallable t, BytesIn<?> in) throws InvalidMarshallableException {
         for (@NotNull FieldAccess field : fields) {
@@ -102,17 +90,7 @@ public class BytesMarshaller<T> {
     }
 
     /**
-     * Writes the state of the given WriteBytesMarshallable object to the specified BytesOut.
-     *
-     * @param t   the object to write.
-     * @param out the BytesOut to which to write.
-     * @throws IllegalArgumentException       If a method is invoked with an illegal or inappropriate argument.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
-     * @throws BufferOverflowException        If there is not enough space in the buffer.
-     * @throws BufferUnderflowException       If there is not enough data available in the buffer.
-     * @throws ArithmeticException            If there is an arithmetic error.
-     * @throws InvalidMarshallableException   If the object cannot be written due to invalid data.
+     * Writes all fields of {@code t} to {@code out} using reflection.
      */
     public void writeMarshallable(WriteBytesMarshallable t, BytesOut<?> out)
             throws IllegalArgumentException, ClosedIllegalStateException, BufferOverflowException, BufferUnderflowException, ArithmeticException, InvalidMarshallableException, ThreadingIllegalStateException {

--- a/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
@@ -29,15 +29,10 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.bytes.internal.ReferenceCountedUtil.throwExceptionIfReleased;
 
 /**
- * This interface represents an output stream for writing data to bytes.
- * It extends {@link StreamingDataOutput}, {@link ByteStringAppender},
- * {@link BytesPrepender}, and {@link HexDumpBytesDescription}, thus providing a
- * wide range of operations for handling byte data, including appending, prepending,
- * and producing a hex dump description.
+ * Output interface for writing to a {@link Bytes} buffer. It combines streaming
+ * writes with text appending and prepending utilities.
  *
- * <p>Note: This interface suppresses rawtypes and unchecked warnings.
- *
- * @param <U> the type of the BytesOut
+ * @param <U> underlying store type
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface BytesOut<U> extends
@@ -47,15 +42,8 @@ public interface BytesOut<U> extends
         HexDumpBytesDescription<BytesOut<U>> {
 
     /**
-     * Creates a proxy for the provided interface(s), such that each method invocation on the proxy
-     * is written to this {@code BytesOut} instance for replay.
-     *
-     * @param tClass     the primary interface to be proxied.
-     * @param additional any additional interfaces to be proxied.
-     * @return a proxy implementing the provided interfaces.
-     * @throws IllegalArgumentException    If an argument is inappropriate
-     * @throws NullPointerException        If the provided {@code tClass} is {@code null}
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
+     * Returns a proxy that serialises method calls to this output. Additional
+     * interfaces may be supplied.
      */
     @NotNull
     default <T> T bytesMethodWriter(@NotNull Class<T> tClass, Class<?>... additional)
@@ -69,32 +57,15 @@ public interface BytesOut<U> extends
     }
 
     /**
-     * Writes a {@link WriteBytesMarshallable} to this {@code BytesOut} instance.
-     *
-     * @param marshallable the object to be written.
-     * @throws IllegalArgumentException       If a method is invoked with an illegal or inappropriate argument.
-     * @throws BufferOverflowException        If there is not enough space in the buffer.
-     * @throws BufferUnderflowException       If there is not enough data available in the buffer.
-     * @throws InvalidMarshallableException   If the object cannot be written due to invalid data.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way.
+     * Serialises {@code marshallable} prefixed with a 16‑bit length.
      */
     void writeMarshallableLength16(WriteBytesMarshallable marshallable)
             throws IllegalArgumentException, BufferOverflowException, BufferUnderflowException, InvalidMarshallableException, ClosedIllegalStateException, ThreadingIllegalStateException;
 
     /**
-     * Writes an object of a given type to this {@code BytesOut} instance.
-     * This method supports a limited set of writeObject types.
-     *
-     * @param componentType the expected type of the object.
-     * @param obj           the object to be written.
-     * @throws IllegalArgumentException       If a method is invoked with an illegal or inappropriate argument.
-     * @throws BufferOverflowException        If there is not enough space in the buffer.
-     * @throws ArithmeticException            If there is an arithmetic error.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way.
-     * @throws BufferUnderflowException       If there is not enough data available in the buffer.
-     * @throws InvalidMarshallableException   If the object cannot be written due to invalid data.
+     * Writes {@code obj} according to {@code componentType}. Supported types
+     * include {@link String}, boxed primitives, {@link BytesStore} and
+     * {@link BytesMarshallable} implementations.
      */
     default void writeObject(Class<?>componentType, Object obj)
             throws IllegalArgumentException, BufferOverflowException, ArithmeticException, ClosedIllegalStateException, BufferUnderflowException, InvalidMarshallableException, ThreadingIllegalStateException {

--- a/src/main/java/net/openhft/chronicle/bytes/BytesParselet.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesParselet.java
@@ -16,19 +16,14 @@
 package net.openhft.chronicle.bytes;
 
 /**
- * Functional interface representing a parselet for processing byte data.
- * The implementing class should provide the logic to accept and handle
- * a certain type of message represented in bytes.
+ * Parses messages read from a {@link BytesIn} when no specific method handler
+ * is available.
  */
 @FunctionalInterface
 public interface BytesParselet {
     /**
-     * This method is invoked with a message type and an input stream of bytes.
-     * The implementing class is expected to parse and process the bytes according
-     * to the provided message type.
-     *
-     * @param messageType a long value representing the type of the message to be processed.
-     * @param in          a {@link BytesIn} instance containing the message data in bytes.
+     * Handles a message of the supplied {@code messageType} using bytes from
+     * {@code in}.
      */
     void accept(long messageType, BytesIn<?> in);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesPrepender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesPrepender.java
@@ -24,33 +24,17 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.BufferOverflowException;
 
 /**
- * An interface defining a prependable buffer of bytes. A BytesPrepender can prepend bytes, byte arrays,
- * and numeric values to a buffer, making them accessible for reading operations from the front.
- * <p>
- * This interface is generic and can be parameterized with any type that extends BytesPrepender.
- * <p>
- * Note: For all prepend and prewrite operations, the read position (but not the write position or read limit)
- * is moved backward.
- * <p>
- * BufferOverflowException can occur if the capacity of the underlying
- * buffer is exceeded during operation execution.
+ * Supports writing data before the current {@link Bytes#readPosition()}.
+ * After each operation the read position moves backwards.
  *
- * @param <B> the type of BytesPrepender. This is a self-referential generic type parameter.
- * @see BufferOverflowException
- * @see IllegalStateException
+ * @param <B> self type
  */
 @SuppressWarnings("unchecked")
 public interface BytesPrepender<B extends BytesPrepender<B>> {
 
     /**
-     * Clears the buffer and pads it with a specified length to allow prepending later.
-     * clearAndPad(0) is equivalent to clear().
-     *
-     * @param length the padding length
-     * @return this instance, after clearing and padding
-     * @throws BufferOverflowException If the length is greater than the difference of capacity() and start()
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * Clears the buffer then advances both cursors by {@code length} bytes so
+     * data can be prepended later.
      */
     @NotNull
     B clearAndPad(@NonNegative long length)

--- a/src/main/java/net/openhft/chronicle/bytes/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/package-info.java
@@ -1,38 +1,24 @@
 /**
- * The Chronicle Bytes package provides low-level memory access wrappers with functionalities
- * akin to Java NIO's ByteBuffer. The API supports UTF-8 and ISO-8859-1 encoded strings,
- * thread-safe off-heap memory operations, deterministic release of resources via reference
- * counting, and more.
- * <p>
- * The main classes in this package are:
- * <p>
- * {@link net.openhft.chronicle.bytes.Bytes}: A class for managing byte arrays, including
- * operations for reading and writing data. It extends if you write data into it which is
- * larger than its real capacity. It provides access to the cursors for reading and writing
- * data at desired indices.
- * <p>
- * {@link net.openhft.chronicle.bytes.BytesStore}: A block of memory with fixed size into
- * which you can write data and later read. You cannot use the cursors with a BytesStore,
- * unlike Bytes.
- * <p>
- * {@link net.openhft.chronicle.bytes.BytesIn}: Interface that provides a range of methods
- * for reading data from bytes.
- * <p>
- * {@link net.openhft.chronicle.bytes.BytesOut}: Interface that provides a range of methods
- * for writing data to bytes.
- * <p>
- * {@link net.openhft.chronicle.bytes.ByteStringParser}: An interface for parsing byte strings.
- * <p>
- * {@link net.openhft.chronicle.bytes.ByteStringAppender}: An interface for appending byte strings.
- * <p>
- * {@link net.openhft.chronicle.bytes.RandomDataInput}: An interface that extends the {@link net.openhft.chronicle.bytes.StreamingDataInput}.
- * <p>
- * {@link net.openhft.chronicle.bytes.RandomDataOutput}: An interface that extends the {@link net.openhft.chronicle.bytes.StreamingDataOutput}.
- * <p>
- * {@link net.openhft.chronicle.bytes.StreamingDataInput}: An interface for reading data from a stream.
- * <p>
- * {@link net.openhft.chronicle.bytes.StreamingDataOutput}: An interface for writing data to a stream.
- * <p>
- * For more information, please refer to each class documentation.
+ * Provides versatile, high-performance access to contiguous regions of memory.
+ * Implementations cover on-heap arrays, native memory and memory-mapped files.
+ * The API forms a building block for other Chronicle libraries.
+ *
+ * <p>Key features:
+ * <ul>
+ * <li>Support for 63-bit addressing for large structures.</li>
+ * <li>Efficient encoding and decoding for UTF-8 and ISO-8859-1 strings.</li>
+ * <li>Thread-safe atomic operations via {@link net.openhft.chronicle.bytes.BytesStore BytesStore}.</li>
+ * <li>Deterministic resource management using
+ * {@link net.openhft.chronicle.core.io.ReferenceCounted ReferenceCounted}.</li>
+ * <li>Elastic buffers such as {@link net.openhft.chronicle.bytes.Bytes#allocateElasticDirect()}.</li>
+ * <li>Direct number parsing and formatting to and from byte sequences.</li>
+ * </ul>
+ *
+ * Core abstractions:
+ * <ul>
+ * <li>{@link net.openhft.chronicle.bytes.BytesStore BytesStore} &ndash; a fixed-size region of memory.</li>
+ * <li>{@link net.openhft.chronicle.bytes.Bytes Bytes} &ndash; a mutable view with independent
+ * read and write cursors.</li>
+ * </ul>
  */
 package net.openhft.chronicle.bytes;


### PR DESCRIPTION
## Summary
- refine comments for context and consumption APIs
- update reader and writer docs for methods and classes
- tighten Bytes interface overview and constants
- simplify marshalling helper documentation
- clarify store ownership in ByteBuffer wrappers

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*