### PR TITLE
Improve Javadoc for bytes utilities

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/ByteStringParser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ByteStringParser.java
@@ -30,23 +30,11 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 
 /**
- * An interface that provides support for parsing bytes as text. This interface is designed to facilitate
- * the reading and parsing of textual data that is encoded within a byte stream. It supports parsing
- * various data types including booleans, integers, floats, doubles, and decimal numbers,
- * and provides utility methods for dealing with character encoding such as UTF-8 and ISO-8859-1.
+ * Extends {@link StreamingDataInput} with helpers for parsing textual data directly from a
+ * {@link Bytes} stream.  Implementations consume data from the current read position and advance it
+ * as characters or numbers are parsed.
  *
- * <p>The {@code ByteStringParser} extends {@link StreamingDataInput}, inheriting the capabilities
- * of reading and manipulating streams of binary data.
- *
- * <p>This interface is especially useful for reading and converting bytes into human-readable text
- * or numerical representations. It includes methods for parsing numbers with flexible formatting,
- * reading text with specified character encoding, and utilities for dealing with character
- * termination conditions.
- *
- * <p>Example use cases include reading and parsing data from binary communication protocols,
- * files, or any other source where bytes need to be interpreted as text or numbers.
- *
- * @param <B> the type of {@code ByteStringParser} which extends itself, allowing for method chaining.
+ * @param <B> self type for fluent chaining
  */
 public interface ByteStringParser<B extends ByteStringParser<B>> extends StreamingDataInput<B> {
     /**
@@ -61,18 +49,11 @@ public interface ByteStringParser<B extends ByteStringParser<B>> extends Streami
     }
 
     /**
-     * Attempts to parse the next series of characters in the byte string as a boolean value.
-     * It uses the provided {@code tester} to detect the end of the text. The parsing is case-insensitive.
-     * <p>
-     * False can be: "f", "false", "n", "no", "0".
-     * True can be: "t", "true", "y", "yes", "1".
+     * Parses a boolean token, stopping when {@code tester} returns {@code true}. The recognised
+     * tokens are case-insensitive variants of {@code true/t/yes/y/1} and {@code false/f/no/n/0}.
      *
-     * @param tester a {@code StopCharTester} used to detect the end of the boolean text.
-     * @return a {@code Boolean} value if the text could be parsed as boolean; null otherwise.
-     * @throws BufferUnderflowException       If there is insufficient data.
-     * @throws ArithmeticException            If a numeric overflow occurs.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way.
+     * @param tester stop condition for the parse
+     * @return parsed value or {@code null} if no recognised token was found
      */
     @Nullable
     default Boolean parseBoolean(@NotNull StopCharTester tester)
@@ -81,17 +62,8 @@ public interface ByteStringParser<B extends ByteStringParser<B>> extends Streami
     }
 
     /**
-     * Attempts to parse the next series of characters in the byte string as a boolean value.
-     * It uses a default {@code StopCharTester} to detect non-alpha-numeric characters.
-     * <p>
-     * False can be: "f", "false", "n", "no", "0".
-     * True can be: "t", "true", "y", "yes", "1".
-     *
-     * @return a {@code Boolean} value if the text could be parsed as boolean; null otherwise.
-     * @throws BufferUnderflowException       If there is insufficient data.
-     * @throws ArithmeticException            If a numeric overflow occurs.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way.
+     * Convenience wrapper for {@link #parseBoolean(StopCharTester)} using
+     * {@link StopCharTesters#NON_ALPHA_DIGIT}.
      */
     @Nullable
     default Boolean parseBoolean()
@@ -349,12 +321,8 @@ public interface ByteStringParser<B extends ByteStringParser<B>> extends Streami
     void lastNumberHadDigits(boolean lastNumberHadDigits);
 
     /**
-     * Skips over characters in the byte string until a terminating character is encountered.
-     *
-     * @param tester the StopCharTester instance to use for determining the terminating character.
-     * @return true if a terminating character was found, false if the end of the buffer was reached.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way.
+     * Advances the read position until {@code tester.isStopChar()} returns {@code true} or end of input
+     * is reached.  The terminating character itself remains unread.
      */
     default boolean skipTo(@NotNull StopCharTester tester)
             throws ClosedIllegalStateException, ThreadingIllegalStateException {

--- a/src/main/java/net/openhft/chronicle/bytes/BytesTextMethodTester.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesTextMethodTester.java
@@ -26,11 +26,14 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 /**
- * The {@code BytesTextMethodTester} class is a utility for comparing the expected and actual results
- * of executing a method from a given interface that manipulates bytes. It utilizes hexadecimal data
- * from the input and output files to perform this comparison.
+ * Utility for exercising an interface backed by {@link Bytes} using a textual description of the
+ * method calls.  The input file typically contains a hex dump with optional comments describing
+ * the invocations.  These calls are dispatched to a component supplied by {@code componentFunction}
+ * and the resulting output is serialised to text and compared with the expected output file.
+ * It is a convenient way to perform data driven tests of writer/reader style APIs.
  *
- * @param <T> the type of the interface that includes the methods to be tested.
+ * @param <T> interface type whose methods are recorded and verified
+ * @see net.openhft.chronicle.bytes.readme.StringsTest
  */
 @SuppressWarnings("rawtypes")
 public class BytesTextMethodTester<T> {
@@ -46,12 +49,12 @@ public class BytesTextMethodTester<T> {
     private String actual;
 
     /**
-     * Constructs a {@code BytesTextMethodTester} instance with the provided parameters.
+     * Creates a tester configured with the given files and component builder.
      *
-     * @param input             The input file containing hexadecimal data to feed into the methods of the class under test.
-     * @param componentFunction A function that defines how to instantiate or manipulate the object that the class under test needs.
-     * @param outputClass       The class of the interface that includes the methods to be tested.
-     * @param output            The output file containing the expected hexadecimal results of the tested methods.
+     * @param input             path to the text (usually hex) file describing the method invocations
+     * @param componentFunction function producing the component(s) that will process the invocations
+     * @param outputClass       interface class defining the methods encoded in the files
+     * @param output            path to the expected output file
      */
     public BytesTextMethodTester(String input, Function<T, Object> componentFunction, Class<T> outputClass, String output) {
         this.input = input;
@@ -60,20 +63,38 @@ public class BytesTextMethodTester<T> {
         this.componentFunction = componentFunction;
     }
 
+    /**
+     * Returns the path to the optional setup file.
+     */
     public String setup() {
         return setup;
     }
 
+    /**
+     * Sets a setup file to be processed before the main input.
+     *
+     * @param setup path to the setup file
+     * @return this tester for chaining
+     */
     @NotNull
     public BytesTextMethodTester setup(String setup) {
         this.setup = setup;
         return this;
     }
 
+    /**
+     * Returns the post-processing function applied to actual and expected output.
+     */
     public Function<String, String> afterRun() {
         return afterRun;
     }
 
+    /**
+     * Sets a post-processing function applied to both expected and actual output before comparison.
+     *
+     * @param afterRun normalising function
+     * @return this tester for chaining
+     */
     @NotNull
     public BytesTextMethodTester afterRun(UnaryOperator<String> afterRun) {
         this.afterRun = afterRun;
@@ -81,11 +102,13 @@ public class BytesTextMethodTester<T> {
     }
 
     /**
-     * Runs the methods of the class under test using the hexadecimal data from the input file,
-     * then compares the results with the expected output from the output file.
+     * Executes the test.  The input (and optional setup) files are parsed and the resulting
+     * invocations dispatched to the component.  All calls made to the output writer are captured
+     * and written back to text for comparison with the expected output file.  The processed
+     * strings can be retrieved via {@link #expected()} and {@link #actual()}.
      *
-     * @return The instance of {@code BytesTextMethodTester}, allowing for method chaining.
-     * @throws IOException              If an I/O error occurs when reading the files or writing the results.
+     * @return this tester for chaining
+     * @throws IOException if any of the files cannot be read
      */
     @NotNull
     public BytesTextMethodTester run()
@@ -142,15 +165,25 @@ public class BytesTextMethodTester<T> {
         return this;
     }
 
+    /**
+     * Default handler invoked when a message id is not recognised while parsing the input stream.
+     * The remaining bytes of that message are skipped and a warning is logged.
+     */
     private void unknownMessageId(long id, BytesIn<?> b) {
         Jvm.warn().on(getClass(), "Unknown message id " + Long.toHexString(id));
         b.readPosition(b.readLimit());
     }
 
+    /**
+     * Returns the contents of the expected output file after optional post-processing.
+     */
     public String expected() {
         return expected;
     }
 
+    /**
+     * Returns the text generated from running the component under test.
+     */
     public String actual() {
         return actual;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/CommonMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/CommonMarshallable.java
@@ -18,20 +18,17 @@ package net.openhft.chronicle.bytes;
 import net.openhft.chronicle.core.annotation.DontChain;
 
 /**
- * Defines common behavior for marshallable objects, i.e., objects that can be converted to and from
- * a series of bytes. An object of a class implementing this interface can be written as a
- * self-describing message, meaning that it includes metadata about its own structure.
+ * Marker for objects that can be serialised to bytes.  Implementations may choose to embed
+ * type or structural metadata so that the resulting message is self describing.
  */
 @DontChain
 public interface CommonMarshallable {
 
     /**
-     * Determines whether the message produced by this object is self-describing.
-     * A self-describing message includes metadata about its structure, which aids
-     * in decoding the message without prior knowledge of its structure.
+     * Indicates whether the serialised form should contain enough metadata for a generic parser to
+     * understand it without prior knowledge of the concrete type.
      *
-     * @return {@code true} if the message should be self-describing, {@code false} otherwise.
-     * By default, this method returns {@code true}.
+     * @return {@code true} by default
      */
     default boolean usesSelfDescribingMessage() {
         return true;

--- a/src/main/java/net/openhft/chronicle/bytes/ConnectionDroppedException.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ConnectionDroppedException.java
@@ -18,14 +18,8 @@ package net.openhft.chronicle.bytes;
 import net.openhft.chronicle.core.io.IORuntimeException;
 
 /**
- * Exception thrown when the TcpChannelHub loses its connection to the server.
- * <p>
- * This exception is a runtime exception, which means that it does not need to be
- * declared in a method or constructor's {@code throws} clause if it can be thrown
- * by the execution of the method or constructor and propagate outside the method
- * or constructor boundary.
- * <p>
- * TODO Move to network where it is used.
+ * {@link IORuntimeException} signalling an unexpected loss of connection, typically used by
+ * networking components.
  */
 public class ConnectionDroppedException extends IORuntimeException {
     private static final long serialVersionUID = 0L;

--- a/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeDeduplicator.java
+++ b/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeDeduplicator.java
@@ -15,21 +15,21 @@
  */
 package net.openhft.chronicle.bytes;
 
+/**
+ * Detects and optionally retains the newest timestamp for each host id so duplicates can be filtered.
+ */
 public interface DistributedUniqueTimeDeduplicator {
 
     /**
-     * Compare this new timestamp to the previously retained timstamp for the hostId
+     * Compares {@code timestampHostId} with the last timestamp held for its host id.
      *
-     * @param timestampHostId to compare
-     * @return -1 if the timestamp is older, 0 if the same, +1 if newer
+     * @param timestampHostId value embedding time and host id
+     * @return -1 if older, 0 if equal or no previous value, +1 if newer
      */
     int compareByHostId(long timestampHostId);
 
     /**
-     * Compare this new timestamp to the previously retained timestamp for the hostId and retaining the timestamp
-     *
-     * @param timestampHostId to compare
-     * @return -1 if the timestamp is older, 0 if the same, +1 if newer
+     * As {@link #compareByHostId(long)} but also retains {@code timestampHostId} if it is newer.
      */
     int compareAndRetainNewer(long timestampHostId);
 }

--- a/src/main/java/net/openhft/chronicle/bytes/DynamicallySized.java
+++ b/src/main/java/net/openhft/chronicle/bytes/DynamicallySized.java
@@ -16,13 +16,7 @@
 package net.openhft.chronicle.bytes;
 
 /**
- * An interface that indicates an implementor of {@link Byteable} has dynamic size requirements.
- *
- * <p>
- * A class implementing the {@code DynamicallySized} interface indicates that
- * the size of its instances in bytes cannot be determined statically (at compile time) but
- * instead is dependent on the state of the individual object instances.
- * 
+ * Marker for {@link Byteable} objects whose encoded length may vary with their state.
  */
 public interface DynamicallySized {
 }

--- a/src/main/java/net/openhft/chronicle/bytes/FieldGroup.java
+++ b/src/main/java/net/openhft/chronicle/bytes/FieldGroup.java
@@ -20,24 +20,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 /**
- * Annotation used for logically grouping fields within a class. It is especially useful in classes
- * where precise control over the memory layout of fields is required, or in scenarios where
- * logically grouping related fields can simplify code that operates on these fields.
- *
- * <p>The {@link FieldGroup} annotation is retained at runtime and can be used to annotate
- * fields within a class. The name of the group is specified through the 'value' method,
- * allowing multiple fields to be associated with the same group by assigning them the same name.
- *
- * <p>One common use case is organizing the memory layout for serialization or memory-mapped
- * objects where fields that are accessed together are placed adjacently in memory.
- *
- * <p>Example:
- * <pre>
- * public class Record {
- *     &#64;FieldGroup("body")
- *     private int bodyField1, bodyField2;
- * }
- * </pre>
+ * Groups related fields so a contiguous {@link Bytes} view can be created via utilities such as
+ * {@link Bytes#forFieldGroup(Object, String)}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/src/main/java/net/openhft/chronicle/bytes/GuardedNativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/GuardedNativeBytes.java
@@ -26,24 +26,24 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.bytes.BinaryWireCode.*;
 
 /**
- * <p>
- * This class extends the {@link NativeBytes} class and provides an additional layer of safety by tracking the raw primitives written to the byte buffer.
- * <p>
- * The purpose of this class is to facilitate the detection of inconsistencies during testing. When inconsistencies are detected, they can be corrected before the code is moved into production.
- * <p>
- * GuardedNativeBytes records the type of each primitive written into the bytes buffer (byte, short, int, long, float, double). This tracking enables validation of the consistency of data written and read, which is critical for data integrity.
- * <p>
- * Please note that while this class is very useful for ensuring data consistency during testing, it may introduce a performance overhead and thus not recommended to be used in a production environment.
- *
- * @param <U> The type of the object that this byte buffer is bound to.
+ * Debugging wrapper that prefixes each primitive written with a type code and checks it on reads.
+ * Useful for catching mismatched read/write pairs but adds considerable overhead and should not be
+ * used in production.
  */
 public class GuardedNativeBytes<U> extends NativeBytes<U> {
+    /** type marker for a single byte */
     static final byte BYTE_T = (byte) INT8;
+    /** type marker for a short */
     static final byte SHORT_T = (byte) INT16;
+    /** type marker for an int */
     static final byte INT_T = (byte) INT32;
+    /** type marker for a long */
     static final byte LONG_T = (byte) INT64;
+    /** type marker for stop-bit encoded value */
     static final byte STOP_T = (byte) STOP_BIT;
+    /** type marker for a float */
     static final byte FLOAT_T = (byte) FLOAT32;
+    /** type marker for a double */
     static final byte DOUBLE_T = (byte) FLOAT64;
 
     private static final String[] STRING_FOR_CODE = _stringForCode(GuardedNativeBytes.class);
@@ -223,6 +223,9 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
         return super.readDouble();
     }
 
+    /**
+     * Verifies the next type marker matches {@code expected}.
+     */
     private void expectByte(byte expected) throws IllegalStateException {
         byte type = super.readByte();
         if (type != expected)
@@ -230,6 +233,9 @@ public class GuardedNativeBytes<U> extends NativeBytes<U> {
                     + " but was " + STRING_FOR_CODE[type & 0xFF]);
     }
 
+    /**
+     * Verifies the next marker matches either {@code expected} or {@code expected2}.
+     */
     private void expectByte(byte expected, byte expected2) throws IllegalStateException {
         byte type = super.readByte();
         if (type != expected && type != expected2)

--- a/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
@@ -45,13 +45,8 @@ import static net.openhft.chronicle.core.util.Longs.requireNonNegative;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * A class that implements the {@link Bytes} interface for generating a hex dump of byte data. The hex dump is a
- * human-readable display of data in hexadecimal and ASCII formats. It's commonly used for debugging, forensics,
- * and analyzing low-level data.
- * <p>
- * It supports setting specific number wrap for byte data and custom offset formatting to provide more flexibility
- * and control over the output of the hex dump. The class also enables indentation adjustment, which can be useful
- * for nested data structures or logically grouped data within the byte array.
+ * {@link Bytes} implementation that records all writes and produces a formatted hexadecimal dump of the data.
+ * Primarily intended for diagnostics and testing.
  */
 
 @SuppressWarnings("rawtypes")
@@ -70,7 +65,7 @@ public class HexDumpBytes
     private int numberWrap = 16;
 
     /**
-     * Constructs a HexDumpBytes instance with default settings.
+     * Creates an empty instance with default buffer sizes.
      */
     public HexDumpBytes() {
         base = Bytes.allocateElasticDirect(256);
@@ -80,12 +75,7 @@ public class HexDumpBytes
     }
 
     /**
-     * Constructs a HexDumpBytes instance with provided base and text bytes.
-     *
-     * @param base NativeBytes instance representing base data.
-     * @param text BytesStore instance representing text data.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way.
+     * Internal constructor used when copying an existing dump.
      */
     HexDumpBytes(@NotNull Bytes<?> base, @NotNull BytesStore<?, ?> text) {
         final long size = base.readRemaining();
@@ -96,11 +86,7 @@ public class HexDumpBytes
     }
 
     /**
-     * Creates a HexDumpBytes instance from provided text reader.
-     *
-     * @param reader Reader instance to read the text data.
-     * @return HexDumpBytes instance initialized with the read text data.
-     * @throws NumberFormatException if parsing a number fails.
+     * Parses a textual hex dump and returns a populated instance.
      */
     public static HexDumpBytes fromText(@NotNull Reader reader) throws NumberFormatException {
         HexDumpBytes tb = new HexDumpBytes();
@@ -115,11 +101,7 @@ public class HexDumpBytes
     }
 
     /**
-     * Creates a HexDumpBytes instance from provided char sequence.
-     *
-     * @param text CharSequence to read the text data from.
-     * @return HexDumpBytes instance initialized with the read text data.
-     * @throws NumberFormatException if parsing a number fails.
+     * Convenience overload of {@link #fromText(Reader)}.
      */
     public static HexDumpBytes fromText(@NotNull CharSequence text) throws NumberFormatException {
         return fromText(new StringReader(text.toString()));

--- a/src/main/java/net/openhft/chronicle/bytes/HexDumpBytesDescription.java
+++ b/src/main/java/net/openhft/chronicle/bytes/HexDumpBytesDescription.java
@@ -21,25 +21,19 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 import static net.openhft.chronicle.core.Jvm.uncheckedCast;
 
 /**
- * This interface is for additional description to be added to HexDumpBytes
+ * Provides hooks for adding comments and controlling indentation when generating hex dumps.
  */
 public interface HexDumpBytesDescription<B extends HexDumpBytesDescription<B>> {
     /**
-     * Do these Bytes support saving comments as descriptions for fields.
-     *
-     * @return true if comments are for field descriptions
+     * @return {@code true} if comments are retained for later inclusion in the hex dump
      */
     default boolean retainedHexDumpDescription() {
         return false;
     }
 
     /**
-     * Add comment as appropriate for the toHexString format
-     *
-     * @param comment to add (or ignore)
-     * @return this
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * Adds {@code comment} to the output, either as a full line (if starting with {@code '#'}) or
+     * appended to the current line.
      */
     default B writeHexDumpDescription(CharSequence comment)
             throws ClosedIllegalStateException, ThreadingIllegalStateException {
@@ -47,10 +41,7 @@ public interface HexDumpBytesDescription<B extends HexDumpBytesDescription<B>> {
     }
 
     /**
-     * Adjust the indent for nested data
-     *
-     * @param n +1 indent in, -1 reduce indenting
-     * @return this.
+     * Adjusts the indentation level for subsequent dump lines.
      */
     default B adjustHexDumpIndentation(int n)
             throws IllegalStateException {


### PR DESCRIPTION
## Summary
- refine comments for `BytesTextMethodTester`
- clarify usage of `ByteStringAppender` and `ByteStringParser`
- document helper behaviour in `BytesUtil` and related utilities
- describe exceptions and interfaces used for unique timestamps
- tidy docs across hex dump classes and guarded bytes

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*