### PR TITLE
Improve Javadoc across streaming interfaces

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/StreamingCommon.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingCommon.java
@@ -20,24 +20,23 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a streaming interface for handling streaming data with support for random access.
- * The interface is used for managing reading and writing positions within the streaming data.
+ * A common base interface for streaming data access. It manages fundamental
+ * buffer properties such as positions and limits and supports random access
+ * semantics. Implementations are mainly used by higher level streaming
+ * interfaces like {@link StreamingDataInput} and {@link StreamingDataOutput}.
  *
- * @param <S> Type of the implementing class, extending StreamingCommon
+ * @param <S> type of the implementing class
  */
 public interface StreamingCommon<S extends StreamingCommon<S>> extends RandomCommon {
 
     /**
-     * Resets the read and write positions to the start of the streaming buffer,
-     * and sets the write limit to the capacity of the buffer. This effectively
-     * clears any existing data in the buffer and prepares it for new data to be written.
+     * Resets the read and write positions to {@link #start()} and sets the
+     * effective limits to {@link #capacity()}. The underlying data is left
+     * unchanged but the buffer behaves as if newly allocated.
      *
-     * <p>This operation is similar to rewinding the tape to the beginning,
-     * and having it ready to record new data over anything that was there before.
-     *
-     * @return A reference to this object, allowing for method chaining.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @return this instance for chaining
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if accessed by multiple threads in an unsafe way
      */
     @NotNull
     S clear() throws ClosedIllegalStateException, ThreadingIllegalStateException;

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
@@ -43,31 +43,10 @@ import static net.openhft.chronicle.core.util.Longs.requireNonNegative;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * StreamingDataOutput is an interface for classes that support writing data to a stream.
- * Position based access.  Once data has been read, the writePosition() moves.
- *
- * <p>The various write methods in this interface support writing bytes, arrays of bytes, and sequences
- * of bytes from other sources like {@link ByteBuffer} and {@link RandomDataInput}. It also provides
- * methods for writing primitive data types and their boxed counterparts. Additionally, it supports
- * writing complex data structures such as {@link BigDecimal}, {@link BigInteger}, {@link Histogram}
- * and objects in unsafe way.
- *
- * <p>Not all the methods are expected to be implemented by classes. Default methods are provided for
- * common use cases. Classes that extend this interface can override these methods to provide more
- * efficient or custom implementations.
- *
- * <p>Implementations of this interface are expected to handle cases where the buffer may not have
- * enough capacity to handle the write operation. In such cases, methods should throw a {@link BufferOverflowException}.
- *
- * <p>Instances of classes implementing StreamingDataOutput are not guaranteed to be thread safe. If multiple
- * threads interact with the same instance, external synchronization should be used.
- *
- * @see RandomDataOutput
- * @see ByteBuffer
- * @see BufferOverflowException
- * @see BigDecimal
- * @see BigInteger
- * @see Histogram
+ * Provides sequential, cursor based writing of binary and textual data to a
+ * stream or buffer. Methods typically advance the {@link #writePosition()} by
+ * the number of bytes written. Implementations may throw
+ * {@link BufferOverflowException} if insufficient space is available.
  */
 @SuppressWarnings("unchecked")
 @DontChain
@@ -76,9 +55,8 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
     int JAVA9_STRING_CODER_UTF16 = 1;
 
     /**
-     * Sets the current write position in the data stream. The write position indicates the point
-     * where the next write operation will begin. Calling this method does not modify the data in
-     * the stream; it only changes the position where future write operations will take place.
+     * Sets the current write position. No data is written or removed; this merely
+     * changes the index at which the next write will occur.
      *
      * @param position The new write position. It must be a non-negative number.
      * @return The current StreamingDataOutput instance.
@@ -91,8 +69,8 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
             throws BufferOverflowException, ClosedIllegalStateException, ThreadingIllegalStateException;
 
     /**
-     * Sets the limit for writing to the data stream. No data can be written beyond this limit.
-     * If an attempt is made to write data beyond this limit, a BufferOverflowException will be thrown.
+     * Sets the maximum writeable offset. Attempts to write beyond this limit
+     * result in {@link BufferOverflowException}.
      *
      * @param limit The new write limit. It must be a non-negative number.
      * @return The current StreamingDataOutput instance.
@@ -103,9 +81,8 @@ public interface StreamingDataOutput<S extends StreamingDataOutput<S>> extends S
             throws BufferOverflowException;
 
     /**
-     * Skips a specified number of bytes from the current write position in the data stream.
-     * This method adjusts the write position either forward or backward based on the value of
-     * bytesToSkip. The new position should not exceed the write limit.
+     * Advances or rewinds the write position by {@code bytesToSkip}. The result
+     * must remain within {@link #writeLimit()}.
      *
      * @param bytesToSkip The number of bytes to skip. This can be a negative number to move the
      *                    position backward.

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingInputStream.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingInputStream.java
@@ -24,13 +24,9 @@ import java.io.InputStream;
 import java.nio.BufferUnderflowException;
 
 /**
- * A special kind of InputStream implementation which reads data from a StreamingDataInput instance.
- *
- * <p>This class provides a way to connect APIs expecting an InputStream with data sources
- * encapsulated in StreamingDataInput instances.
- *
- * @see StreamingDataInput
- * @see InputStream
+ * An {@link InputStream} adapter that sources its data from a
+ * {@link StreamingDataInput}. Useful when an API requires an
+ * {@code InputStream} but the data resides in a Chronicle Bytes stream.
  */
 @SuppressWarnings("rawtypes")
 public class StreamingInputStream extends InputStream {

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingOutputStream.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingOutputStream.java
@@ -24,13 +24,9 @@ import java.io.OutputStream;
 import java.nio.BufferOverflowException;
 
 /**
- * A special kind of OutputStream implementation which writes data to a StreamingDataOutput instance.
- *
- * <p>This class provides a way to connect APIs expecting an OutputStream with data destinations
- * encapsulated in StreamingDataOutput instances.
- *
- * @see StreamingDataOutput
- * @see OutputStream
+ * An {@link OutputStream} adapter that writes its bytes to a
+ * {@link StreamingDataOutput}. This allows Chronicle Bytes streams to be used
+ * where a standard {@code OutputStream} is required.
  */
 @SuppressWarnings("rawtypes")
 public class StreamingOutputStream extends OutputStream {
@@ -65,6 +61,12 @@ public class StreamingOutputStream extends OutputStream {
     }
 
     @Override
+    /**
+     * Writes bytes from the given array to the underlying {@link StreamingDataOutput}.
+     * Any {@link BufferOverflowException}, {@link IllegalArgumentException} or
+     * {@link IllegalStateException} from the target is wrapped in an
+     * {@link IOException}.
+     */
     public void write(byte[] b, @NonNegative int off, @NonNegative int len)
             throws IOException {
         try {
@@ -76,6 +78,10 @@ public class StreamingOutputStream extends OutputStream {
     }
 
     @Override
+    /**
+     * Writes a single byte value. Exceptions thrown by the target
+     * {@link StreamingDataOutput} are wrapped in an {@link IOException}.
+     */
     public void write(int b)
             throws IOException {
         try {

--- a/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
@@ -23,10 +23,11 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.BufferUnderflowException;
 
 /**
- * A {@code SubBytes} object represents a subsection of a {@link BytesStore} from a given start index up to a specified capacity.
- * This is useful when you want to handle a specific part of the data within a larger BytesStore.
+ * Represents a fixed size view over a region of another {@link BytesStore}.
+ * The view has its own start offset and capacity, effectively creating a slice
+ * of the parent store. It is non elastic and extends {@link VanillaBytes}.
  *
- * @param <U> the type of the BytesStore
+ * @param <U> the type of the underlying object
  */
 @SuppressWarnings("rawtypes")
 public class SubBytes<U> extends VanillaBytes<U> {
@@ -34,16 +35,17 @@ public class SubBytes<U> extends VanillaBytes<U> {
     private final long capacity;
 
     /**
-     * Class constructor. Creates a SubBytes from the bytes in a specified BytesStore from a specified Offset to
-     * a specified index (excluding).
+     * Creates a sub region view of the supplied {@code bytesStore}.
+     * The new view spans from {@code start} for {@code capacity} bytes.
+     * The initial read and write positions are set to {@code start} and the
+     * write limit to {@code start + capacity}.
      *
-     * @param bytesStore the parent BytesStore that contains the data
-     * @param start      the start index in the parent BytesStore from which the SubBytes start
-     * @param capacity   the number of elements from the start index that the SubBytes cover
-     * @throws BufferUnderflowException       If the capacity is less than the start index
-     * @throws IllegalArgumentException       If any other argument issue occurs
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param bytesStore the parent store
+     * @param start      absolute start offset within {@code bytesStore}
+     * @param capacity   number of bytes in the sub region
+     * @throws BufferUnderflowException       if {@code start + capacity} exceeds the parent capacity
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if accessed by multiple threads in an unsafe way
      */
     @SuppressWarnings("this-escape")
     public SubBytes(@NotNull BytesStore<?, ?> bytesStore, @NonNegative long start, @NonNegative long capacity)
@@ -56,7 +58,7 @@ public class SubBytes<U> extends VanillaBytes<U> {
     }
 
     /**
-     * @return the capacity as a long value
+     * Returns the fixed capacity supplied at construction.
      */
     @NonNegative
     @Override
@@ -65,7 +67,7 @@ public class SubBytes<U> extends VanillaBytes<U> {
     }
 
     /**
-     * @return the start index as a long value
+     * Returns the absolute start offset within the parent store.
      */
     @NonNegative
     @Override
@@ -74,7 +76,7 @@ public class SubBytes<U> extends VanillaBytes<U> {
     }
 
     /**
-     * @return the capacity as a long value
+     * Returns the real capacity, which is identical to {@link #capacity()} for this view.
      */
     @NonNegative
     @Override

--- a/src/main/java/net/openhft/chronicle/bytes/SyncMode.java
+++ b/src/main/java/net/openhft/chronicle/bytes/SyncMode.java
@@ -18,25 +18,22 @@ package net.openhft.chronicle.bytes;
 import net.openhft.posix.MSyncFlag;
 
 /**
- * An enumeration of sync modes for disk operations.
- * This enum controls whether the write operations are synchronized with the disk, and if so, whether
- * to wait for the synchronization to complete before continuing with the program execution.
+ * Synchronisation options for memory mapped file updates, mirroring the
+ * behaviour of {@code msync(2)}.
  */
 public enum SyncMode {
     /**
-     * No synchronization is performed. The write operations are not explicitly synced with the disk.
+     * No synchronisation is requested.
      */
     NONE(null),
     /**
-     * Synchronization is performed, and the program waits for the sync operation to complete before proceeding.
-     * This mode guarantees that the write operation is completed before the next operation is carried out.
-     * However, this mode may not be supported on all platforms.
+     * Synchronous update using {@link MSyncFlag#MS_SYNC}. The call blocks until
+     * all modified pages are written to disk.
      */
     SYNC(MSyncFlag.MS_SYNC),
     /**
-     * Synchronization is scheduled but the program does not wait for it to complete before proceeding.
-     * This mode allows the write operation to be carried out asynchronously. The actual write to the disk
-     * happens later and does not block the program execution. However, this mode may not be supported on all platforms.
+     * Asynchronous update using {@link MSyncFlag#MS_ASYNC}. Dirty pages are
+     * scheduled for write out but the call returns immediately.
      */
     ASYNC(MSyncFlag.MS_ASYNC);
 

--- a/src/main/java/net/openhft/chronicle/bytes/UTFDataFormatRuntimeException.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UTFDataFormatRuntimeException.java
@@ -18,9 +18,8 @@ package net.openhft.chronicle.bytes;
 import net.openhft.chronicle.core.io.IORuntimeException;
 
 /**
- * An unchecked exception thrown when there is an issue with encoding or decoding UTF-8 data.
- * This exception extends {@link IORuntimeException}, which is a base class for exceptions that can
- * be thrown during reading and writing operations.
+ * Thrown to indicate a failure when encoding or decoding UTF-8 data. Extends
+ * {@link IORuntimeException} so callers need not catch it.
  */
 public class UTFDataFormatRuntimeException extends IORuntimeException {
     private static final long serialVersionUID = 0L;

--- a/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
@@ -36,10 +36,12 @@ import static net.openhft.chronicle.core.util.Longs.requireNonNegative;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * A simple Bytes implementation that is non-elastic. It does not support dynamic resizing.
- * This class provides functionality to work with a sequence of bytes, offering various read and write operations.
+ * Base implementation of {@link Bytes} backed by a fixed-capacity
+ * {@link BytesStore}. Subclasses such as {@link NativeBytes} or
+ * {@link OnHeapBytes} provide concrete behaviour. This class itself is not
+ * elastic.
  *
- * @param <U> the type of the underlying object representation
+ * @param <U> type of the object representation
  */
 @SuppressWarnings("rawtypes")
 public class VanillaBytes<U>
@@ -91,10 +93,9 @@ public class VanillaBytes<U>
     }
 
     /**
-     * Factory method for creating an instance of VanillaBytes with no initial ByteStore.
-     * This can be used in scenarios where the ByteStore is to be replaced or provided at a later point.
-     *
-     * @return a new instance of VanillaBytes with no ByteStore.
+     * Creates a new {@code VanillaBytes} backed by an empty native store.
+     * The returned instance is elastic as it actually delegates to
+     * {@link NativeBytes}.
      */
     @NotNull
     public static VanillaBytes<Void> vanillaBytes() {

--- a/src/main/java/net/openhft/chronicle/bytes/WriteBytesMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/WriteBytesMarshallable.java
@@ -23,27 +23,24 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 import java.nio.BufferOverflowException;
 
 /**
- * An interface defining a contract for serializing data directly to a Bytes instance.
- * Objects implementing this interface can be marshalled into a sequence of bytes.
- *
- * @see net.openhft.chronicle.core.io.Validatable
+ * Functional interface for objects that can serialise their state directly to a
+ * {@link BytesOut} stream. Implementations typically call
+ * {@link net.openhft.chronicle.core.io.Validatable#validate()} before writing.
  */
 @FunctionalInterface
 @DontChain
 public interface WriteBytesMarshallable extends CommonMarshallable {
 
     /**
-     * Serializes this object to the provided Bytes instance.
+     * Writes this object's state to {@code bytes} using a custom binary format.
+     * Implementations may validate their state prior to writing and throw
+     * {@link InvalidMarshallableException} if invalid.
      *
-     * <p>This method is responsible for calling
-     * {@link net.openhft.chronicle.core.io.Validatable#validate()} as needed to ensure
-     * the validity of the state of the object before serialization.
-     *
-     * @param bytes the {@link BytesOut} instance to write the object's state to.
-     * @throws BufferOverflowException        If there is no more space left to write in the buffer.
-     * @throws InvalidMarshallableException   If the object cannot be successfully serialized.
-     * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
+     * @param bytes the target stream
+     * @throws BufferOverflowException        if there is insufficient space in the buffer
+     * @throws InvalidMarshallableException   if the object is not in a valid state for serialisation
+     * @throws ClosedIllegalStateException    if the resource has been released or closed
+     * @throws ThreadingIllegalStateException if accessed by multiple threads in an unsafe way
      */
     void writeMarshallable(BytesOut<?> bytes)
             throws IllegalStateException, BufferOverflowException, InvalidMarshallableException;


### PR DESCRIPTION
## Summary
- clarify StreamingCommon contract and clear() behaviour
- refine StreamingDataInput and StreamingDataOutput interface docs
- document StreamingInputStream and StreamingOutputStream usage
- expand docs for SubBytes, SyncMode and several unchecked byte wrappers
- tidy VanillaBytes and WriteBytesMarshallable Javadocs

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*