### PR TITLE
Improve internal documentation

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
@@ -44,8 +44,9 @@ import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.core.util.Longs.*;
 
 /**
- * A memory mapped files which can be randomly accessed in chunks. It has overlapping regions to
- * avoid wasting bytes at the end of chunks.
+ * Implementation of {@link MappedFile} that divides a file into multiple
+ * potentially overlapping memory mapped chunks. Only a subset of chunks may be
+ * mapped at once allowing access to files larger than a single mapping.
  */
 @SuppressWarnings("restriction")
 public class ChunkedMappedFile extends MappedFile {

--- a/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
@@ -36,19 +36,26 @@ import static net.openhft.chronicle.core.util.Longs.requireNonNegative;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * Wrapper for Heap ByteBuffers and arrays.
+ * {@link net.openhft.chronicle.bytes.BytesStore} implementation backed by an
+ * on-heap byte array or heap {@link ByteBuffer}. Accesses are performed using
+ * {@code Unsafe} for speed. Instances are reference counted.
  *
- * @param <U> Underlying type
+ * @param <U> underlying type
  */
 @SuppressWarnings("restriction")
 public class HeapBytesStore<U>
         extends AbstractBytesStore<HeapBytesStore<U>, U> {
+    /** Actual byte array backing this store when wrapping heap memory. */
     @Nullable
     private final Object realUnderlyingObject;
+    /** Unsafe offset of the first data byte. */
     private final int dataOffset;
+    /** Usable capacity of this store. */
     private final long capacity;
+    /** Original object passed to the constructor, array or ByteBuffer. */
     @Nullable
     private final U underlyingObject;
+    /** Memory accessor used for heap operations. */
     private UnsafeMemory memory = UnsafeMemory.MEMORY;
 
     private HeapBytesStore(@NotNull ByteBuffer byteBuffer) {
@@ -96,6 +103,10 @@ public class HeapBytesStore<U>
         return new HeapBytesStore<>(bb);
     }
 
+    /**
+     * Returns the base unsafe offset for accessing data within
+     * {@link #realUnderlyingObject}.
+     */
     long dataOffset() {
         return dataOffset;
     }

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
@@ -36,8 +36,8 @@ import java.nio.channels.FileLock;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 
 /**
- * A memory mapped files which can be randomly accessed in a single chunk. It has no overlapping region to
- * avoid wasting bytes at the end of file.
+ * {@link MappedFile} implementation that maps the entire file as one contiguous
+ * region. Suitable when the full capacity fits into the process address space.
  */
 @SuppressWarnings({"rawtypes", "restriction"})
 public class SingleMappedFile extends MappedFile {


### PR DESCRIPTION
## Summary
- expand javadoc for internal helpers in `BytesInternal`
- document native, heap and mapped file internals
- clarify byte copy helpers and UTF-8 append methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*