### PR TITLE
Fix ChunkedMappedBytes large write

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -90,14 +90,18 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
                 return this;
             }
 
-            bytesStore.write(wp, byteArray, offset, (int) safeCopySize);
+            int bytesToWrite = (int) Math.min(safeCopySize, (long) Integer.MAX_VALUE);
+            bytesToWrite = Math.min(bytesToWrite, remaining);
 
-            offset += (int) safeCopySize;
-            wp += safeCopySize;
-            remaining -= (int) safeCopySize;
+            bytesStore.write(wp, byteArray, offset, bytesToWrite);
 
-            // move to the next chunk
-            bytesStore = acquireNextByteStore0(wp, false);
+            offset += bytesToWrite;
+            wp += bytesToWrite;
+            remaining -= bytesToWrite;
+
+            if (bytesToWrite == safeCopySize)
+                // move to the next chunk
+                bytesStore = acquireNextByteStore0(wp, false);
         }
         return this;
 


### PR DESCRIPTION
## Summary
- ensure ChunkedMappedBytes.write(byte[]) does not cast a long to int when chunk sizes exceed 2GB

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c1207a468832993bd35dd2213f196