### PR TITLE
Handle inaccessible ByteBuffer fields gracefully

### DIFF
--- a/src/main/adoc/memory-management.adoc
+++ b/src/main/adoc/memory-management.adoc
@@ -26,10 +26,14 @@ leaks by recording where a store was reserved.
 
 == 2  Native Memory
 
-`NativeBytesStore` allocates direct memory using `Unsafe`. `releaseLast()`
-returns the memory to the OS. For mapped files `MappedBytesStore` delegates to
-`MappedFile` which may unmap via an internal `Unmapper` or the JDK
-`Cleaner`. Failure to release prevents the memory from being reclaimed.
+`NativeBytesStore` allocates direct memory using `Unsafe`. It also
+reflectively accesses the backing `ByteBuffer` fields to obtain the raw
+address and capacity for speed. If this reflective access is blocked by
+the module system or a security manager the library logs a warning and the
+optimisation is disabled. `releaseLast()` returns the memory to the OS. For
+mapped files `MappedBytesStore` delegates to `MappedFile` which may unmap
+via an internal `Unmapper` or the JDK `Cleaner`. Failure to release prevents
+the memory from being reclaimed.
 
 == 3  Memory-Mapped Files
 

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -157,6 +157,7 @@ using raw wire format or if endianness-sensitive operations are exposed. (Note: 
 Enterprise-only features (e.g. encrypted queue files at a higher level, specific `BytesStore` types) are attempted to be used. |Unit test verifies.
 |CB-RISK-003 |Ensure that direct use of `sun.misc.Unsafe` is clearly demarcated, justified, and encapsulated. Fallback mechanisms should be considered if `Unsafe` is unavailable, or clear documentation of `Unsafe` necessity. |Code review and documentation justifying `Unsafe` use; tests for fallback mechanisms if any, or CI runs with `Unsafe` restricted.
 |CB-RISK-004 |Potential for `OutOfMemoryError` (both Java heap and native memory) if not managed correctly by users. |Clear documentation (CB-DOC-006) on resource lifecycle and typical patterns to avoid leaks. `BytesMetrics` (CB-NF-O-002) for monitoring.
+|CB-RISK-005 |Reflection on internal JDK fields (e.g., direct `ByteBuffer` address) must fail gracefully when blocked by the module system or security manager. A warning should be logged and a safe fallback used. |Unit test installs a restrictive security manager and verifies warning output and functional behaviour.
 |===
 
 == 10  Operational Concerns

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ByteBuffers.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ByteBuffers.java
@@ -34,8 +34,16 @@ public final class ByteBuffers {
 
     static {
         ByteBuffer direct = ByteBuffer.allocateDirect(0);
-        ADDRESS = Jvm.getField(direct.getClass(), "address");
-        CAPACITY = Jvm.getField(direct.getClass(), "capacity");
+        Field address = null;
+        Field capacity = null;
+        try {
+            address = Jvm.getField(direct.getClass(), "address");
+            capacity = Jvm.getField(direct.getClass(), "capacity");
+        } catch (Throwable t) {
+            Jvm.warn().on(ByteBuffers.class, "Unable to access direct ByteBuffer fields", t);
+        }
+        ADDRESS = address;
+        CAPACITY = capacity;
     }
 
     /**
@@ -51,6 +59,8 @@ public final class ByteBuffers {
      * @throws AssertionError if the operation fails due to IllegalAccessException or IllegalArgumentException
      */
     public static void setAddressCapacity(ByteBuffer buffer, long address, long capacity) {
+        if (ADDRESS == null || CAPACITY == null)
+            throw new UnsupportedOperationException("Direct ByteBuffer fields not accessible");
         int cap = Math.toIntExact(capacity);
         try {
             ADDRESS.setLong(buffer, address);

--- a/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
@@ -54,9 +54,19 @@ public class NativeBytesStore<U>
 
     static {
         Class<?> directBB = ByteBuffer.allocateDirect(0).getClass();
-        BB_ADDRESS = Jvm.getField(directBB, "address");
-        BB_CAPACITY = Jvm.getField(directBB, "capacity");
-        BB_ATT = Jvm.getField(directBB, "att");
+        Field address = null;
+        Field capacity = null;
+        Field att = null;
+        try {
+            address = Jvm.getField(directBB, "address");
+            capacity = Jvm.getField(directBB, "capacity");
+            att = Jvm.getField(directBB, "att");
+        } catch (Throwable t) {
+            Jvm.warn().on(NativeBytesStore.class, "Unable to access ByteBuffer fields", t);
+        }
+        BB_ADDRESS = address;
+        BB_CAPACITY = capacity;
+        BB_ATT = att;
     }
 
     // Even though not referenced, this field needs to stay


### PR DESCRIPTION
## Summary
- warn if internal `ByteBuffer` fields cannot be accessed
- disable optimisation when reflection fails
- document reflective field access in `NativeBytesStore`
- add new risk requirement about failing gracefully

## Testing
- `mvn -q verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd2187ed48329b26b55c1ed73a3b3