### PR TITLE
Improve logging for ignored exceptions

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -1491,8 +1491,8 @@ enum BytesInternal {
                     if (bytes.readLong(end - 8) != 0)
                         break;
                 }
-            } catch (@NotNull UnsupportedOperationException | BufferUnderflowException ignored) {
-                // ignore
+            } catch (@NotNull UnsupportedOperationException | BufferUnderflowException e) {
+                Jvm.debug().on(BytesInternal.class, "vectorized toString check failed", e);
             }
             toString(bytes, sb, start, readPosition, readLimit, end);
             if (end < bytes.readLimit())

--- a/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
@@ -376,8 +376,8 @@ public abstract class CommonMappedBytes extends MappedBytes {
             throws ClosedIllegalStateException {
         try {
             super.release(id);
-        } catch (ClosedIllegalStateException ignored) {
-            // ignored
+        } catch (ClosedIllegalStateException e) {
+            Jvm.debug().on(CommonMappedBytes.class, "release called on closed resource", e);
         }
         initReleased |= id == INIT;
         if (refCount() <= 0)

--- a/src/main/java/net/openhft/chronicle/bytes/internal/EmbeddedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/EmbeddedBytes.java
@@ -19,6 +19,7 @@ import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.VanillaBytes;
 import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.ClosedIllegalStateException;
+import net.openhft.chronicle.core.Jvm;
 import org.jetbrains.annotations.NotNull;
 
 import static net.openhft.chronicle.core.Jvm.uncheckedCast;
@@ -48,7 +49,8 @@ public class EmbeddedBytes<U> extends VanillaBytes<U> {
     public @NonNegative long writePosition() {
         try {
             return bytesStore.readUnsignedByte(lengthOffset());
-        } catch (ClosedIllegalStateException ignored) {
+        } catch (ClosedIllegalStateException e) {
+            Jvm.debug().on(EmbeddedBytes.class, "bytesStore is closed", e);
             return 0;
         }
     }

--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -20,6 +20,7 @@ import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.MappedBytesStore;
 import net.openhft.chronicle.core.annotation.NonNegative;
 import net.openhft.chronicle.core.io.*;
+import net.openhft.chronicle.core.Jvm;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -131,8 +132,8 @@ public abstract class AbstractReference extends AbstractCloseable implements Byt
         this.bytesStore = null;
         try {
             bytes0.release(this);
-        } catch (ClosedIllegalStateException ignored) {
-            // ignored
+        } catch (ClosedIllegalStateException e) {
+            Jvm.debug().on(AbstractReference.class, "release after close", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- add debug logging when bytes stores are unexpectedly closed
- log debug message if vectorised mismatch loop fails

## Testing
- `mvn -q verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd2b77114832993c443810a39c312