### PR TITLE
Improve pooled buffer security

### DIFF
--- a/src/main/adoc/api-guide.adoc
+++ b/src/main/adoc/api-guide.adoc
@@ -527,7 +527,7 @@ Do not release the `Bytes` instance in a way that expects to free the underlying
 == 8  Performance Tips
 
 * **Thread Affinity**: Pin critical threads to specific CPU cores (e.g., using `AffinityLock`) to improve cache utilization (L1/L2) and reduce context switching.
-* **Buffer Reuse**: For frequently needed, fixed-size buffers, consider pooling `Bytes` instances or, more commonly, allocating them once per thread (using `ThreadLocal`) and reusing them by calling `clear()` or resetting cursors.
+* **Buffer Reuse**: For frequently needed, fixed-size buffers, consider pooling `Bytes` instances or, more commonly, allocating them once per thread (using `ThreadLocal`) and reusing them by calling `clear()` or resetting cursors. Pooled buffers should zero the bytes written so far before reuse to prevent data leakage. The built-in `BytesPool` performs this via `zeroOut()` on the used region.
 * **Bulk Operations**: Use bulk methods like `Bytes.write(BytesStore anotherBytes, long offset, long length)` or `Bytes.unsafeWriteObject(Object obj, long offset, int length)` (with extreme care) for copying large chunks of data, as they often have lower per-byte overhead than repeated individual primitive writes.
 * **JVM Options**: Experiment with relevant JVM options (e.g., `-XX:+UnlockDiagnosticVMOptions -XX:PrintAssembly` to inspect generated code, `-XX:+UseLargePages` for off-heap memory).
 * **Disable Debug Fields (Production)**: If Chronicle Bytes has compile-time or runtime flags to strip debug assertions or fields (e.g., `-Dbytes.compact=true` if such a flag exists), enable them in production for minimal overhead.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -83,7 +83,7 @@ enum BytesInternal {
                 IOTools.unmonitor(bbb);
                 return bbb;
             },
-            Bytes::clear,
+            BytesInternal::clearAndZero,
             THREAD_LOCAL_BYTES_POOL_SIZE);
     public static final StringInternerBytes SI;
     static final char[] HEXADECIMAL = "0123456789abcdef".toCharArray();
@@ -3471,6 +3471,15 @@ enum BytesInternal {
         }
 
         return bytesStore;
+    }
+
+    private static void clearAndZero(Bytes<?> bytes) {
+        try {
+            bytes.zeroOut(bytes.start(), bytes.writePosition());
+        } catch (IllegalStateException e) {
+            Jvm.warn().on(BytesInternal.class, "Failed to zero pooled Bytes", e);
+        }
+        bytes.clear();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
+++ b/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
@@ -54,7 +54,7 @@ public final class BytesPool {
     public static ScopedResourcePool<Bytes<?>> createThreadLocal(int instancesPerThread) {
         return new ScopedThreadLocal<>(
                 BytesPool::createBytes,
-                Bytes::clear,
+                BytesPool::clearAndZero,
                 instancesPerThread);
     }
 
@@ -76,5 +76,14 @@ public final class BytesPool {
         Bytes<?> bbb = Bytes.allocateElasticDirect(256);
         IOTools.unmonitor(bbb);
         return bbb;
+    }
+
+    private static void clearAndZero(Bytes<?> bytes) {
+        try {
+            bytes.zeroOut(bytes.start(), bytes.writePosition());
+        } catch (IllegalStateException e) {
+            Jvm.warn().on(BytesPool.class, "Failed to zero pooled Bytes", e);
+        }
+        bytes.clear();
     }
 }


### PR DESCRIPTION
## Summary
- zero pooled Bytes only up to its written region
- clarify buffer reuse guidance

## Testing
- `mvn -q verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd207c44c8329bf681180cc5770ef