### PR TITLE
Add bounds checks for array deserialisation

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
@@ -354,19 +354,20 @@ public class BytesMarshaller<T> {
         protected void setValue(Object o, BytesIn<?> read)
                 throws ClosedIllegalStateException, BufferUnderflowException, IllegalArgumentException, ArithmeticException, BufferOverflowException, InvalidMarshallableException, IllegalAccessException {
             Object[] c = (Object[]) field.get(o);
-            int length = Maths.toInt32(read.readStopBit());
-            if (length < 0) {
+            int elementCount = Maths.toInt32(read.readStopBit());
+            if (elementCount < 0) {
                 if (c != null)
                     field.set(o, null);
                 return;
             }
-            BytesUtil.checkArrayLength(length, read.readRemaining());
+            // this assumes each entry is at least 1 byte, so we can use readRemaining() to check the elementCount
+            BytesUtil.checkArrayLength(elementCount, read.readRemaining());
             if (c == null) {
-                c = (Object[]) Array.newInstance(field.getType().getComponentType(), length);
+                c = (Object[]) Array.newInstance(field.getType().getComponentType(), elementCount);
                 field.set(o, c);
-            } else if (c.length != length)
-                field.set(o, c = Arrays.copyOf(c, length));
-            for (int i = 0; i < length; i++) {
+            } else if (c.length != elementCount)
+                field.set(o, c = Arrays.copyOf(c, elementCount));
+            for (int i = 0; i < elementCount; i++) {
                 Object o2 = c[i];
                 if (o2 instanceof BytesMarshallable)
                     ((BytesMarshallable) o2).readMarshallable(read);

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
@@ -360,6 +360,7 @@ public class BytesMarshaller<T> {
                     field.set(o, null);
                 return;
             }
+            BytesUtil.checkArrayLength(length, read.readRemaining());
             if (c == null) {
                 c = (Object[]) Array.newInstance(field.getType().getComponentType(), length);
                 field.set(o, c);
@@ -435,6 +436,7 @@ public class BytesMarshaller<T> {
                     field.set(o, null);
                 return;
             }
+            BytesUtil.checkArrayLength(length, read.readRemaining());
 
             if (c == null)
                 field.set(o, c = collectionSupplier.get());
@@ -502,6 +504,7 @@ public class BytesMarshaller<T> {
                     field.set(o, null);
                 return;
             }
+            BytesUtil.checkArrayLength(Maths.toInt32(length), read.readRemaining());
             if (m == null) {
                 field.set(o, m = collectionSupplier.get());
             } else {
@@ -573,14 +576,15 @@ public class BytesMarshaller<T> {
             int len = read.readInt();
             if (len == ~0) {
                 field.set(o, null);
-            } else if (len >= 0) {
-                byte[] array = (byte[]) field.get(o);
-                if (array == null || array.length != len) {
-                    array = new byte[len];
-                    field.set(o, array);
-                }
-                read.read(array);
+                return;
             }
+            BytesUtil.checkArrayLength(len, read.readRemaining());
+            byte[] array = (byte[]) field.get(o);
+            if (array == null || array.length != len) {
+                array = new byte[len];
+                field.set(o, array);
+            }
+            read.read(array);
         }
     }
 
@@ -667,15 +671,16 @@ public class BytesMarshaller<T> {
             int len = read.readInt();
             if (len == ~0) {
                 field.set(o, null);
-            } else if (len >= 0) {
-                int[] array = (int[]) field.get(o);
-                if (array == null || array.length != len) {
-                    array = new int[len];
-                    field.set(o, array);
-                }
-                for (int i = 0; i < len; i++)
-                    array[i] = read.readInt();
+                return;
             }
+            BytesUtil.checkArrayLength(len, read.readRemaining() / 4);
+            int[] array = (int[]) field.get(o);
+            if (array == null || array.length != len) {
+                array = new int[len];
+                field.set(o, array);
+            }
+            for (int i = 0; i < len; i++)
+                array[i] = read.readInt();
         }
     }
 
@@ -722,15 +727,16 @@ public class BytesMarshaller<T> {
             int len = read.readInt();
             if (len == ~0) {
                 field.set(o, null);
-            } else if (len >= 0) {
-                float[] array = (float[]) field.get(o);
-                if (array == null || array.length != len) {
-                    array = new float[len];
-                    field.set(o, array);
-                }
-                for (int i = 0; i < len; i++)
-                    array[i] = read.readFloat();
+                return;
             }
+            BytesUtil.checkArrayLength(len, read.readRemaining() / 4);
+            float[] array = (float[]) field.get(o);
+            if (array == null || array.length != len) {
+                array = new float[len];
+                field.set(o, array);
+            }
+            for (int i = 0; i < len; i++)
+                array[i] = read.readFloat();
         }
     }
 
@@ -777,15 +783,16 @@ public class BytesMarshaller<T> {
             int len = read.readInt();
             if (len == ~0) {
                 field.set(o, null);
-            } else if (len >= 0) {
-                long[] array = (long[]) field.get(o);
-                if (array == null || array.length != len) {
-                    array = new long[len];
-                    field.set(o, array);
-                }
-                for (int i = 0; i < len; i++)
-                    array[i] = read.readLong();
+                return;
             }
+            BytesUtil.checkArrayLength(len, read.readRemaining() / 8);
+            long[] array = (long[]) field.get(o);
+            if (array == null || array.length != len) {
+                array = new long[len];
+                field.set(o, array);
+            }
+            for (int i = 0; i < len; i++)
+                array[i] = read.readLong();
         }
     }
 
@@ -832,15 +839,16 @@ public class BytesMarshaller<T> {
             int len = read.readInt();
             if (len == ~0) {
                 field.set(o, null);
-            } else if (len >= 0) {
-                double[] array = (double[]) field.get(o);
-                if (array == null || array.length != len) {
-                    array = new double[len];
-                    field.set(o, array);
-                }
-                for (int i = 0; i < len; i++)
-                    array[i] = read.readDouble();
+                return;
             }
+            BytesUtil.checkArrayLength(len, read.readRemaining() / 8);
+            double[] array = (double[]) field.get(o);
+            if (array == null || array.length != len) {
+                array = new double[len];
+                field.set(o, array);
+            }
+            for (int i = 0; i < len; i++)
+                array[i] = read.readDouble();
         }
     }
 }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
@@ -117,7 +117,9 @@ public enum BytesUtil {
      */
     public static void checkArrayLength(int len, long remaining) throws IORuntimeException {
         if (len < 0 || len > MAX_ARRAY_LEN || len > remaining)
-            throw new IORuntimeException("Invalid array length: " + len);
+            throw new IORuntimeException("Invalid array length: " + len +
+                    ", max: " + MAX_ARRAY_LEN +
+                    ", remaining: " + remaining);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
@@ -95,6 +95,32 @@ public enum BytesUtil {
     static final String TIME_STAMP_PATH = Jvm.getProperty("timestamp.path", new File(TIME_STAMP_DIR, ".time-stamp." + USER_NAME + ".dat").getAbsolutePath());
 
     /**
+     * The maximum array length that will be accepted when reading data.
+     * Oversized requests trigger an {@link IORuntimeException}.
+     */
+    // Default to 16 MiB to avoid inadvertent OOMs when deserialising data.
+    private static final int MAX_ARRAY_LEN = Jvm.getInteger("bytes.max-array-len", 16 << 20);
+
+    /**
+     * Returns the configured maximum array length.
+     */
+    public static int maxArrayLength() {
+        return MAX_ARRAY_LEN;
+    }
+
+    /**
+     * Validates the requested length against {@link #MAX_ARRAY_LEN} and the bytes remaining.
+     *
+     * @param len       the length requested
+     * @param remaining bytes remaining in the source
+     * @throws IORuntimeException if the length is negative or exceeds the limits
+     */
+    public static void checkArrayLength(int len, long remaining) throws IORuntimeException {
+        if (len < 0 || len > MAX_ARRAY_LEN || len > remaining)
+            throw new IORuntimeException("Invalid array length: " + len);
+    }
+
+    /**
      * Checks if the given class is trivially copyable.
      *
      * @param clazz Class to check.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesMarshallerTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesMarshallerTest.java
@@ -118,6 +118,7 @@ class BytesMarshallerTest {
     void setValueWithNonEmptyArray() throws IllegalAccessException {
         // Simulate reading 2 for array size, then read strings
         when(bytesIn.readStopBit()).thenReturn(2L);
+        when(bytesIn.readRemaining()).thenReturn(12L);
         when(bytesIn.readObject(String.class)).thenReturn("hello", "world");
         fieldAccess.setValue(testObject, bytesIn);
         assert Arrays.equals(testObject.stringArray, new String[]{"hello", "world"});

--- a/systemProperties.adoc
+++ b/systemProperties.adoc
@@ -15,4 +15,5 @@ NOTE: All boolean properties below are read using link:https://javadoc.io/static
 | user.name | unknown | The default user name, unless otherwise specified | _USER_NAME_ (String)
 | timestamp.dir | OS.TMP | Returns directory of file as timestamp | _TIME_STAMP_DIR_ (String)
 | timestamp.path | unknown | Returns file path of timestamp.dir file | _TIME_STAMP_PATH_(String)
+| bytes.max-array-len | 16777216 | Maximum array length accepted when reading | _MAX_ARRAY_LEN_ (int)
 |===


### PR DESCRIPTION
## Summary
- guard against unreasonably large arrays in BytesMarshaller
- expose new system property `bytes.max-array-len`
- document the property in `systemProperties.adoc`
- default the maximum array length to 16 MB instead of 1 MB

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd26c7bf4832989b650e0f8381083