### PR TITLE
Update third party BOM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
-                <version>3.27ea0</version>
+                <version>3.27ea2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Update third party BOM version to 3.27ea2 to remove references to legacy staging repository URL.