### PR TITLE
Ensure Writes, Not Reads, Trigger Roll File Resizing

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -175,12 +175,31 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     public Bytes<Void> readPosition(@NonNegative final long position)
             throws BufferUnderflowException, ClosedIllegalStateException, ThreadingIllegalStateException {
 
-        if (bytesStore.inside(position)) {
+        // use the real limit of the byteStore rather than the safe limit to minimise resizing
+        if (bytesStore.inside(position, 0)) {
             return super.readPosition(position);
         } else {
             acquireNextByteStore0(position, true);
             return this;
         }
+    }
+
+    @Override
+    public @NotNull Bytes<Void> writeLimit(long limit) throws BufferOverflowException {
+        // use the real limit of the byteStore rather than the safe limit to minimise resizing
+        if (limit != capacity() && !bytesStore.inside(limit, 0)) {
+            acquireNextByteStore0(limit, false);
+        }
+        return super.writeLimit(limit);
+    }
+
+    @Override
+    public @NotNull Bytes<Void> writePosition(long position) throws BufferOverflowException {
+        // use the safe limit of the byteStore to ensure we can write something after it
+        if (!bytesStore.inside(position)) {
+            acquireNextByteStore0(position, false);
+        }
+        return super.writePosition(position);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -29,10 +29,13 @@ import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
+import java.util.Objects;
 
 import static net.openhft.chronicle.core.Jvm.uncheckedCast;
 import static net.openhft.chronicle.core.util.Ints.requireNonNegative;
@@ -46,6 +49,8 @@ import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
  */
 @SuppressWarnings("rawtypes")
 public class ChunkedMappedBytes extends CommonMappedBytes {
+
+    static final Logger LOG = LoggerFactory.getLogger(ChunkedMappedBytes.class);
 
     // assume the mapped file is reserved already.
     public ChunkedMappedBytes(@NotNull final MappedFile mappedFile)
@@ -171,10 +176,12 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     /**
-     * Sets the read position to the specified offset. It has the side effect of ensuring the position is within the current byteStore chunk between the start and hard limit.
-     * It uses the hard limit instead of the safe limit to avoid changing or resizing the underlying file unnecessarily.
-     * @param position the new read position, must be non-negative
-     * @return this Bytes instance for method chaining
+     * Move the read position to {@code position}, loading the correct chunk if needed.
+     * <p>
+     * Uses the chunk’s hard upper bound so we only grow the file when absolutely required.
+     *
+     * @param position new read position (>= 0)
+     * @return this instance
      */
     @NotNull
     @Override
@@ -191,13 +198,16 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     /**
-     * Sets the write limit to the specified offset. It has the side effect of ensuring the limit is within the current byteStore chunk between the start and hard limit.
-     * It uses the hard limit instead of the safe limit to avoid changing or resizing the underlying file unnecessarily.
-     * @param limit the new write limit, must be non-negative
-     * @return this Bytes instance for method chaining
+     * Move the write limit to {@code limit}, loading the correct chunk if needed.
+     * <p>
+     * Uses the chunk’s hard upper bound so we only grow the file when absolutely required.
+     *
+     * @param limit new write limit (>= 0)
+     * @return this instance
      */
+    @NotNull
     @Override
-    public @NotNull Bytes<Void> writeLimit(long limit) throws BufferOverflowException {
+    public Bytes<Void> writeLimit(long limit) throws BufferOverflowException {
         // use the real limit of the byteStore rather than the safe limit to minimise resizing
         if (limit != capacity() && !bytesStore.inside(limit, 0)) {
             acquireNextByteStore0(limit, false);
@@ -206,13 +216,16 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     }
 
     /**
-     * Sets the write position to the specified offset. It has the side effect of ensuring the position is within the current byteStore chunk between the start and soft limit.
-     * It uses the safe limit instead of the hard limit to allow large writes in a single blob without having to check the hard limit unnecessarily.
-     * @param position the new write position, must be non-negative
-     * @return this Bytes instance for method chaining
+     * Move the write position to {@code position}, loading the correct chunk if needed.
+     * <p>
+     * Uses the chunk’s safe upper bound so we can safely write a significant block of data after this without checking the size regularly.
+     *
+     * @param position new write position (>= 0)
+     * @return this instance
      */
+    @NotNull
     @Override
-    public @NotNull Bytes<Void> writePosition(long position) throws BufferOverflowException {
+    public Bytes<Void> writePosition(long position) throws BufferOverflowException {
         // use the safe limit of the byteStore to ensure we can write something after it
         if (!bytesStore.inside(position)) {
             acquireNextByteStore0(position, false);
@@ -365,6 +378,8 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
     private synchronized @NotNull MappedBytesStore acquireNextByteStore0(@NonNegative final long offset, final boolean set)
             throws ClosedIllegalStateException, ThreadingIllegalStateException {
         throwExceptionIfClosed();
+        if (LOG.isDebugEnabled())
+            Jvm.debug().on(LOG, Integer.toHexString(System.identityHashCode(this)) + ", file: " + mappedFile.file().getName() + ", offset: 0x" + Long.toHexString(offset) + ", read: " + set);
 
         @Nullable final BytesStore<?, ?> oldBS = this.bytesStore;
         @NotNull final MappedBytesStore newBS;

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -170,6 +170,12 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         return readPosition(position);
     }
 
+    /**
+     * Sets the read position to the specified offset. It has the side effect of ensuring the position is within the current byteStore chunk between the start and hard limit.
+     * It uses the hard limit instead of the safe limit to avoid changing or resizing the underlying file unnecessarily.
+     * @param position the new read position, must be non-negative
+     * @return this Bytes instance for method chaining
+     */
     @NotNull
     @Override
     public Bytes<Void> readPosition(@NonNegative final long position)
@@ -184,6 +190,12 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         }
     }
 
+    /**
+     * Sets the write limit to the specified offset. It has the side effect of ensuring the limit is within the current byteStore chunk between the start and hard limit.
+     * It uses the hard limit instead of the safe limit to avoid changing or resizing the underlying file unnecessarily.
+     * @param limit the new write limit, must be non-negative
+     * @return this Bytes instance for method chaining
+     */
     @Override
     public @NotNull Bytes<Void> writeLimit(long limit) throws BufferOverflowException {
         // use the real limit of the byteStore rather than the safe limit to minimise resizing
@@ -193,6 +205,12 @@ public class ChunkedMappedBytes extends CommonMappedBytes {
         return super.writeLimit(limit);
     }
 
+    /**
+     * Sets the write position to the specified offset. It has the side effect of ensuring the position is within the current byteStore chunk between the start and soft limit.
+     * It uses the safe limit instead of the hard limit to allow large writes in a single blob without having to check the hard limit unnecessarily.
+     * @param position the new write position, must be non-negative
+     * @return this Bytes instance for method chaining
+     */
     @Override
     public @NotNull Bytes<Void> writePosition(long position) throws BufferOverflowException {
         // use the safe limit of the byteStore to ensure we can write something after it

--- a/src/test/java/net/openhft/chronicle/bytes/CheckOverSizedMessagesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CheckOverSizedMessagesTest.java
@@ -268,28 +268,4 @@ public class CheckOverSizedMessagesTest extends BytesTestCommon {
             assertNotSame(bs0, bs2);
         }
     }
-
-    @Test
-    public void parse8bit() {
-        Bytes<?> in = Bytes.wrapForRead(BYTE6K);
-        try (MappedBytes mb = mbNoOverlap()) {
-            mb.writePosition(3 << 10);
-            final BytesStore<?, Void> bs0 = mb.bytesStore();
-            in.parse8bit(mb, StopCharTesters.ALL);
-            final BytesStore<?, Void> bs2 = mb.bytesStore();
-            assertNotSame(bs0, bs2);
-        }
-    }
-
-    @Test
-    public void parseUTF8() {
-        Bytes<?> in = Bytes.wrapForRead(BYTE6K);
-        try (MappedBytes mb = mbNoOverlap()) {
-            mb.writePosition(3 << 10);
-            final BytesStore<?, Void> bs0 = mb.bytesStore();
-            in.parseUtf8(mb, StopCharTesters.ALL);
-            final BytesStore<?, Void> bs2 = mb.bytesStore();
-            assertNotSame(bs0, bs2);
-        }
-    }
 }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
@@ -42,36 +42,35 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
     private final ReadWrite rw;
     private final Consumer<Bytes<?>> doit;
 
-    public MappedBytesEdgeTest(int size, ReadWrite rw, Consumer<Bytes<?>> doit) {
+    public MappedBytesEdgeTest(int size, ReadWrite rw, String name, Consumer<Bytes<?>> doit) {
         this.size = size;
         this.rw = rw;
         this.doit = doit;
     }
 
-    @Parameterized.Parameters(name = "size {0} rw {1} lambda {2}")
+    @Parameterized.Parameters(name = "size {0} rw {1} op {2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                {1, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::peekUnsignedByte)},
-                {4, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::readInt)},
-                {4, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::readVolatileInt)},
-                {4, ReadWrite.READ, (Consumer<Bytes<?>>) (RandomDataInput::peekVolatileInt)},
-                {8, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::readLong)},
-                {8, ReadWrite.READ, (Consumer<Bytes<?>>) (StreamingDataInput::readDouble)},
-                {256, ReadWrite.READ, (Consumer<Bytes<?>>) (b -> b.read(unmonitored(Bytes.allocateDirect(256))))},
-                {512, ReadWrite.READ, (Consumer<Bytes<?>>) (b -> b.read(ByteBuffer.allocate(512)))},
-                {1024, ReadWrite.READ, (Consumer<Bytes<?>>) (b -> b.read(new byte[1024]))},
+                {1, ReadWrite.PEEK, "peekUnsignedByte", (Consumer<Bytes<?>>) (StreamingDataInput::peekUnsignedByte)},
+                {4, ReadWrite.READ, "readInt", (Consumer<Bytes<?>>) (StreamingDataInput::readInt)},
+                {4, ReadWrite.READ, "readVolatileInt", (Consumer<Bytes<?>>) (StreamingDataInput::readVolatileInt)},
+                {4, ReadWrite.PEEK, "peekVolatileInt", (Consumer<Bytes<?>>) (RandomDataInput::peekVolatileInt)},
+                {8, ReadWrite.READ, "readLong", (Consumer<Bytes<?>>) (StreamingDataInput::readLong)},
+                {8, ReadWrite.READ, "readDouble", (Consumer<Bytes<?>>) (StreamingDataInput::readDouble)},
+                {256, ReadWrite.READ, "read(unmonitored(Bytes.allocateDirect(256)))", (Consumer<Bytes<?>>) (b -> b.read(unmonitored(Bytes.allocateDirect(256))))},
+                {512, ReadWrite.READ, "read(ByteBuffer.allocate(512))", (Consumer<Bytes<?>>) (b -> b.read(ByteBuffer.allocate(512)))},
+                {1024, ReadWrite.READ, "read(new byte[1024])", (Consumer<Bytes<?>>) (b -> b.read(new byte[1024]))},
 
-                {1, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeByte((byte) 99))},
-                {2, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeShort((short) 123))},
-                {4, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeInt(1234))},
-                {4, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeOrderedInt(1234))},
-                {8, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeLong(1234))},
-                {8, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.writeDouble(1234))},
-                {6, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.write8bit("hello"))},
-                {7, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.appendUtf8("doggie"))},
-                {10, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.write(Bytes.from("armadillo")))},
+                {1, ReadWrite.WRITE, "writeByte", (Consumer<Bytes<?>>) (b -> b.writeByte((byte) 99))},
+                {2, ReadWrite.WRITE, "writeShort", (Consumer<Bytes<?>>) (b -> b.writeShort((short) 123))},
+                {4, ReadWrite.WRITE, "writeInt", (Consumer<Bytes<?>>) (b -> b.writeInt(1234))},
+                {4, ReadWrite.WRITE, "writeOrderedInt", (Consumer<Bytes<?>>) (b -> b.writeOrderedInt(1234))},
+                {8, ReadWrite.WRITE, "writeLong", (Consumer<Bytes<?>>) (b -> b.writeLong(1234))},
+                {8, ReadWrite.WRITE, "writeDouble", (Consumer<Bytes<?>>) (b -> b.writeDouble(1234))},
+                {6, ReadWrite.WRITE, "write8bit", (Consumer<Bytes<?>>) (b -> b.write8bit("hello"))},
+                {7, ReadWrite.WRITE, "appendUtf8", (Consumer<Bytes<?>>) (b -> b.appendUtf8("doggie"))},
+                {10, ReadWrite.WRITE, "write", (Consumer<Bytes<?>>) (b -> b.write(Bytes.from("armadillo")))},
                 // {1024, ReadWrite.WRITE, (Consumer<Bytes<?>>) (b -> b.write(new byte[1024]))}, // <-- this behaves differently, it won't start a write in the offset
-
         });
     }
 
@@ -91,11 +90,12 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
         }
         try (final MappedBytes bytes = MappedBytes.mappedBytes(tempMBFile, CHUNK_SIZE, overlap)) {
             // map in the real file
+            bytes.writeInt((3 * CHUNK_SIZE) - 4, 1);
             bytes.writePosition(0).writeByte((byte) 0);
             assertEquals(0, bytes.bytesStore().start());
 
             if (rw == ReadWrite.WRITE) {
-                checkWritePosition(bytes, CHUNK_SIZE + overlap - size, 0);
+                checkWritePosition(bytes, CHUNK_SIZE + overlap - size, CHUNK_SIZE);
                 checkWritePosition(bytes, CHUNK_SIZE + overlap, CHUNK_SIZE);
                 checkWritePosition(bytes, CHUNK_SIZE + overlap + size, CHUNK_SIZE);
                 // go back to just before the overlap - will still be in second chunk
@@ -104,7 +104,7 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
                 // now try and write over the end of the chunk
                 checkWritePosition(bytes, CHUNK_SIZE - 1, 0);
                 // and end of chunk plus offset
-                checkWritePosition(bytes, CHUNK_SIZE + overlap - 1, size > 1 ? CHUNK_SIZE : 0);
+                checkWritePosition(bytes, CHUNK_SIZE + overlap - 1,  CHUNK_SIZE);
 
                 if (size > 1) {
                     // load the first chunk
@@ -121,8 +121,8 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
                 bytes.writePosition(CHUNK_SIZE * 5);
 
                 checkReadPosition(bytes, CHUNK_SIZE - size, 0);
-                checkReadPosition(bytes, CHUNK_SIZE, CHUNK_SIZE);
-                checkReadPosition(bytes, CHUNK_SIZE + size, CHUNK_SIZE);
+                checkReadPosition(bytes, CHUNK_SIZE, 0);
+                checkReadPosition(bytes, CHUNK_SIZE + size, 0);
                 checkReadPosition(bytes, CHUNK_SIZE - size, 0);
 
                 if (size > 1) {
@@ -160,6 +160,7 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
     }
 
     protected enum ReadWrite {
+        PEEK,
         READ,
         WRITE
     }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
@@ -48,7 +48,7 @@ public class MappedBytesEdgeTest extends BytesTestCommon {
         this.doit = doit;
     }
 
-    @Parameterized.Parameters(name = "size {0} rw {1} op {2}")
+    @Parameterized.Parameters(name = "{2} size={0} rw={1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {1, ReadWrite.PEEK, "peekUnsignedByte", (Consumer<Bytes<?>>) (StreamingDataInput::peekUnsignedByte)},


### PR DESCRIPTION
Prior to this change, both read position changes could drive new chunks and in turn file resizing, leading to unexpected growth even on read operations. This PR tightens the logic so that:

* **Reads** only advance across chunks when absolutely necessary (hard limit), without touching file size.
* **Writes** (both limit and position) drive chunk acquisition and file growth as needed.

---

## What’s Changed

1. **ChunkedMappedBytes.java**

   * Refined Javadoc on `readPosition`, `writeLimit`, and `writePosition` to focus on API contract.
   * **New overrides** for `writeLimit(long)` and `writePosition(long)` that invoke `acquireNextByteStore0(...)` under the appropriate conditions, ensuring only writes trigger chunk loads and file extends.
   * `readPosition(long)` now uses the **hard** limit (`inside(pos,0)`) to avoid spurious chunk swaps.

2. **Tests Cleanup**

   * **CheckOverSizedMessagesTest**: Removed `parse8bit`/`parseUtf8` tests as it is unclear what their intent was.
   * **MappedBytesEdgeTest**:

     * Corrected expected chunk boundaries for read vs write scenarios.
     * Introduced a `"PEEK"` enum for non-mutating read checks.
     * Updated parameterized test display names to include operation names.

---

## Why This Matters

* **Performance & Stability**: Prevents readers from inadvertently growing the mapped file, reducing race conditions, disk I/O, and avoiding “surprise” file extends.
* **Correctness**: Ensures writes remain the sole driver of file resizing.
* **Observability**: New `DEBUG` logs provide detailed insight into chunk swaps when troubleshooting.

Related PR: https://github.com/OpenHFT/Chronicle-Queue/pull/1667