### PR TITLE
Improve handling of ISO_8859-1 data (8-bit text)

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -646,7 +646,7 @@ public interface Bytes<U> extends
             try {
                 @NotNull final StringBuilder builder = new StringBuilder();
                 while (buffer.readRemaining() > 0) {
-                    builder.append((char) buffer.readByte());
+                    builder.append((char) buffer.readUnsignedByte());
                 }
 
                 // remove the last comma

--- a/src/test/java/net/openhft/chronicle/bytes/Bytes3Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Bytes3Test.java
@@ -265,4 +265,19 @@ public class Bytes3Test extends BytesTestCommon {
     public void writeUtf8FromBytes() {
         doAppend((b, s) -> b.writeUtf8(Bytes.from(s)));
     }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void toString8bit() {
+        if (forRead) return;
+        bytes = supplier.get();
+        for (char ch = 0; ch < 256; ch++) {
+            bytes.writeUnsignedByte(ch);
+        }
+        String s = bytes.toString();
+        for (char ch = 0; ch < 256; ch++) {
+            assertEquals("Character mismatch at index " + ch + " in: " + s, ch, s.charAt(ch));
+        }
+        assertEquals("Expected 256 characters, but got: " + s.length(), 256, s.length());
+    }
 }


### PR DESCRIPTION
Currently, `Bytes.toString()` reads each byte via `buffer.readByte()` and casts it directly to `char`. Because `readByte()` returns a signed `byte`, any value ≥ 0x80 (128) is interpreted as negative, resulting in sign-extension when cast to `char`. As a result, high-bit characters in ISO-8859-1 (Latin-1) sequences—common in many legacy and European encodings—are corrupted in the output `String`.

### What’s Changed

* **Use unsigned byte values** when constructing the `StringBuilder` in `Bytes.toString()`:

  * **Old:**

    ```java
    builder.append((char) buffer.readByte());
    ```
  * **New:**

    ```java
    builder.append((char) buffer.readUnsignedByte());
    ```

  Casting from `readUnsignedByte()` preserves the 0–255 range, ensuring all ISO-8859-1 characters map correctly to Java’s `char` values.

* **Added unit test** `toString8bit()` in `Bytes3Test` to verify full round-trip of all 256 possible byte values:

  * Writes bytes 0–255 via `writeUnsignedByte(ch)`
  * Calls `toString()`
  * Asserts that each character in the resulting `String` matches its original byte value, and that the total length is 256

### Impact

* **Correctness**: All 8-bit ISO-8859-1 characters are now faithfully reproduced by `toString()`.
* **Backward Compatibility**: No change to existing APIs; behavior is only corrected for high-bit values.
* **Performance**: Negligible overhead—`readUnsignedByte()` is as efficient as `readByte()`.
