### PR TITLE
Refresh copyright headers to 2025 and tidy license comments

### DIFF
--- a/docs/images/source/Figure1.svg
+++ b/docs/images/source/Figure1.svg
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  - Copyright 2016-2022 chronicle.software
-  -
-  - https://chronicle.software
+  - Copyright 2016-2025 chronicle.software
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,7 +1,5 @@
 Copyright (c) 2016-${currentYear} chronicle.software
 
-    https://chronicle.software
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016-${currentYear} chronicle.software
+Copyright 2016-${currentYear} chronicle.software
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/license_header_def.xml
+++ b/license_header_def.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2016-2022 chronicle.software
-
-        https://chronicle.software
+    Copyright 2016-2025 chronicle.software
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/license_header_def.xml
+++ b/license_header_def.xml
@@ -24,7 +24,7 @@
         <afterEachLine> </afterEachLine>
         <firstLineDetectionPattern>(\s|\t)*/\*.*$</firstLineDetectionPattern>
         <lastLineDetectionPattern>.*\*/(\s|\t)*$</lastLineDetectionPattern>
-        <allowBlankLines>false</allowBlankLines>
+        <allowBlankLines>true</allowBlankLines>
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>
     </javadoc_style>

--- a/microbenchmarks/pom.xml
+++ b/microbenchmarks/pom.xml
@@ -1,8 +1,6 @@
 <!--
 
-    Copyright (c) 2016-2022 chronicle.software
-
-        https://chronicle.software
+    Copyright 2016-2025 chronicle.software
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/AppendDoubleBenchmark.java
+++ b/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/AppendDoubleBenchmark.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/AppendLongCoolerMain.java
+++ b/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/AppendLongCoolerMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/BytesCoolerMain.java
+++ b/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/BytesCoolerMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/DistributedUniqueTimeProviderBenchmark.java
+++ b/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/DistributedUniqueTimeProviderBenchmark.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/GenParseMain.java
+++ b/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/GenParseMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/jmh/ElasticBenchmarkRunner.java
+++ b/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/jmh/ElasticBenchmarkRunner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/jmh/ElasticByteBufferJmh.java
+++ b/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/jmh/ElasticByteBufferJmh.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/jmh/ElasticDirectJmh.java
+++ b/microbenchmarks/src/main/java/net/openhft/chronicle/bytes/microbenchmarks/jmh/ElasticDirectJmh.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microbenchmarks/system.properties
+++ b/microbenchmarks/system.properties
@@ -1,7 +1,5 @@
 #
-# Copyright (c) 2016-2022 chronicle.software
-#
-#     https://chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -292,20 +292,15 @@
                 <configuration>
                     <header>license_header.txt</header>
                     <properties>
-                        <currentYear>2022</currentYear>
+                        <currentYear>2025</currentYear>
                     </properties>
                     <headerDefinitions>
                         <headerDefinition>license_header_def.xml</headerDefinition>
                     </headerDefinitions>
                     <excludes>
-                        <exclude>**/README</exclude>
-                        <exclude>**/README.md</exclude>
                         <exclude>**/package-info.java</exclude>
                         <exclude>**/*.versionsBackup</exclude>
-                        <exclude>CONTRIBUTOR_LICENSE_AGREEMENT</exclude>
                         <exclude>LICENSE</exclude>
-                        <exclude>DISCLAIMER</exclude>
-                        <exclude>THIRD_PARTY_LICENSES</exclude>
                         <exclude>src/test/resources/**</exclude>
                         <exclude>src/main/resources/**</exclude>
                     </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016-2022 chronicle.software
-
-        https://chronicle.software
+    Copyright 2016-2025 chronicle.software
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AbstractBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryWireCode.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryWireCode.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ByteStringAppender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ByteStringAppender.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ByteStringParser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ByteStringParser.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/Byteable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Byteable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesConsumer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesContext.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesContext.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesIn.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesIn.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMarshallable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMarshaller.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMethodReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMethodReaderBuilder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesMethodWriterInvocationHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesOut.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesParselet.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesParselet.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesPrepender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesPrepender.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesRingBuffer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesRingBuffer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesRingBufferStats.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesRingBufferStats.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesTextMethodTester.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesTextMethodTester.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/CommonMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/CommonMarshallable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ConnectionDroppedException.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ConnectionDroppedException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeDeduplicator.java
+++ b/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeDeduplicator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProvider.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/DynamicallySized.java
+++ b/src/main/java/net/openhft/chronicle/bytes/DynamicallySized.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/FieldGroup.java
+++ b/src/main/java/net/openhft/chronicle/bytes/FieldGroup.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/GuardedNativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/GuardedNativeBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/HexDumpBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/HexDumpBytesDescription.java
+++ b/src/main/java/net/openhft/chronicle/bytes/HexDumpBytesDescription.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/Invocation.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Invocation.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytesStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MappedBytesStoreFactory.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedBytesStoreFactory.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedFile.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MappedUniqueTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MappedUniqueTimeProvider.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodEncoder.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodEncoder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodEncoderLookup.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodEncoderLookup.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodId.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodId.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodReaderBuilder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodReaderInterceptorReturns.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodReaderInterceptorReturns.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodWriterBuilder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodWriterInterceptorReturns.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodWriterInterceptorReturns.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MethodWriterInvocationHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/MultiReaderBytesRingBuffer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/MultiReaderBytesRingBuffer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NativeBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/NewChunkListener.java
+++ b/src/main/java/net/openhft/chronicle/bytes/NewChunkListener.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/OffsetFormat.java
+++ b/src/main/java/net/openhft/chronicle/bytes/OffsetFormat.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/OnHeapBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/OnHeapBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/PageUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/PageUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/PointerBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/PointerBytesStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/RandomCommon.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomCommon.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataInput.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/RandomDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RandomDataOutput.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ReadBytesMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ReadBytesMarshallable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/RingBufferReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RingBufferReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/RingBufferReaderStats.java
+++ b/src/main/java/net/openhft/chronicle/bytes/RingBufferReaderStats.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/StopCharTester.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StopCharTester.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/StopCharTesters.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StopCharTesters.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/StopCharsTester.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StopCharsTester.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingCommon.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingCommon.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataInput.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingDataOutput.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingInputStream.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingInputStream.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/StreamingOutputStream.java
+++ b/src/main/java/net/openhft/chronicle/bytes/StreamingOutputStream.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/SubBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/SyncMode.java
+++ b/src/main/java/net/openhft/chronicle/bytes/SyncMode.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/UTFDataFormatRuntimeException.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UTFDataFormatRuntimeException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/UncheckedNativeBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UncheckedNativeBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/UpdateInterceptor.java
+++ b/src/main/java/net/openhft/chronicle/bytes/UpdateInterceptor.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/VanillaBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/WriteBytesMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/bytes/WriteBytesMarshallable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/BytesStoreHash.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHash.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/VanillaBytesStoreHash.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
+++ b/src/main/java/net/openhft/chronicle/bytes/algo/XxHash.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLock.java
+++ b/src/main/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLock.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/AbstractBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/AbstractBytesStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ByteBuffers.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ByteBuffers.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ByteStringReader.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ByteStringReader.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ByteStringWriter.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ByteStringWriter.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesFieldInfo.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/CanonicalPathUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/CanonicalPathUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/Chars.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/Chars.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ChunkedMappedFile.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/CommonMappedBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/EmbeddedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/EmbeddedBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/HasUncheckedRandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/HasUncheckedRandomDataInput.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/HeapBytesStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/NativeBytesStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -955,11 +953,11 @@ public class NativeBytesStore<U>
     }
 
     private final class Finalizer {
-        @SuppressWarnings({"deprecation", "removal"})
-        @Override
         /*
          * This finalize() is used to detect when a component is not released deterministically. It is not required to be run, but provides a warning
          */
+        @Override
+        @SuppressWarnings({"deprecation", "removal"})
         protected void finalize()
                 throws Throwable {
             super.finalize();

--- a/src/main/java/net/openhft/chronicle/bytes/internal/NoBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/NoBytesStore.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/ReferenceCountedUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/ReferenceCountedUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/SingleMappedFile.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/UncheckedRandomDataInput.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/UncheckedRandomDataInput.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/Unmapper.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/Unmapper.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/UnsafeText.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/UnsafeText.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/migration/HashCodeEqualsUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/migration/HashCodeEqualsUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/package-info.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
+++ b/src/main/java/net/openhft/chronicle/bytes/pool/BytesPool.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/AbstractReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryBooleanReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryIntReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryLongReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/BinaryTwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/BinaryTwoLongReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableIntArrayValues.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/ByteableLongArrayValues.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/LongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/LongReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextBooleanReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntArrayReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextIntReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongArrayReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TextLongReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/TwoLongReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
+++ b/src/main/java/net/openhft/chronicle/bytes/ref/UncheckedLongReference.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/render/DecimalAppender.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/DecimalAppender.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/render/Decimaliser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/Decimaliser.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/render/GeneralDecimaliser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/GeneralDecimaliser.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/render/MaximumPrecision.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/MaximumPrecision.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/render/SimpleDecimaliser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/SimpleDecimaliser.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/render/StandardDecimaliser.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/StandardDecimaliser.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/render/UsesBigDecimal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/render/UsesBigDecimal.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/AbstractInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/AbstractInterner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/BinaryLengthLength.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/BinaryLengthLength.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/Bit8StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Bit8StringInterner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/Compression.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Compression.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/Compressions.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/Compressions.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/DecoratedBufferOverflowException.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/DecoratedBufferOverflowException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/DecoratedBufferUnderflowException.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/DecoratedBufferUnderflowException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/EscapingStopCharTester.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/EscapingStopCharTester.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/EscapingStopCharsTester.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/EscapingStopCharsTester.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/StringInternerBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/bytes/util/UTF8StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/UTF8StringInterner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/AbstractBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/AbstractBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/AllocationRatesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/AllocationRatesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Allocator.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Allocator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ByteCheckSumTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteCheckSumTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ByteStringAppenderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStringAppenderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ByteStringParserTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStringParserTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ByteableTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Bytes2Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Bytes2Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Bytes3Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Bytes3Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Bytes4Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Bytes4Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesCompactTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesCompactTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesContextTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesContextTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesEqualityTests.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesEqualityTests.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesFactoryUtil.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesFactoryUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesJavaDocComplianceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesJavaDocComplianceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesMarshallableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesMarshallerTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesMarshallerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesMethodReaderBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesMethodReaderBuilderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesMethodWriterBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesMethodWriterBuilderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesPrimitiveParameterTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesPrimitiveParameterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesReleaseInvariantNonPerformantMethodsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesReleaseInvariantNonPerformantMethodsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesReleaseInvariantObjectTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesReleaseInvariantObjectTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesRingBufferTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesRingBufferTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTestCommon.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTextMethodTesterTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTextMethodTesterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/CheckOverSizedMessagesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CheckOverSizedMessagesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/CipherPerfMain.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CipherPerfMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/CommonMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CommonMarshallableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ConcurrentRafAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ConcurrentRafAccessTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ConnectionDroppedExceptionTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ConnectionDroppedExceptionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ContentEqualsJLBHTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ContentEqualsJLBHTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/CopyBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CopyBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/CopyToTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/CopyToTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProviderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/GuardedNativeBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/GuardedNativeBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/HeapByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/HeapByteStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/HexDumpBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/HexDumpBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/IBytesMethod.java
+++ b/src/test/java/net/openhft/chronicle/bytes/IBytesMethod.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ISO88591CharsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ISO88591CharsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Issue128Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Issue128Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Issue225Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Issue225Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Issue281Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Issue281Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Issue523Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Issue523Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/Issue85Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Issue85Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/LockingByteableTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/LockingByteableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesEdgeTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesStoreFactoryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesStoreFactoryTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileMultiThreadTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MappedMemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedMemoryTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MappedUniqueTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedUniqueTimeProviderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MethodReaderBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MethodReaderBuilderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MoreBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MoreBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MultiReaderBytesRingBufferTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MultiReaderBytesRingBufferTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MyByteable.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MyByteable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MyBytes.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MyBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MyNested.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MyNested.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/MyScalars.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MyScalars.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/NativeBytesOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NativeBytesOverflowTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/NativeBytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NativeBytesStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/NativeBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NativeBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/NotNullHandlingTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NotNullHandlingTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/PageUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/PageUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/PointerBytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/PointerBytesStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/PrewriteTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/PrewriteTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/PrintVdsoMain.java
+++ b/src/test/java/net/openhft/chronicle/bytes/PrintVdsoMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ReadLenientTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ReadLenientTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ReadWriteMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ReadWriteMarshallableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ReleasedBytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ReleasedBytesStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/RingBufferReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/RingBufferReaderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StopBitDecimalTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StopBitDecimalTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StopBitTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StopBitTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StopCharTesterTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StopCharTesterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StopCharsTesterTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StopCharsTesterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StreamingDataInputTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StreamingDataInputTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StreamingInputStreamTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StreamingInputStreamTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StreamingOutputStreamTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StreamingOutputStreamTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StringRWPerfTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StringRWPerfTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/StructTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StructTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/SyncModeTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/SyncModeTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/UTF8BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UTF8BytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/UncheckedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UncheckedBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/UncheckedNativeBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UncheckedNativeBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/UnicodeToStringTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UnicodeToStringTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/UnsafeRWObjectTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UnsafeRWObjectTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/UnsafeTextBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UnsafeTextBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/VanillaBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/VanillaBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/WriteLimitTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/WriteLimitTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ZeroCostAssertionStatusTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ZeroCostAssertionStatusTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHashTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/algo/OptimisedBytesStoreHashTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/algo/XxHashTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/algo/XxHashTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLockTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/domestic/ReentrantFileLockTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesFieldInfoTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesFieldInfoTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalContentEqualsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalContentEqualsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalGuardedTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalGuardedTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/DecimaliserDoubleTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/DecimaliserDoubleTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/DecimaliserFloatTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/DecimaliserFloatTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/EmptyBytesStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/EmptyBytesStoreTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/ReferenceCountedUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/ReferenceCountedUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/ResourceUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/ResourceUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/internal/UnsafeTextTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/UnsafeTextTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/issue/AppendDoubleTicket1808Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/issue/AppendDoubleTicket1808Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/issue/Issue384ReplaceByteStoreOnEmptyArrayTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/issue/Issue384ReplaceByteStoreOnEmptyArrayTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/issue/Issue462Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/issue/Issue462Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/issue/Issue464BytesStoreEmptyTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/issue/Issue464BytesStoreEmptyTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/jitter/MemoryMessager.java
+++ b/src/test/java/net/openhft/chronicle/bytes/jitter/MemoryMessager.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/jitter/MemoryReadJitterMain.java
+++ b/src/test/java/net/openhft/chronicle/bytes/jitter/MemoryReadJitterMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/jitter/MemoryWriteJitterMain.java
+++ b/src/test/java/net/openhft/chronicle/bytes/jitter/MemoryWriteJitterMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/BytesReadWriteJLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/BytesReadWriteJLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ChunkedMappedBytesReadWriteJLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ChunkedMappedBytesReadWriteJLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual128JLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual128JLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual20JLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual20JLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual2JLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual2JLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual8192JLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqual8192JLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqualJLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/ContentEqualJLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/MMapPingPongMain.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/MMapPingPongMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/NativeBytesReadWriteJLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/NativeBytesReadWriteJLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/OnHeapBytesReadWriteJLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/OnHeapBytesReadWriteJLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/perf/SingleMappedBytesReadWriteJLBH.java
+++ b/src/test/java/net/openhft/chronicle/bytes/perf/SingleMappedBytesReadWriteJLBH.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/pool/BytesPoolTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/pool/BytesPoolTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/readme/CASTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/readme/CASTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/readme/PrimitiveTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/readme/PrimitiveTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/readme/StopBitTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/readme/StopBitTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/readme/StringsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/readme/StringsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/BinaryIntArrayReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/BinaryIntReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/BinaryIntReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/BinaryLongArrayReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/BinaryLongReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/BinaryLongReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/BinaryTwoLongReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/BinaryTwoLongReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/BooleanReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/BooleanReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/ByteableReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/ByteableReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/TextIntArrayReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/TextIntArrayReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/TextIntReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/TextIntReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/TextLongArrayReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/TextLongArrayReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/TextLongReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/TextLongReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/ref/UncheckedLongReferenceTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/UncheckedLongReferenceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/AbstractInternerTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/AbstractInternerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/BinaryLengthLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/BinaryLengthLengthTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/Bit8StringInternerTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/Bit8StringInternerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/CompressionTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/CompressionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/CompressionsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/CompressionsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/DecoratedBufferOverflowExceptionTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/DecoratedBufferOverflowExceptionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/EscapingStopCharTesterTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/EscapingStopCharTesterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/EscapingStopCharsTesterTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/EscapingStopCharsTesterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/GzipTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/GzipTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/LZWTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/LZWTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/PropertyReplacerTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/PropertyReplacerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/bytes/util/StringInternerBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/util/StringInternerBytesTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
- *
- *     https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/system.properties
+++ b/system.properties
@@ -1,7 +1,5 @@
 #
-# Copyright (c) 2016-2022 chronicle.software
-#
-#     https://chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates project copyright headers to reflect **2016–2025** and removes the redundant `https://chronicle.software` line from header blocks across the codebase. It also tidies a small annotation placement in an internal class and aligns ancillary files (POM, system properties, SVG attribution, license header templates).

## What changed

* **Copyright year bump** from `2016–2022` → `2016–2025` in:

  * Source files under `src/main/java/**` and `src/test/java/**`
  * Internal/utility packages (`internal/**`, `ref/**`, `render/**`, `util/**`, etc.)
  * Microbenchmarks sources and `pom.xml`
  * `license_header.txt` and `license_header_def.xml`
  * `system.properties`
  * `docs/images/source/Figure1.svg` header
* **Removed website line** (`https://chronicle.software`) from header comments where present.
* **Style-only tweak** in `NativeBytesStore.java`:

  * Reordered the `@Override` and `@SuppressWarnings` annotations around `Finalizer.finalize()` to follow the comment block more cleanly; no logic changes.

## Functional impact

**None.**

* All edits are within comment blocks, license templates, or header metadata.
* The `finalize()` method still carries the same annotations and implementation; only annotation order relative to the comment changed. Java behavior is unaffected.

## Rationale

* Keep legal notices current for the 2025 cycle.
* Simplify headers by removing a non-essential URL line.
* Maintain consistent header style across all modules and docs.