### PR TITLE
Stabilise coverage + JPMS flags in test runs; tidy build; document Sonar/generics intent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 
@@ -146,7 +145,7 @@
 
     <build>
         <plugins>
-
+            <!-- SortPom moved to an opt-in profile to avoid automatic sorting during normal builds -->
             <plugin>
                 <groupId>net.openhft</groupId>
                 <artifactId>binary-compatibility-enforcer-plugin</artifactId>
@@ -177,16 +176,6 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>4</forkCount>
-                    <reuseForks>true</reuseForks>
-                    <runOrder>hourly</runOrder>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
 
                 <configuration>
@@ -212,6 +201,23 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>chronicle.bytes</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
             <!--
                 generate maven dependencies versions file that can be used later
                 to install the right bundle in test phase.
@@ -231,6 +237,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Include JaCoCo argLine when present and required JPMS flags from parent -->
+                    <argLine>${argLine} ${jvm.requiredArgs}</argLine>
+                    <forkCount>4</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <runOrder>hourly</runOrder>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -263,23 +281,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                        </manifest>
-                        <manifestEntries>
-                            <Automatic-Module-Name>chronicle.bytes</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -375,24 +376,36 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.sonarsource.scanner.maven</groupId>
+                        <artifactId>sonar-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <!-- Include JPMS flags from parent and coverage flag for sonar runs -->
+                            <argLine>${argLine} ${jvm.requiredArgs} -Djvm.coverage=true</argLine>
+                            <!-- Use a single fork to ensure JaCoCo agent reliably writes execution data -->
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <!--<exclude>META-INF/**</exclude>-->
-                                <exclude>*.jar</exclude>
-                                <!--                                <exclude>net/openhft/chronicle/bytes/AbstractBytes.class</exclude>
-                                                                <exclude>net/openhft/chronicle/bytes/AppendableUtil.class</exclude>
-                                                                <exclude>net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.class</exclude>
-                                                                <exclude>net/openhft/chronicle/bytes/BinaryWireCode.class</exclude>
-                                                                <exclude>net/openhft/chronicle/bytes/*.class</exclude>-->
-                            </excludes>
-                        </configuration>
+                        <version>${jacoco-maven-plugin.version}</version>
                         <executions>
                             <execution>
+                                <id>prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
+                                <phase>initialize</phase>
+                                <configuration>
+                                    <!-- Ensure exec is written even with forks; reuse the default dest -->
+                                    <append>true</append>
+                                    <destFile>${project.build.directory}/jacoco.exec</destFile>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>report</id>
@@ -403,10 +416,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.sonarsource.scanner.maven</groupId>
-                        <artifactId>sonar-maven-plugin</artifactId>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -415,15 +424,8 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <pom>microbenchmarks/pom.xml</pom>
                             <goals>clean,integration-test</goals>
@@ -436,6 +438,14 @@
                             </properties>
                             <streamLogs>true</streamLogs>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
@@ -563,5 +573,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BinaryBytesMethodWriterInvocationHandler.java
@@ -42,6 +42,7 @@ public class BinaryBytesMethodWriterInvocationHandler extends AbstractInvocation
      * write position is rolled back to preserve stream integrity.
      */
     @Override
+    @SuppressWarnings("java:S1181") // Reset writePosition on any Throwable to preserve stream integrity; rethrow immediately
     protected Object doInvoke(Object proxy, Method method, Object[] args)
             throws IllegalStateException, BufferOverflowException, BufferUnderflowException, IllegalArgumentException, ArithmeticException, InvalidMarshallableException {
         MethodEncoder info = methodToIdMap.computeIfAbsent(method, methodToId);

--- a/src/main/java/net/openhft/chronicle/bytes/Bytes.java
+++ b/src/main/java/net/openhft/chronicle/bytes/Bytes.java
@@ -474,8 +474,11 @@ public interface Bytes<U> extends
     }
 
     /**
-     * Allocate an elastic bytes as direct if available, or on heap if not.
+     * Returns an elastic Bytes, preferring direct when available. The underlying store type depends
+     * on the runtime (direct or heap), so the return uses a wildcard. Prefer calling
+     * {@link #allocateElasticDirect()} or {@link #allocateElasticOnHeap()} for a concrete type.
      */
+    @SuppressWarnings("java:S1452")
     static Bytes<?> allocateElastic() {
         return Jvm.maxDirectMemory() == 0 ? allocateElasticOnHeap() : allocateElasticDirect();
     }
@@ -504,9 +507,11 @@ public interface Bytes<U> extends
     }
 
     /**
-     * Allocate an elastic bytes as direct if available, or on heap if not.
-     * @param initialCapacity to allocate
+     * Returns an elastic Bytes with an initial capacity. The underlying store type depends on the
+     * runtime (direct or heap), so the return uses a wildcard. Prefer calling
+     * {@link #allocateElasticDirect(long)} or {@link #allocateElasticOnHeap(int)} for a concrete type.
      */
+    @SuppressWarnings("java:S1452")
     static Bytes<?> allocateElastic(@NonNegative int initialCapacity) {
         return Jvm.maxDirectMemory() == 0 ? allocateElasticOnHeap(initialCapacity) : allocateElasticDirect(initialCapacity);
     }

--- a/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
+++ b/src/main/java/net/openhft/chronicle/bytes/BytesStore.java
@@ -40,13 +40,15 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
         extends RandomDataInput, RandomDataOutput<B>, ReferenceCounted, CharSequence {
 
     /**
-     * Converts a CharSequence into a BytesStore. The characters are encoded using ISO_8859_1.
+     * Converts a CharSequence into a BytesStore. The component type depends on the input,
+     * hence the wildcard in the return. Prefer using the typed overloads when possible.
      *
      * @param cs the CharSequence to be converted
      * @return a BytesStore which contains the bytes from the CharSequence
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way.
      */
+    @SuppressWarnings("java:S1452")
     static BytesStore<?, ?> from(@NotNull CharSequence cs) throws ClosedIllegalStateException, ThreadingIllegalStateException {
         if (cs.length() == 0)
             return empty();
@@ -101,9 +103,11 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
     }
 
     /**
-     * Takes ownership of {@code bb} and returns a store backed by it. Closing
-     * the store will deallocate the buffer if it is direct.
+     * Takes ownership of {@code bb} and returns a store backed by it. The wildcard is used for the
+     * store type parameter; for strict typing use {@link NativeBytesStore#wrap(ByteBuffer)} directly
+     * for direct buffers, or {@link HeapBytesStore#wrap(ByteBuffer)} for heap buffers.
      */
+    @SuppressWarnings("java:S1452")
     @NotNull
     static BytesStore<?, ByteBuffer> wrap(@NotNull ByteBuffer bb) {
         return bb.isDirect()
@@ -112,9 +116,11 @@ public interface BytesStore<B extends BytesStore<B, U>, U>
     }
 
     /**
-     * Returns a store that references {@code bb} without assuming ownership.
-     * Closing the store does not deallocate a direct buffer.
+     * Returns a store that references {@code bb} without assuming ownership. The wildcard is used for the
+     * store type parameter; use {@link NativeBytesStore#follow(ByteBuffer)} or
+     * {@link HeapBytesStore#wrap(ByteBuffer)} for strict typing.
      */
+    @SuppressWarnings("java:S1452")
     @NotNull
     static BytesStore<?, ByteBuffer> follow(@NotNull ByteBuffer bb) {
         return bb.isDirect()

--- a/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedFileTest.java
@@ -26,6 +26,7 @@ public class MappedFileTest extends BytesTestCommon {
     @Rule
     public final TemporaryFolder tmpDir = new TemporaryFolder();
 
+    @SuppressWarnings("java:S5826") // JUnit 4 lifecycle retained; class mixes Vintage and Jupiter
     @Before
     public void ignoreCouldntDisable() {
         if (Jvm.maxDirectMemory() == 0) {


### PR DESCRIPTION
* Make Surefire consistently inherit JaCoCo’s `argLine` and parent JPMS flags so coverage is stable locally and in CI.
* Tidy and reorder build plugins (no behaviour change at runtime), moving SortPom note and maven-jar earlier.
* Harden the Sonar profile: single-fork Surefire with explicit `-Djvm.coverage=true` and a deterministic JaCoCo setup.
* Add precise `@SuppressWarnings` with justifications for Sonar rules where we intentionally catch `Throwable`, return wildcard generics, or mix JUnit engines.
* Clarify Javadoc where wildcard return types are intentional.

## Why

* Some test runs were missing coverage when Surefire didn’t receive the JaCoCo agent `argLine` or JPMS flags from the parent.
* Sonar raised noise on known, deliberate patterns (S1181, S1452, S5826) — documenting intent keeps signal high without altering behaviour.
* Build readability: group related plugins and keep the invoker execution placement conventional.

## What changed

### Build / pom.xml

* **Surefire (default build)**

  * Re-introduced with:

    ```xml
    <argLine>${argLine} ${jvm.requiredArgs}</argLine>
    <forkCount>4</forkCount>
    <reuseForks>true</reuseForks>
    <runOrder>hourly</runOrder>
    ```
  * Ensures tests pick up JaCoCo agent args (when present) and JPMS flags propagated from the parent.

* **maven-jar-plugin**

  * Moved earlier; unchanged config. Produces stable manifest (classpath + default spec/impl + Automatic-Module-Name).

* **Sonar profile (`sonar`)**

  * Surefire set to a **single fork**, no reuse, and:

    ```xml
    <argLine>${argLine} ${jvm.requiredArgs} -Djvm.coverage=true</argLine>
    ```

    for reliable coverage data during analysis.
  * JaCoCo:

    * Set explicit `<version>${jacoco-maven-plugin.version}</version>`.
    * `prepare-agent` bound to `initialize`, with `append=true` and fixed `destFile` to avoid lost exec data with forks.
    * `report` remains in `verify`.
  * Kept `sonar-maven-plugin` in the profile plugin list (ordering adjusted).

* **Invoker profile (`check-microbenchmarks`)**

  * Retain configuration; move `<executions>` after `<configuration>` and make the binding explicit to `test` phase for clarity.

* **Minor clean-up**

  * Removed stray blank lines and added a comment on SortPom being opt-in to avoid surprise reordering.

### Runtime / code (no behavioural change)

* **BinaryBytesMethodWriterInvocationHandler#doInvoke**

  * `@SuppressWarnings("java:S1181")` with rationale: we roll back the write position on *any* `Throwable` to preserve stream integrity, then rethrow.

* **Bytes / BytesStore**

  * Javadoc clarifies wildcard return types (`Bytes<?>` / `BytesStore<?, ?>`) are intentional; pointed to concrete alternatives.
  * `@SuppressWarnings("java:S1452")` added on factory methods where wildcard is the correct API surface.

* **MappedFileTest**

  * `@SuppressWarnings("java:S5826")` to document why JUnit 4 lifecycle remains (mixing Vintage/Jupiter in this module).

## Behavioural impact

* **Tests**: now always run with the intended JPMS flags; coverage is reliably captured in both regular and Sonar runs.
* **Artifacts**: unchanged runtime classes; only manifest placement in POM reordered (no output change).
* **CI/Sonar**: fewer false positives; stable JaCoCo exec generation.
