### PR TITLE
Enable CI-only coverage enforcement and add a focused test suite that exercises boundary conditions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,13 @@
         </profile>
         <profile>
             <id>sonar</id>
+            <!-- If you keep thresholds as properties, define them here
+                 (or in the parent) so they resolve during this profile) -->
+            <properties>
+                <jacoco.line.coverage>0.7</jacoco.line.coverage>
+                <jacoco.branch.coverage>0.6</jacoco.branch.coverage>
+            </properties>
+
             <build>
                 <plugins>
                     <plugin>
@@ -385,9 +392,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- Include JPMS flags from parent and coverage flag for sonar runs -->
-                            <argLine>${argLine} ${jvm.requiredArgs} -Djvm.coverage=true</argLine>
-                            <!-- Use a single fork to ensure JaCoCo agent reliably writes execution data -->
+                            <argLine>${surefireArgLine} ${jvm.requiredArgs} -Djvm.coverage=true</argLine>
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
                         </configuration>
@@ -402,20 +407,8 @@
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
-                                <phase>initialize</phase>
                                 <configuration>
-                                    <!-- Ensure exec is written even with forks; reuse the default dest -->
-                                    <append>true</append>
-                                    <destFile>${project.build.directory}/jacoco.exec</destFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                                <phase>verify</phase>
-                                <configuration>
+                                    <propertyName>surefireArgLine</propertyName>
                                     <excludes>
                                         <!-- Low-level reflection/unsafe helpers where behaviour is JVM/architecture gated -->
                                         <exclude>net/openhft/chronicle/bytes/internal/ByteBuffers*</exclude>
@@ -423,18 +416,22 @@
                                     </excludes>
                                 </configuration>
                             </execution>
+
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>
+
                             <execution>
                                 <id>check</id>
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
-                                <phase>prepare-package</phase>
+                                <phase>verify</phase>
                                 <configuration>
-                                    <excludes>
-                                        <!-- Mirror report excludes for consistency of thresholds -->
-                                        <exclude>net/openhft/chronicle/bytes/internal/ByteBuffers*</exclude>
-                                        <exclude>net/openhft/chronicle/bytes/internal/UnsafeText*</exclude>
-                                    </excludes>
                                     <rules>
                                         <rule>
                                             <element>BUNDLE</element>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
         <zero.cost.assertions>disabled</zero.cost.assertions>
         <sonar.organization>openhft</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <jacoco.line.coverage>0.8</jacoco.line.coverage>
+        <jacoco.branch.coverage>0.7</jacoco.branch.coverage>
     </properties>
 
     <dependencyManagement>
@@ -393,7 +395,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco-maven-plugin.version}</version>
+                        <version>0.8.14</version>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>
@@ -409,10 +411,48 @@
                             </execution>
                             <execution>
                                 <id>report</id>
-                                <phase>prepare-package</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <excludes>
+                                        <!-- Low-level reflection/unsafe helpers where behaviour is JVM/architecture gated -->
+                                        <exclude>net/openhft/chronicle/bytes/internal/ByteBuffers*</exclude>
+                                        <exclude>net/openhft/chronicle/bytes/internal/UnsafeText*</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <excludes>
+                                        <!-- Mirror report excludes for consistency of thresholds -->
+                                        <exclude>net/openhft/chronicle/bytes/internal/ByteBuffers*</exclude>
+                                        <exclude>net/openhft/chronicle/bytes/internal/UnsafeText*</exclude>
+                                    </excludes>
+                                    <rules>
+                                        <rule>
+                                            <element>BUNDLE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${jacoco.line.coverage}</minimum>
+                                                </limit>
+                                                <limit>
+                                                    <counter>BRANCH</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${jacoco.branch.coverage}</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <zero.cost.assertions>disabled</zero.cost.assertions>
         <sonar.organization>openhft</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <!-- Define the target coverage thresholds as properties -->
         <jacoco.line.coverage>0.8</jacoco.line.coverage>
         <jacoco.branch.coverage>0.7</jacoco.branch.coverage>
     </properties>

--- a/src/test/java/net/openhft/chronicle/bytes/BytesBoundsAndLimitsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesBoundsAndLimitsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+
+import static org.junit.Assert.*;
+
+public class BytesBoundsAndLimitsTest extends BytesTestCommon {
+
+    @Test(expected = BufferOverflowException.class)
+    public void writeBeyondWriteLimitThrows() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(8);
+        try {
+            b.writeLimit(4);
+            b.writeLong(1L); // 8 bytes > writeLimit
+        } finally {
+            b.releaseLast();
+        }
+    }
+
+    @Test(expected = BufferUnderflowException.class)
+    public void readBeyondReadLimitThrows() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(8);
+        try {
+            b.writeInt(123);
+            b.readPosition(0);
+            b.readLong(); // 8 bytes > available 4
+        } finally {
+            b.releaseLast();
+        }
+    }
+
+    @Test
+    public void clearIsClearAndZeroOut() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(16);
+        try {
+            assertTrue(b.isClear());
+            b.writeLimit(b.capacity() - 1);
+            assertFalse(b.isClear());
+            b.clear();
+            assertTrue(b.isClear());
+
+            b.append("abcdef");
+            b.zeroOut(0, 6);
+            for (int i = 0; i < 6; i++) {
+                assertEquals(0, b.peekUnsignedByte(i));
+            }
+        } finally {
+            b.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/BytesCopyOfTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesCopyOfTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BytesCopyOfTest extends BytesTestCommon {
+
+    @Test
+    public void copyOfReturnsDirectBytesWithSameReadableContent() {
+        Bytes<?> src = Bytes.allocateElasticOnHeap(32);
+        try {
+            src.append("lorem-ipsum");
+            src.readSkip(6); // point to "ipsum"
+            Bytes<Void> copy = BytesUtil.copyOf(src);
+            try {
+                assertEquals("ipsum", copy.toString());
+                // copy is direct; avoid growing it to keep within fixed capacity
+            } finally {
+                copy.releaseLast();
+            }
+        } finally {
+            src.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/BytesDebugAndUtf8Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesDebugAndUtf8Test.java
@@ -5,8 +5,7 @@ package net.openhft.chronicle.bytes;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class BytesDebugAndUtf8Test extends BytesTestCommon {
 
@@ -22,10 +21,9 @@ public class BytesDebugAndUtf8Test extends BytesTestCommon {
 
             // debug string contains representation
             String dbg = BytesUtil.toDebugString(b, rp, 5);
-            assertTrue(dbg.length() > 0);
+            assertFalse(dbg.isEmpty());
         } finally {
             b.releaseLast();
         }
     }
 }
-

--- a/src/test/java/net/openhft/chronicle/bytes/BytesDebugAndUtf8Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesDebugAndUtf8Test.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BytesDebugAndUtf8Test extends BytesTestCommon {
+
+    @Test
+    public void appendAndParseUtf8AndDebugString() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(64);
+        try {
+            BytesUtil.appendUtf8(b, "hello");
+            long rp = b.readPosition();
+            StringBuilder sb = new StringBuilder();
+            BytesUtil.parseUtf8(b, sb, 5);
+            assertEquals("hello", sb.toString());
+
+            // debug string contains representation
+            String dbg = BytesUtil.toDebugString(b, rp, 5);
+            assertTrue(dbg.length() > 0);
+        } finally {
+            b.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/BytesUtilEqualityTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesUtilEqualityTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BytesUtilEqualityTest extends BytesTestCommon {
+
+    @Test
+    public void bytesEqualCoversLongIntShortBytePaths() {
+        // length 15 => 8 (long) + 4 (int) + 2 (short) + 1 (byte)
+        Bytes<?> a = Bytes.from("ABCDEFGHIJKLMNO");
+        Bytes<?> b = Bytes.from("ABCDEFGHIJKLMNO");
+        Bytes<?> c = Bytes.from("ABCDEFGH1JKLMNO");
+        try {
+            assertTrue(BytesUtil.bytesEqual(a, 0, b, 0, 15));
+            assertFalse(BytesUtil.bytesEqual(a, 0, c, 0, 15));
+        } finally {
+            a.releaseLast();
+            b.releaseLast();
+            c.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
@@ -4,15 +4,16 @@
 package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.core.Jvm;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.AfterEach;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 
@@ -26,16 +27,14 @@ public class BytesUtilTest extends BytesTestCommon {
 
     File testFile;
 
-    @BeforeEach
-    void setUp() {
+    @Before
+    public void setUp() {
         testFile = new File(tempDir.toFile(), "testFile.bin");
     }
 
-    @AfterEach
-    void tearDown() {
-        if (testFile.exists()) {
-            testFile.delete();
-        }
+    @After
+    public void tearDown() throws IOException {
+        Files.deleteIfExists(testFile.toPath());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
@@ -216,6 +216,99 @@ public class BytesUtilTest extends BytesTestCommon {
         doTestCombineDoubleNewline("AA   ", "AA   ");
     }
 
+
+    @Test
+    public void bytesEqualAndCharsEqual() {
+        Bytes<?> a = Bytes.from("abcdef");
+        Bytes<?> b = Bytes.from("abCdef");
+        Bytes<?> c = Bytes.from("abcdef");
+        try {
+            assertFalse(BytesUtil.bytesEqual(a, 0, b, 0, a.readRemaining()));
+            assertTrue(BytesUtil.bytesEqual(a, 0, c, 0, a.readRemaining()));
+
+            assertTrue(BytesUtil.bytesEqual("abc", a, 0, 3));
+            assertFalse(BytesUtil.bytesEqual("abC", a, 0, 3));
+            assertFalse(BytesUtil.bytesEqual(null, a, 0, 3));
+        } finally {
+            a.releaseLast();
+            b.releaseLast();
+            c.releaseLast();
+        }
+    }
+
+    @Test
+    public void asIntStopBitAndPadding() {
+        // Validate against native-endian view used by BytesUtil.asInt
+        int expected = java.nio.ByteBuffer.wrap("1234".getBytes(java.nio.charset.StandardCharsets.ISO_8859_1))
+                .order(java.nio.ByteOrder.nativeOrder())
+                .getInt();
+        assertEquals(expected, BytesUtil.asInt("1234"));
+        assertEquals(1, BytesUtil.stopBitLength(0x7F));
+        assertEquals(2, BytesUtil.stopBitLength(0x80));
+        assertEquals(2, BytesUtil.stopBitLength(0x3FFF));
+        assertTrue(BytesUtil.stopBitLength(0x4000) >= 3);
+
+        assertEquals(64L, BytesUtil.roundUpTo64ByteAlign(1));
+        assertEquals(0L, BytesUtil.roundUpTo64ByteAlign(0));
+        assertEquals(8L, BytesUtil.roundUpTo8ByteAlign(1));
+        assertEquals(0L, BytesUtil.padOffset(0));
+        assertEquals(2L, BytesUtil.padOffset(2));
+    }
+
+    @Test
+    public void readWrite8ByteAlignPaddingAndReverseAndCombineNewline() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(64);
+        try {
+            bytes.append("hello");
+            BytesUtil.read8ByteAlignPadding(bytes);
+            assertEquals(0, bytes.readPosition());
+
+            bytes.clear();
+            bytes.append("abc");
+            long wp = bytes.writePosition();
+            BytesUtil.write8ByteAlignPadding(bytes);
+            long newWp = bytes.writePosition();
+            assertTrue(newWp >= wp);
+            for (long i = wp; i < newWp; i++) {
+                assertEquals(0, bytes.peekUnsignedByte(i));
+            }
+
+            bytes.clear();
+            bytes.append("abcdef");
+            BytesUtil.reverse(bytes, 0);
+            assertEquals("fedcba", bytes.toString());
+
+            bytes.clear();
+            bytes.append("line1\n\n");
+            BytesUtil.combineDoubleNewline(bytes);
+            assertEquals("line1\n", bytes.toString());
+
+            bytes.clear();
+            bytes.append("a \n");
+            BytesUtil.combineDoubleNewline(bytes);
+            assertEquals("a\n", bytes.toString());
+
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void findAndReadFileLiteral() throws Exception {
+        // exercise literal path in readFile
+        Bytes<?> literal = BytesUtil.readFile("=XYZ");
+        try {
+            assertEquals("XYZ", literal.toString());
+        } finally {
+            literal.releaseLast();
+        }
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void findFileThrowsWhenMissing() throws Exception {
+        BytesUtil.findFile("this-file-should-not-exist-chronicle-bytes");
+    }
+
     private void doTestCombineDoubleNewline(String a, String b) {
         final Bytes<byte[]> b2 = Bytes.from(b);
         BytesUtil.combineDoubleNewline(b2);

--- a/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
@@ -5,6 +5,7 @@ package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,6 +31,7 @@ public class BytesUtilTest extends BytesTestCommon {
 
     @After
     public void tearDown() throws IOException {
+        BackgroundResourceReleaser.releasePendingResources();
         Files.deleteIfExists(testFile.toPath());
     }
 

--- a/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesUtilTest.java
@@ -4,17 +4,16 @@
 package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
@@ -22,14 +21,11 @@ import static org.junit.Assume.assumeTrue;
 
 public class BytesUtilTest extends BytesTestCommon {
 
-    @TempDir
-    Path tempDir;
-
     File testFile;
 
     @Before
     public void setUp() {
-        testFile = new File(tempDir.toFile(), "testFile.bin");
+        testFile = new File(OS.getTarget(), "testFile-" + System.nanoTime() + ".bin");
     }
 
     @After
@@ -40,26 +36,26 @@ public class BytesUtilTest extends BytesTestCommon {
     @Test
     public void testStopBitLength() {
         int length = BytesUtil.stopBitLength(128);
-        Assertions.assertEquals(2, length);
+        assertEquals(2, length);
     }
 
     @Test
     public void testAsString() {
         Exception exception = new Exception("Test exception");
         String result = BytesUtil.asString("Error occurred", exception);
-        Assertions.assertTrue(result.startsWith("Error occurred\njava.lang.Exception: Test exception"));
+        assertTrue(result.startsWith("Error occurred\njava.lang.Exception: Test exception"));
     }
 
     @Test
     public void testRoundUpTo64ByteAlign() {
         long result = BytesUtil.roundUpTo64ByteAlign(65);
-        Assertions.assertEquals(128, result);
+        assertEquals(128, result);
     }
 
     @Test
     public void testIsControlSpace() {
-        Assertions.assertTrue(BytesUtil.isControlSpace(' '));
-        Assertions.assertFalse(BytesUtil.isControlSpace('A'));
+        assertTrue(BytesUtil.isControlSpace(' '));
+        assertFalse(BytesUtil.isControlSpace('A'));
     }
 
     @Test
@@ -97,8 +93,8 @@ public class BytesUtilTest extends BytesTestCommon {
 
         assertTrue(BytesUtil.isTriviallyCopyable(A.class));
 
-        assertEquals(start, BytesUtil.triviallyCopyableStart(A.class));
-        assertEquals(20, BytesUtil.triviallyCopyableLength(A.class));
+        Assert.assertEquals(start, BytesUtil.triviallyCopyableStart(A.class));
+        Assert.assertEquals(20, BytesUtil.triviallyCopyableLength(A.class));
     }
 
     @Test
@@ -107,7 +103,7 @@ public class BytesUtilTest extends BytesTestCommon {
 
         int start = BytesUtil.triviallyCopyableStart(Nested.class);
 
-        assertEquals("[" + start + ", " + (start + 20) + "]", Arrays.toString(BytesUtil.triviallyCopyableRange(A.class)));
+        Assert.assertEquals("[" + start + ", " + (start + 20) + "]", Arrays.toString(BytesUtil.triviallyCopyableRange(A.class)));
         assertTrue(BytesUtil.isTriviallyCopyable(A.class, start, 4 + 2 * 8));
         assertTrue(BytesUtil.isTriviallyCopyable(A.class, start + 4, 8));
         assertFalse(BytesUtil.isTriviallyCopyable(A.class, start - 4, 4 + 2 * 8));
@@ -115,20 +111,20 @@ public class BytesUtilTest extends BytesTestCommon {
 
         assertTrue(BytesUtil.isTriviallyCopyable(A2.class));
         int size = Jvm.isAzulZing() ? 28 : 24;
-        assertEquals("[" + start + ", " + (start + size) + "]", Arrays.toString(BytesUtil.triviallyCopyableRange(A2.class)));
+        Assert.assertEquals("[" + start + ", " + (start + size) + "]", Arrays.toString(BytesUtil.triviallyCopyableRange(A2.class)));
         assertTrue(BytesUtil.isTriviallyCopyable(A2.class, start, 4 + 2 * 8 + 2 * 2));
         assertTrue(BytesUtil.isTriviallyCopyable(A2.class, start + 4, 8));
         assertFalse(BytesUtil.isTriviallyCopyable(A2.class, start - 4, 4 + 2 * 8));
-        assertEquals(Jvm.isAzulZing(), BytesUtil.isTriviallyCopyable(A2.class, start + 8, 4 + 2 * 8));
+        Assert.assertEquals(Jvm.isAzulZing(), BytesUtil.isTriviallyCopyable(A2.class, start + 8, 4 + 2 * 8));
         assertFalse(BytesUtil.isTriviallyCopyable(A2.class, start + 12, 4 + 2 * 8));
 
         assertTrue(BytesUtil.isTriviallyCopyable(A3.class));
         // However, by copying a region that is safe.
-        assertEquals("[" + start + ", " + (start + size) + "]", Arrays.toString(BytesUtil.triviallyCopyableRange(A3.class)));
+        Assert.assertEquals("[" + start + ", " + (start + size) + "]", Arrays.toString(BytesUtil.triviallyCopyableRange(A3.class)));
         assertTrue(BytesUtil.isTriviallyCopyable(A3.class, start, 4 + 2 * 8 + 2 * 2));
         assertTrue(BytesUtil.isTriviallyCopyable(A3.class, start + 4, 8));
         assertFalse(BytesUtil.isTriviallyCopyable(A3.class, start - 4, 4 + 2 * 8));
-        assertEquals(Jvm.isAzulZing(), BytesUtil.isTriviallyCopyable(A3.class, start + 8, 4 + 2 * 8));
+        Assert.assertEquals(Jvm.isAzulZing(), BytesUtil.isTriviallyCopyable(A3.class, start + 8, 4 + 2 * 8));
         assertFalse(BytesUtil.isTriviallyCopyable(A3.class, start + 12, 4 + 2 * 8));
     }
 
@@ -138,7 +134,7 @@ public class BytesUtilTest extends BytesTestCommon {
         assertTrue(BytesUtil.isTriviallyCopyable(E.class));
         int size2 = 20;
         int[] range = BytesUtil.triviallyCopyableRange(E.class);
-        assertEquals(size2, range[1] - range[0]);
+        Assert.assertEquals(size2, range[1] - range[0]);
     }
 
     @Test
@@ -168,6 +164,7 @@ public class BytesUtilTest extends BytesTestCommon {
         String a = "a";
         assertTrue(BytesUtil.equals(a, a));
     }
+
     @Test
     public void equals_equivalentCharSequences() {
         Bytes<byte[]> a = Bytes.from("a");
@@ -187,7 +184,7 @@ public class BytesUtilTest extends BytesTestCommon {
         Bytes<byte[]> bytes = Bytes.from("test");
         char[] charArray = BytesUtil.toCharArray(bytes);
         for (char c : charArray) {
-            assertEquals(bytes.readChar(), c);
+            Assert.assertEquals(bytes.readChar(), c);
         }
     }
 
@@ -195,7 +192,7 @@ public class BytesUtilTest extends BytesTestCommon {
     public void reverse() {
         Bytes<byte[]> test = Bytes.from("test");
         BytesUtil.reverse(test, 0);
-        assertEquals(Bytes.from("tset"), test);
+        Assert.assertEquals(Bytes.from("tset"), test);
     }
 
     @Test
@@ -241,17 +238,17 @@ public class BytesUtilTest extends BytesTestCommon {
         int expected = java.nio.ByteBuffer.wrap("1234".getBytes(java.nio.charset.StandardCharsets.ISO_8859_1))
                 .order(java.nio.ByteOrder.nativeOrder())
                 .getInt();
-        assertEquals(expected, BytesUtil.asInt("1234"));
-        assertEquals(1, BytesUtil.stopBitLength(0x7F));
-        assertEquals(2, BytesUtil.stopBitLength(0x80));
-        assertEquals(2, BytesUtil.stopBitLength(0x3FFF));
+        Assert.assertEquals(expected, BytesUtil.asInt("1234"));
+        Assert.assertEquals(1, BytesUtil.stopBitLength(0x7F));
+        Assert.assertEquals(2, BytesUtil.stopBitLength(0x80));
+        Assert.assertEquals(2, BytesUtil.stopBitLength(0x3FFF));
         assertTrue(BytesUtil.stopBitLength(0x4000) >= 3);
 
-        assertEquals(64L, BytesUtil.roundUpTo64ByteAlign(1));
-        assertEquals(0L, BytesUtil.roundUpTo64ByteAlign(0));
-        assertEquals(8L, BytesUtil.roundUpTo8ByteAlign(1));
-        assertEquals(0L, BytesUtil.padOffset(0));
-        assertEquals(2L, BytesUtil.padOffset(2));
+        Assert.assertEquals(64L, BytesUtil.roundUpTo64ByteAlign(1));
+        Assert.assertEquals(0L, BytesUtil.roundUpTo64ByteAlign(0));
+        Assert.assertEquals(8L, BytesUtil.roundUpTo8ByteAlign(1));
+        Assert.assertEquals(0L, BytesUtil.padOffset(0));
+        Assert.assertEquals(2L, BytesUtil.padOffset(2));
     }
 
     @Test
@@ -260,7 +257,7 @@ public class BytesUtilTest extends BytesTestCommon {
         try {
             bytes.append("hello");
             BytesUtil.read8ByteAlignPadding(bytes);
-            assertEquals(0, bytes.readPosition());
+            Assert.assertEquals(0, bytes.readPosition());
 
             bytes.clear();
             bytes.append("abc");
@@ -269,23 +266,23 @@ public class BytesUtilTest extends BytesTestCommon {
             long newWp = bytes.writePosition();
             assertTrue(newWp >= wp);
             for (long i = wp; i < newWp; i++) {
-                assertEquals(0, bytes.peekUnsignedByte(i));
+                Assert.assertEquals(0, bytes.peekUnsignedByte(i));
             }
 
             bytes.clear();
             bytes.append("abcdef");
             BytesUtil.reverse(bytes, 0);
-            assertEquals("fedcba", bytes.toString());
+            Assert.assertEquals("fedcba", bytes.toString());
 
             bytes.clear();
             bytes.append("line1\n\n");
             BytesUtil.combineDoubleNewline(bytes);
-            assertEquals("line1\n", bytes.toString());
+            Assert.assertEquals("line1\n", bytes.toString());
 
             bytes.clear();
             bytes.append("a \n");
             BytesUtil.combineDoubleNewline(bytes);
-            assertEquals("a\n", bytes.toString());
+            Assert.assertEquals("a\n", bytes.toString());
 
         } finally {
             bytes.releaseLast();
@@ -297,7 +294,7 @@ public class BytesUtilTest extends BytesTestCommon {
         // exercise literal path in readFile
         Bytes<?> literal = BytesUtil.readFile("=XYZ");
         try {
-            assertEquals("XYZ", literal.toString());
+            Assert.assertEquals("XYZ", literal.toString());
         } finally {
             literal.releaseLast();
         }
@@ -311,7 +308,7 @@ public class BytesUtilTest extends BytesTestCommon {
     private void doTestCombineDoubleNewline(String a, String b) {
         final Bytes<byte[]> b2 = Bytes.from(b);
         BytesUtil.combineDoubleNewline(b2);
-        assertEquals(a, b2.toString());
+        Assert.assertEquals(a, b2.toString());
     }
 
     static class A {

--- a/src/test/java/net/openhft/chronicle/bytes/BytesWrite8bitRoundTripTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesWrite8bitRoundTripTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BytesWrite8bitRoundTripTest extends BytesTestCommon {
+
+    @Test
+    public void roundTripOnHeap() {
+        roundTrip(Bytes.allocateElasticOnHeap());
+    }
+
+    @Test
+    public void roundTripDirect() {
+        roundTrip(Bytes.allocateElasticDirect());
+    }
+
+    private void roundTrip(Bytes<?> bytes) {
+        try {
+            String[] names = {
+                    "", // empty
+                    "a",
+                    "helloWorld",
+                    // ISO-8859-1 content
+                    "price£",
+                    // near 255 boundary
+                    repeat('x', 250)
+            };
+
+            for (String s : names) {
+                long pos0 = bytes.writePosition();
+                bytes.write8bit(s);
+                long pos1 = bytes.writePosition();
+                bytes.readPosition(pos0);
+                String got = bytes.read8bit();
+                assertEquals(s, got);
+                // read position should catch up to write
+                assertEquals(pos1, bytes.readPosition());
+            }
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    private static String repeat(char c, int n) {
+        StringBuilder sb = new StringBuilder(n);
+        for (int i = 0; i < n; i++) sb.append(c);
+        return sb.toString();
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/BytesWriteSkipBehaviourTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesWriteSkipBehaviourTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import java.nio.BufferOverflowException;
+
+import static org.junit.Assert.*;
+
+public class BytesWriteSkipBehaviourTest extends BytesTestCommon {
+
+    @Test
+    public void reserveThenFillHeader() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(64);
+        try {
+            long start = bytes.writePosition();
+            bytes.writeSkip(4); // reserve header
+            bytes.writeInt(0x11223344);
+            bytes.writeShort((short) 0x55AA);
+            long end = bytes.writePosition();
+            // backfill header with payload length
+            long payloadLen = end - start - 4;
+            bytes.writeInt(start, (int) payloadLen);
+
+            bytes.readPosition(start);
+            assertEquals(payloadLen, bytes.readInt());
+            assertEquals(0x11223344, bytes.readInt());
+            assertEquals((short) 0x55AA, bytes.readShort());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void backtrackOneRemovesTrailingSeparator() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(32);
+        try {
+            // Use length-prefixed UTF-8 so readUtf8() is valid
+            bytes.writeUtf8("abc,");
+            // Overwrite the last payload byte (comma) with 'd'
+            bytes.writeSkip(-1); // drop comma
+            bytes.writeByte((byte) 'd');
+            bytes.readPosition(0);
+            assertEquals("abcd", bytes.readUtf8());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test(expected = BufferOverflowException.class)
+    public void excessiveNegativeSkipThrows() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(16);
+        try {
+            bytes.append("xx");
+            // attempt to backtrack beyond start
+            bytes.writeSkip(- (bytes.writePosition() + 2));
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/HexDumpBytesAdvancedTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/HexDumpBytesAdvancedTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class HexDumpBytesAdvancedTest extends BytesTestCommon {
+
+    @Test
+    public void numberWrapAndIndentation() {
+        HexDumpBytes hdb = new HexDumpBytes();
+        try {
+            hdb.numberWrap(16).offsetFormat((o, b) -> b.appendBase16(o, 2));
+            hdb.writeHexDumpDescription("hdr");
+            hdb.write("1234567890abcdefghij".getBytes());
+            hdb.adjustHexDumpIndentation(2);
+            hdb.writeHexDumpDescription("nest");
+            hdb.write("zz".getBytes());
+
+            final String s = hdb.toHexString();
+            assertTrue(s.contains("hdr"));
+            assertTrue(s.contains("nest"));
+            assertTrue(s.contains("00"));
+        } finally {
+            hdb.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/HexDumpBytesLayoutTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/HexDumpBytesLayoutTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Consolidated layout tests for HexDumpBytes covering wrap widths,
+ * offset formatting and description handling without data.
+ */
+public class HexDumpBytesLayoutTest extends BytesTestCommon {
+
+    @Test
+    public void zeroLengthDescriptionIsEmitted() {
+        HexDumpBytes hdb = new HexDumpBytes();
+        try {
+            hdb.numberWrap(8).offsetFormat((o, b) -> b.appendBase16(o, 2));
+            hdb.writeHexDumpDescription("empty");
+            // write a single byte so the description line is emitted
+            hdb.write(new byte[1]);
+            String s = hdb.toHexString();
+            assertTrue(s.contains("empty"));
+        } finally {
+            hdb.releaseLast();
+        }
+    }
+
+    @Test
+    public void formattingWithNestedBlocksAndOffsets() {
+        HexDumpBytes hdb = new HexDumpBytes();
+        try {
+            hdb.numberWrap(8).offsetFormat((o, b) -> b.appendBase16(o, 2));
+            hdb.writeHexDumpDescription("hdr");
+            hdb.write(new byte[32]);
+            hdb.adjustHexDumpIndentation(1);
+            hdb.writeHexDumpDescription("nested");
+            hdb.write(new byte[4]);
+            String s = hdb.toHexString();
+            assertTrue(s.contains("hdr"));
+            assertTrue(s.contains("nested"));
+            assertTrue(s.contains("00"));
+        } finally {
+            hdb.releaseLast();
+        }
+    }
+
+    @Test
+    public void wrapWidthOneProducesPerByteLines() {
+        HexDumpBytes hdb = new HexDumpBytes();
+        try {
+            hdb.numberWrap(1).offsetFormat((o, b) -> b.appendBase16(o, 2));
+            hdb.writeHexDumpDescription("wrap1");
+            hdb.write(new byte[5]);
+            String s = hdb.toHexString();
+            String[] lines = s.split("\\R");
+            // 1 header + 5 data lines (wrapping every byte) + possibly a trailing empty line
+            assertTrue("Expected multiple wrapped lines", lines.length >= 5);
+            assertTrue(s.contains("wrap1"));
+        } finally {
+            hdb.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/HexDumpBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/HexDumpBytesTest.java
@@ -4,8 +4,10 @@
 package net.openhft.chronicle.bytes;
 
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 
 import static org.junit.Assert.assertEquals;
@@ -38,8 +40,17 @@ public class HexDumpBytesTest extends BytesTestCommon {
     public void memoryMapped() throws FileNotFoundException {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
-        try (MappedBytes mappedBytes = MappedBytes.mappedBytes("test.dat", 64 * 1024)) {
+        File file = new File(OS.getTarget(), "HexDumpBytesTest-" + System.nanoTime() + ".dat");
+        File parent = file.getParentFile();
+        if (parent != null && !parent.exists()) {
+            parent.mkdirs();
+        }
+        try (MappedBytes mappedBytes = MappedBytes.mappedBytes(file, 64 * 1024)) {
             doTest(new HexDumpBytes(mappedBytes));
+        } finally {
+            if (!file.delete()) {
+                file.deleteOnExit();
+            }
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assume.assumeFalse;
 public class MappedBytesBoundaryTest extends BytesTestCommon {
 
     @Test
-    public void writeAcrossChunkBoundary() throws FileNotFoundException {
+    public void writeAcrossChunkBoundary() throws IOException {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
         final int chunk = 4096;
@@ -48,6 +48,7 @@ public class MappedBytesBoundaryTest extends BytesTestCommon {
             mb.read(actual);
             assertArrayEquals(expected, actual);
         }
+        deleteIfPossible(file);
     }
 
     @Test
@@ -76,8 +77,7 @@ public class MappedBytesBoundaryTest extends BytesTestCommon {
             assertTrue("Expected write to read-only mapping to fail", writeFailed);
         }
 
-        BackgroundResourceReleaser.releasePendingResources();
-        Files.deleteIfExists(file.toPath());
+        deleteIfPossible(file);
     }
 
     @Test
@@ -94,8 +94,7 @@ public class MappedBytesBoundaryTest extends BytesTestCommon {
             bytes.readPosition(1024);
             assertEquals((byte) 0x5A, bytes.readByte());
         } finally {
-            BackgroundResourceReleaser.releasePendingResources();
-            Files.deleteIfExists(file.toPath());
+            deleteIfPossible(file);
         }
     }
 
@@ -116,8 +115,7 @@ public class MappedBytesBoundaryTest extends BytesTestCommon {
                 assertTrue("Expected bytes to advance past written payload", bytes.writePosition() > message.length());
             }
         } finally {
-            BackgroundResourceReleaser.releasePendingResources();
-            Files.deleteIfExists(file.toPath());
+            deleteIfPossible(file);
         }
     }
 }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
@@ -7,6 +7,7 @@ import net.openhft.chronicle.bytes.internal.CommonMappedBytes;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -24,6 +25,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 public class MappedBytesBoundaryTest extends BytesTestCommon {
+    @Before
+    public void setUp() {
+        if (OS.isWindows())
+            ignoreException("Unable to delete");
+    }
 
     @Test
     public void writeAcrossChunkBoundary() throws IOException {

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
@@ -76,6 +76,7 @@ public class MappedBytesBoundaryTest extends BytesTestCommon {
             assertTrue("Expected write to read-only mapping to fail", writeFailed);
         }
 
+        BackgroundResourceReleaser.releasePendingResources();
         Files.deleteIfExists(file.toPath());
     }
 
@@ -93,6 +94,7 @@ public class MappedBytesBoundaryTest extends BytesTestCommon {
             bytes.readPosition(1024);
             assertEquals((byte) 0x5A, bytes.readByte());
         } finally {
+            BackgroundResourceReleaser.releasePendingResources();
             Files.deleteIfExists(file.toPath());
         }
     }
@@ -113,8 +115,8 @@ public class MappedBytesBoundaryTest extends BytesTestCommon {
                 assertEquals(message, bytes.read8bit());
                 assertTrue("Expected bytes to advance past written payload", bytes.writePosition() > message.length());
             }
-            BackgroundResourceReleaser.releasePendingResources();
         } finally {
+            BackgroundResourceReleaser.releasePendingResources();
             Files.deleteIfExists(file.toPath());
         }
     }

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import net.openhft.chronicle.bytes.internal.CommonMappedBytes;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.BufferOverflowException;
+import java.nio.ReadOnlyBufferException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+public class MappedBytesBoundaryTest extends BytesTestCommon {
+
+    @Test
+    public void writeAcrossChunkBoundary() throws FileNotFoundException {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        final int chunk = 4096;
+        final byte[] prefix = new byte[chunk - 4];
+        final byte[] tail = "HELLO".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] expected = new byte[prefix.length + tail.length];
+        System.arraycopy(prefix, 0, expected, 0, prefix.length);
+        System.arraycopy(tail, 0, expected, prefix.length, tail.length);
+
+        File file = new File(OS.getTarget(), "mapped-boundary-" + System.nanoTime() + ".dat");
+        try (MappedBytes mb = MappedBytes.mappedBytes(file, chunk)) {
+            // position at end of first chunk minus 4
+            mb.writePosition(prefix.length);
+            mb.write(tail);
+
+            // read back from start
+            mb.readPosition(0);
+            byte[] actual = new byte[expected.length];
+            mb.read(actual);
+            assertArrayEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void readOnlyMappingRejectsWritesAndReportsFlag() throws IOException {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        File file = new File(OS.getTarget(), "mapped-readonly-" + System.nanoTime() + ".dat");
+        Files.createDirectories(file.getParentFile().toPath());
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            raf.setLength(OS.pageSize());
+        }
+
+        try (MappedBytes writable = MappedBytes.singleMappedBytes(file, OS.pageSize())) {
+            writable.writeSkip(32);
+            assertEquals(32, writable.writePosition());
+        }
+
+        try (MappedBytes readOnly = MappedBytes.singleMappedBytes(file, OS.pageSize(), true)) {
+            assertTrue(((CommonMappedBytes) readOnly).isBackingFileReadOnly());
+            boolean writeFailed = false;
+            try {
+                readOnly.writeByte((byte) 0x7F);
+            } catch (ReadOnlyBufferException | BufferOverflowException | IllegalStateException expected) {
+                writeFailed = true;
+            }
+            assertTrue("Expected write to read-only mapping to fail", writeFailed);
+        }
+
+        Files.deleteIfExists(file.toPath());
+    }
+
+    @Test
+    public void writeSkipReservesSpaceLikeQueueWriters() throws IOException {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        File file = new File(OS.getTarget(), "mapped-write-skip-" + System.nanoTime() + ".dat");
+        Files.createDirectories(file.getParentFile().toPath());
+        try (MappedBytes bytes = MappedBytes.mappedBytes(file, OS.pageSize())) {
+            bytes.writeSkip(1024);
+            assertEquals(1024, bytes.writePosition());
+
+            bytes.writeByte((byte) 0x5A);
+            bytes.readPosition(1024);
+            assertEquals((byte) 0x5A, bytes.readByte());
+        } finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+
+    @Test
+    public void write8bitUsesOptimisedPathForAsciiStrings() throws IOException {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        File file = new File(OS.getTarget(), "mapped-write8bit-" + System.nanoTime() + ".dat");
+        Files.createDirectories(file.getParentFile().toPath());
+        String message = "OrderAccepted";
+        try {
+            try (MappedBytes bytes = MappedBytes.mappedBytes(file, OS.pageSize())) {
+                bytes.writePosition(0);
+                bytes.write8bit(message);
+
+                bytes.readPosition(0);
+                assertEquals(message, bytes.read8bit());
+                assertTrue("Expected bytes to advance past written payload", bytes.writePosition() > message.length());
+            }
+            BackgroundResourceReleaser.releasePendingResources();
+        } finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesBoundaryTest.java
@@ -16,7 +16,6 @@ import java.io.RandomAccessFile;
 import java.nio.BufferOverflowException;
 import java.nio.ReadOnlyBufferException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesWrite8bitBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesWrite8bitBoundaryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+
+public class MappedBytesWrite8bitBoundaryTest extends BytesTestCommon {
+
+    @Test
+    public void write8bitAcrossChunkBoundary() throws IOException {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+        // Use page size as chunk to make boundary deterministic
+        final int chunk = OS.pageSize();
+        File file = new File(OS.getTarget(), "mapped-write8bit-boundary-" + System.nanoTime() + ".dat");
+        Files.createDirectories(file.getParentFile().toPath());
+        String msg = repeat('A', 32);
+        try {
+            try (MappedBytes mb = MappedBytes.mappedBytes(file, chunk)) {
+                // position at end of first chunk minus a few bytes so the encoded length + data cross
+                mb.writePosition(chunk - 2);
+                mb.write8bit(msg);
+                mb.readPosition(chunk - 2);
+                String got = mb.read8bit();
+                assertEquals(msg, got);
+            }
+            BackgroundResourceReleaser.releasePendingResources();
+        } finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+
+    private static String repeat(char c, int n) {
+        byte[] b = new byte[n];
+        for (int i = 0; i < n; i++) b[i] = (byte) c;
+        return new String(b, StandardCharsets.ISO_8859_1);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/MappedBytesWrite8bitBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedBytesWrite8bitBoundaryTest.java
@@ -36,8 +36,8 @@ public class MappedBytesWrite8bitBoundaryTest extends BytesTestCommon {
                 String got = mb.read8bit();
                 assertEquals(msg, got);
             }
-            BackgroundResourceReleaser.releasePendingResources();
         } finally {
+            BackgroundResourceReleaser.releasePendingResources();
             Files.deleteIfExists(file.toPath());
         }
     }

--- a/src/test/java/net/openhft/chronicle/bytes/MethodWriterRollbackTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MethodWriterRollbackTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class MethodWriterRollbackTest extends BytesTestCommon {
+
+    interface Failer {
+        void go() throws Throwable; // declare Throwable to test non-Exception path
+    }
+
+    @Test
+    public void writePositionIsRolledBackOnThrowable() {
+        Bytes<?> out = Bytes.allocateElasticOnHeap(64);
+        try {
+            Function<Method, MethodEncoder> failing = m -> new MethodEncoder() {
+                @Override
+                public long messageId() {
+                    return 1L;
+                }
+
+                @Override
+                public void encode(Object[] args, BytesOut<?> bytesOut)
+                        throws IllegalArgumentException, BufferUnderflowException, IllegalStateException, BufferOverflowException, ArithmeticException, InvalidMarshallableException {
+                    bytesOut.writeInt(0xDEADBEEF); // advance position
+                    net.openhft.chronicle.core.Jvm.rethrow(new Throwable("boom"));
+                }
+
+                @Override
+                public Object[] decode(Object[] lastObjects, BytesIn<?> in) {
+                    return lastObjects;
+                }
+            };
+            BinaryBytesMethodWriterInvocationHandler h = new BinaryBytesMethodWriterInvocationHandler(
+                    Failer.class, failing, out);
+            @SuppressWarnings("unchecked")
+            Failer proxy = (Failer) Proxy.newProxyInstance(
+                    Failer.class.getClassLoader(), new Class<?>[]{Failer.class}, h);
+
+            long pos0 = out.writePosition();
+            assertThrows(Throwable.class, proxy::go);
+            assertEquals("write position must be restored on failure", pos0, out.writePosition());
+        } finally {
+            out.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/RandomDataInputUtf8LimitedMoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/RandomDataInputUtf8LimitedMoreTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import java.nio.BufferUnderflowException;
+
+import static org.junit.Assert.assertThrows;
+
+public class RandomDataInputUtf8LimitedMoreTest extends BytesTestCommon {
+
+    @Test
+    public void bufferUnderflowWhenDeclaredLengthExceedsRemaining() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(16);
+        try {
+            // Write stop-bit length larger than the following data
+            b.writeStopBit(10);
+            b.append("abc");
+            StringBuilder sb = new StringBuilder();
+            assertThrows(BufferUnderflowException.class,
+                    () -> b.readUtf8Limited(0, sb, 20));
+        } finally {
+            b.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/StopBitLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/StopBitLengthTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StopBitLengthTest extends BytesTestCommon {
+
+    @Test
+    public void boundaries() {
+        assertEquals(1, BytesUtil.stopBitLength(0));
+        assertEquals(1, BytesUtil.stopBitLength(0x7F));
+        assertEquals(2, BytesUtil.stopBitLength(0x80));
+        assertEquals(2, BytesUtil.stopBitLength(0x3FFF));
+        assertTrue(BytesUtil.stopBitLength(0x4000) >= 3);
+        assertTrue(BytesUtil.stopBitLength(Integer.MAX_VALUE) >= 3);
+        assertTrue(BytesUtil.stopBitLength(Long.MAX_VALUE) >= 9);
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/UncheckedBytesBehaviourTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UncheckedBytesBehaviourTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UncheckedBytesBehaviourTest extends BytesTestCommon {
+
+    @Test
+    public void uncheckedOnDirectAndNoopWhenFalse() {
+        Bytes<?> d = Bytes.allocateDirect(16);
+        Bytes<?> u = d.unchecked(true);
+        try {
+            u.append("zz");
+            assertEquals("zz", u.toString());
+        } finally {
+            u.releaseLast();
+        }
+
+        Bytes<?> h = Bytes.allocateElasticOnHeap(8);
+        try {
+            Bytes<?> same = h.unchecked(false);
+            assertSame(h, same);
+        } finally {
+            h.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/UncheckedNativeBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/UncheckedNativeBytesTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.BufferOverflowException;
 
+import static java.util.Objects.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -62,7 +63,7 @@ class UncheckedNativeBytesTest {
         long offset = 10;
         byte value = 5;
         uncheckedBytes.writeByte(offset, value);
-        verify(underlyingBytes.bytesStore()).writeByte(eq(offset), eq(value));
+        requireNonNull(verify(underlyingBytes.bytesStore())).writeByte(eq(offset), eq(value));
     }
 
     @Test
@@ -70,7 +71,7 @@ class UncheckedNativeBytesTest {
         long offset = 20;
         int value = 123456789;
         uncheckedBytes.writeInt(offset, value);
-        verify(underlyingBytes.bytesStore()).writeInt(eq(offset), eq(value));
+        requireNonNull(verify(underlyingBytes.bytesStore())).writeInt(eq(offset), eq(value));
     }
 
     @Test
@@ -78,11 +79,11 @@ class UncheckedNativeBytesTest {
         long offset = 10;
         int expected = 100;
         int value = 200;
-        when(underlyingBytes.bytesStore().compareAndSwapInt(offset, expected, value)).thenReturn(true);
+        when(requireNonNull(underlyingBytes.bytesStore()).compareAndSwapInt(offset, expected, value)).thenReturn(true);
 
         boolean result = uncheckedBytes.compareAndSwapInt(offset, expected, value);
         assertTrue(result);
-        verify(underlyingBytes.bytesStore()).compareAndSwapInt(eq(offset), eq(expected), eq(value));
+        requireNonNull(verify(underlyingBytes.bytesStore())).compareAndSwapInt(eq(offset), eq(expected), eq(value));
     }
 
     @Test
@@ -208,6 +209,19 @@ class UncheckedNativeBytesTest {
         uncheckedBytes.readPosition(0);
         uncheckedBytes.readLong();
         assertEquals(8, uncheckedBytes.readPosition());
+    }
+
+
+    @Test
+    public void uncheckedWrapEnsureCapacityAndAppend() {
+        Bytes<?> b = Bytes.allocateDirect(8);
+        Bytes<?> u = b.unchecked(true);
+        try {
+            u.append("abc");
+            assertEquals("abc", u.toString());
+        } finally {
+            u.releaseLast();
+        }
     }
 
     private UncheckedNativeBytes<?> createUncheckedNativeBytes() {

--- a/src/test/java/net/openhft/chronicle/bytes/Utf8ParsingBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Utf8ParsingBoundaryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import net.openhft.chronicle.bytes.internal.BytesInternal;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Consolidates UTF-8 parsing boundary tests (explicit length, stop-char parsing,
+ * null sequences and over-length failures).
+ */
+public class Utf8ParsingBoundaryTest extends BytesTestCommon {
+
+    @Test
+    public void parsesExplicitLengthAtBoundaries() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(32);
+        String ascii = "A";
+        String multi = "£\u20ac"; // euro escaped; pound is ISO-8859-1
+        try {
+            b.append(ascii).append(multi);
+            b.readPosition(0);
+
+            StringBuilder sb = new StringBuilder();
+            // parse up to the first byte (1 char)
+            BytesInternal.parseUtf8(b, sb, true, 1);
+            assertEquals(ascii, sb.toString());
+
+            sb.setLength(0);
+            // parse remaining (multi-byte sequence)
+            BytesInternal.parseUtf8(b, sb, true, (int) b.readRemaining());
+            assertEquals(multi, sb.toString());
+        } finally {
+            b.releaseLast();
+        }
+    }
+
+    @Test
+    public void parsesWithCommonStopChars() {
+        Bytes<?> b = Bytes.from("alpha,beta gamma");
+        try {
+            StringBuilder sb = new StringBuilder();
+            BytesInternal.parseUtf8(b, sb, StopCharTesters.COMMA_STOP);
+            assertEquals("alpha", sb.toString());
+        } finally {
+            b.releaseLast();
+        }
+    }
+
+    @Test
+    public void nullSequenceEncodesAsMinusOneAndReturnsNegativeOffset() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(32);
+        try {
+            b.writeStopBit(-1);
+            long res = b.readUtf8Limited(0, new StringBuilder(), 10);
+            assertTrue("Expected negative return value signalling null", res < 0);
+        } finally {
+            b.releaseLast();
+        }
+    }
+
+    @Test(expected = net.openhft.chronicle.core.io.ClosedIllegalStateException.class)
+    public void throwsWhenUtf8LengthExceedsMax() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(32);
+        try {
+            String payload = "WXYZ";
+            b.writeStopBit(AppendableUtil.findUtf8Length(payload));
+            b.append(payload);
+            StringBuilder sb = new StringBuilder();
+            b.readUtf8Limited(0, sb, 3);
+        } finally {
+            b.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/Utf8ParsingBoundaryTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/Utf8ParsingBoundaryTest.java
@@ -19,7 +19,7 @@ public class Utf8ParsingBoundaryTest extends BytesTestCommon {
     public void parsesExplicitLengthAtBoundaries() {
         Bytes<?> b = Bytes.allocateElasticOnHeap(32);
         String ascii = "A";
-        String multi = "£\u20ac"; // euro escaped; pound is ISO-8859-1
+        String multi = "£€"; // euro escaped; pound is ISO-8859-1
         try {
             b.append(ascii).append(multi);
             b.readPosition(0);
@@ -76,4 +76,3 @@ public class Utf8ParsingBoundaryTest extends BytesTestCommon {
         }
     }
 }
-

--- a/src/test/java/net/openhft/chronicle/bytes/VanillaBytesCapacityAndZeroOutTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/VanillaBytesCapacityAndZeroOutTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VanillaBytesCapacityAndZeroOutTest extends BytesTestCommon {
+
+    @Test
+    public void ensureCapacityGrowsAndZeroOutsRange() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(8);
+        try {
+            // Grow in small steps
+            for (int i = 0; i < 10; i++) {
+                b.append('X');
+            }
+            long capAfter = b.capacity();
+            assertTrue("Expected capacity to grow beyond initial", capAfter >= 10);
+
+            // zeroOut a large range including unwritten tail
+            long start = 2;
+            long end = Math.min(b.writePosition() + 16, b.capacity());
+            b.zeroOut(start, end);
+
+            // Verify visible zeroing only on written region
+            b.readPosition(0);
+            byte first = b.readByte();
+            assertEquals('X', first);
+            byte third = b.readByte(2);
+            assertEquals(0, third);
+        } finally {
+            b.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/VanillaBytesEnsureCapacityTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/VanillaBytesEnsureCapacityTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class VanillaBytesEnsureCapacityTest extends BytesTestCommon {
+
+    @Test
+    public void elasticEnsureCapacityGrows() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(8);
+        try {
+            long rc = b.realCapacity();
+            byte[] chunk = new byte[1024];
+            b.write(chunk);
+            assertTrue(b.realCapacity() > rc);
+        } finally {
+            b.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/VanillaBytesOpsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/VanillaBytesOpsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VanillaBytesOpsTest extends BytesTestCommon {
+
+    @Test
+    public void writeReadPrimitivesAndZeroOut() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(64);
+        try {
+            b.writeInt(0x11223344);
+            b.writeLong(0x0102030405060708L);
+
+            b.readPosition(0);
+            assertEquals(0x11223344, b.readInt());
+            assertEquals(0x0102030405060708L, b.readLong());
+
+            // zero out the int we wrote and check
+            b.zeroOut(0, 4);
+            assertEquals(0, b.peekUnsignedByte(0));
+            assertEquals(0, b.peekUnsignedByte(1));
+        } finally {
+            b.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/VanillaBytesUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/VanillaBytesUsageTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 public class VanillaBytesUsageTest extends BytesTestCommon {
 
     @Test
-    public void wrapNativeStoreMaintainsOffsets() throws Exception {
+    public void wrapNativeStoreMaintainsOffsets() {
         NativeBytesStore<Void> store = NativeBytesStore.nativeStoreWithFixedCapacity(64);
         try {
             store.writeLong(0, 0x1122334455667788L);
@@ -30,7 +30,7 @@ public class VanillaBytesUsageTest extends BytesTestCommon {
     }
 
     @Test
-    public void vanillaBytesCanSwapUnderlyingStore() throws Exception {
+    public void vanillaBytesCanSwapUnderlyingStore() {
         NativeBytesStore<Void> storeA = NativeBytesStore.nativeStoreWithFixedCapacity(32);
         NativeBytesStore<Void> storeB = NativeBytesStore.nativeStoreWithFixedCapacity(32);
         try {

--- a/src/test/java/net/openhft/chronicle/bytes/VanillaBytesUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/VanillaBytesUsageTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes;
+
+import net.openhft.chronicle.bytes.internal.NativeBytesStore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VanillaBytesUsageTest extends BytesTestCommon {
+
+    @Test
+    public void wrapNativeStoreMaintainsOffsets() throws Exception {
+        NativeBytesStore<Void> store = NativeBytesStore.nativeStoreWithFixedCapacity(64);
+        try {
+            store.writeLong(0, 0x1122334455667788L);
+
+            VanillaBytes<Void> bytes = VanillaBytes.wrap(store);
+            try {
+                bytes.readLimit(store.capacity());
+                bytes.readPosition(0);
+                assertEquals(0x1122334455667788L, bytes.readLong());
+            } finally {
+                bytes.releaseLast();
+            }
+        } finally {
+            store.releaseLast();
+        }
+    }
+
+    @Test
+    public void vanillaBytesCanSwapUnderlyingStore() throws Exception {
+        NativeBytesStore<Void> storeA = NativeBytesStore.nativeStoreWithFixedCapacity(32);
+        NativeBytesStore<Void> storeB = NativeBytesStore.nativeStoreWithFixedCapacity(32);
+        try {
+            storeA.writeUtf8(0, "alpha");
+            storeB.writeUtf8(0, "beta");
+
+            VanillaBytes<Void> reusable = VanillaBytes.vanillaBytes();
+            try {
+                reusable.bytesStore(storeA, 0, storeA.capacity());
+                reusable.readPosition(0);
+                assertEquals("alpha", reusable.readUtf8());
+
+                reusable.bytesStore(storeB, 0, storeB.capacity());
+                reusable.readPosition(0);
+                assertEquals("beta", reusable.readUtf8());
+            } finally {
+                reusable.releaseLast();
+            }
+        } finally {
+            storeA.releaseLast();
+            storeB.releaseLast();
+        }
+    }
+
+}

--- a/src/test/java/net/openhft/chronicle/bytes/internal/ByteStringReaderWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/ByteStringReaderWriterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ByteStringReaderWriterTest extends BytesTestCommon {
+
+    @Test
+    public void readerReadsAllAndSkipHonoured() throws IOException {
+        final Bytes<?> bytes = Bytes.allocateElasticOnHeap(64);
+        try {
+            bytes.append("abc123XYZ");
+
+            final Reader reader = new ByteStringReader(bytes);
+
+            // skip a few, then read remaining
+            long skipped = reader.skip(3);
+            assertEquals(3L, skipped);
+
+            char[] buf = new char[16];
+            int n = reader.read(buf, 0, buf.length);
+            String s = new String(buf, 0, n);
+            assertEquals("123XYZ", s);
+
+            // EOF returns -1
+            assertEquals(-1, reader.read());
+
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void writerAppendsVariousOverloads() throws IOException {
+        final Bytes<?> bytes = Bytes.allocateElasticOnHeap(64);
+        try {
+            final ByteStringWriter writer = new ByteStringWriter(bytes);
+
+            writer.write('A');
+            writer.write("BC");
+            writer.write("012345", 1, 3); // writes "123"
+            Writer w = writer.append('X')
+                    .append("YZ")
+                    .append("-HELLO-", 1, 6); // "HELLO"
+            w.flush();
+
+            final String out = bytes.toString();
+            assertTrue(out, out.contains("ABC123XYZHELLO"));
+            assertEquals("ABC123XYZHELLO", out);
+
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalContentEqualTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalContentEqualTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BytesInternalContentEqualTest extends BytesTestCommon {
+
+    @Test
+    public void heapVsDirectEqualContent() {
+        Bytes<?> heap = Bytes.from("abcdef");
+        Bytes<?> direct = Bytes.allocateDirect(6);
+        try {
+            direct.append("abcdef");
+            // ensure comparisons start from position 0
+            heap.readPosition(0);
+            direct.readPosition(0);
+
+            assertTrue("Expected equal content across heap and direct stores",
+                    BytesInternal.contentEqual(heap.bytesStore(), direct.bytesStore()));
+        } finally {
+            heap.releaseLast();
+            direct.releaseLast();
+        }
+    }
+
+    @Test
+    public void differentLengthsAreNotEqual() {
+        Bytes<?> left = Bytes.from("abc");
+        Bytes<?> right = Bytes.from("abcd");
+        try {
+            assertFalse(BytesInternal.contentEqual(left.bytesStore(), right.bytesStore()));
+        } finally {
+            left.releaseLast();
+            right.releaseLast();
+        }
+    }
+
+    @Test
+    public void singleByteMismatchDetected() {
+        Bytes<?> left = Bytes.from("abcde");
+        Bytes<?> right = Bytes.from("abXde");
+        try {
+            assertFalse(BytesInternal.contentEqual(left.bytesStore(), right.bytesStore()));
+        } finally {
+            left.releaseLast();
+            right.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalContentEqualTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalContentEqualTest.java
@@ -4,7 +4,6 @@
 package net.openhft.chronicle.bytes.internal;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.BytesTestCommon;
 import org.junit.Test;
 

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalGuardedTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalGuardedTest.java
@@ -81,13 +81,13 @@ public class BytesInternalGuardedTest extends BytesTestCommon {
         assertTrue(BytesInternal.compareUtf8(bs, 0, null));
         assertFalse(BytesInternal.compareUtf8(bs, 0, "test"));
 
-        bs.writeUtf8(1, "£€");
+        bs.writeUtf8(1, "£\u20ac");
         @NotNull StringBuilder sb = new StringBuilder();
         bs.readUtf8(1, sb);
-        assertEquals("£€", sb.toString());
-        assertTrue(BytesInternal.compareUtf8(bs, 1, "£€"));
+        assertEquals("£\u20ac", sb.toString());
+        assertTrue(BytesInternal.compareUtf8(bs, 1, "£\u20ac"));
         assertFalse(BytesInternal.compareUtf8(bs, 1, "£"));
-        assertFalse(BytesInternal.compareUtf8(bs, 1, "£€$"));
+        assertFalse(BytesInternal.compareUtf8(bs, 1, "£\u20ac$"));
         bs.releaseLast();
     }
 

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalIOCopyTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalIOCopyTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Consolidated IO and copy tests for BytesInternal.
+ */
+public class BytesInternalIOCopyTest extends BytesTestCommon {
+
+    @Test
+    public void copyFromRandomDataInputToOutputStreamAndToByteArray() throws IOException {
+        final Bytes<?> src = Bytes.from("abcdef");
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try {
+            BytesInternal.copy(src, bos);
+            assertArrayEquals("abcdef".getBytes(), bos.toByteArray());
+
+            byte[] arr = BytesInternal.toByteArray(src);
+            assertArrayEquals("abcdef".getBytes(), arr);
+
+            // subBytes view from heap-backed input
+            BytesStore<?, ?> sub = BytesInternal.subBytes(src, 2, 3);
+            byte[] got = new byte[3];
+            long n = sub.read(0, got, 0, 3);
+            assertEquals(3L, n);
+            assertArrayEquals("cde".getBytes(), got);
+        } finally {
+            src.releaseLast();
+        }
+    }
+
+    @Test
+    public void copyInputStreamLargeAndDirectToArray() throws Exception {
+        byte[] data = new byte[2000];
+        for (int i = 0; i < data.length; i++) data[i] = (byte) (i & 0x7F);
+        ByteArrayInputStream bis = new ByteArrayInputStream(data);
+        Bytes<?> out = Bytes.allocateElasticOnHeap(128);
+        try {
+            BytesInternal.copy(bis, out);
+            assertEquals(data.length, out.length());
+
+            // direct memory variant of toByteArray
+            Bytes<?> direct = Bytes.allocateDirect(6);
+            try {
+                direct.append("123456");
+                direct.readPosition(0);
+                byte[] arr = BytesInternal.toByteArray(direct);
+                assertArrayEquals("123456".getBytes(), arr);
+            } finally {
+                direct.releaseLast();
+            }
+        } finally {
+            out.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalParsingTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalParsingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import net.openhft.chronicle.bytes.StopCharTesters;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BytesInternalParsingTest extends BytesTestCommon {
+
+    @Test
+    public void parseBooleanTokens() {
+        Bytes<?> t = Bytes.from("true");
+        Bytes<?> f = Bytes.from("false");
+        Bytes<?> y = Bytes.from("yes");
+        Bytes<?> n = Bytes.from("no");
+        Bytes<?> one = Bytes.from("1");
+        Bytes<?> zero = Bytes.from("0");
+        Bytes<?> maybe = Bytes.from("maybe");
+        try {
+            assertEquals(Boolean.TRUE, BytesInternal.parseBoolean(t, StopCharTesters.NON_ALPHA_DIGIT));
+            assertEquals(Boolean.FALSE, BytesInternal.parseBoolean(f, StopCharTesters.NON_ALPHA_DIGIT));
+            assertEquals(Boolean.TRUE, BytesInternal.parseBoolean(y, StopCharTesters.NON_ALPHA_DIGIT));
+            assertEquals(Boolean.FALSE, BytesInternal.parseBoolean(n, StopCharTesters.NON_ALPHA_DIGIT));
+            assertEquals(Boolean.TRUE, BytesInternal.parseBoolean(one, StopCharTesters.NON_ALPHA_DIGIT));
+            assertEquals(Boolean.FALSE, BytesInternal.parseBoolean(zero, StopCharTesters.NON_ALPHA_DIGIT));
+            assertNull(BytesInternal.parseBoolean(maybe, StopCharTesters.NON_ALPHA_DIGIT));
+        } finally {
+            t.releaseLast();
+            f.releaseLast();
+            y.releaseLast();
+            n.releaseLast();
+            one.releaseLast();
+            zero.releaseLast();
+            maybe.releaseLast();
+        }
+    }
+
+    @Test
+    public void parseUtf8IntoBuilder() {
+        Bytes<?> alpha = Bytes.from("alpha");
+        Bytes<?> beta = Bytes.from("beta");
+        try {
+            StringBuilder sb = new StringBuilder();
+            BytesInternal.parseUtf8(alpha, sb, StopCharTesters.NON_ALPHA_DIGIT);
+            assertEquals("alpha", sb.toString());
+            sb.setLength(0);
+            BytesInternal.parseUtf8(beta, sb, StopCharTesters.NON_ALPHA_DIGIT);
+            assertEquals("beta", sb.toString());
+        } finally {
+            alpha.releaseLast();
+            beta.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalSubBytesErrorsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalSubBytesErrorsTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import org.junit.Test;
+
+import java.nio.BufferUnderflowException;
+
+public class BytesInternalSubBytesErrorsTest extends BytesTestCommon {
+
+    @Test(expected = BufferUnderflowException.class)
+    public void subBytesThrowsWhenLengthTooLarge() {
+        Bytes<?> src = Bytes.from("abc");
+        try {
+            // request a sub view longer than remaining
+            BytesInternal.subBytes(src, 0, 10);
+        } finally {
+            src.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalUtf8MoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalUtf8MoreTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import net.openhft.chronicle.bytes.StopCharTesters;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BytesInternalUtf8MoreTest extends BytesTestCommon {
+
+    @Test
+    public void appendUtf8WithLatin1MultibyteChars() {
+        Bytes<?> out = Bytes.allocateElasticOnHeap(64);
+        try {
+            String s = "ab\u00A3\u00E9cd"; // contains '£' and 'é'
+            BytesInternal.appendUtf8(out, s, 0, s.length());
+            // Bytes.toString decodes ISO-8859-1; compare using the same codec on the UTF-8 bytes
+            String expected = new String(s.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                    java.nio.charset.StandardCharsets.ISO_8859_1);
+            assertEquals(expected, out.toString());
+        } finally {
+            out.releaseLast();
+        }
+    }
+
+    @Test
+    public void appendUtf8ToRandomDataOutputHandlesSupplementaryChars() {
+        Bytes<?> out = Bytes.allocateElasticOnHeap(64);
+        try {
+            String text = "ascii \u00A3 \u20AC";
+            long endOffset = BytesInternal.appendUtf8(out, out.writePosition(), text, 0, text.length());
+            out.writePosition(endOffset);
+            out.readLimit(endOffset);
+            out.readPosition(0);
+            byte[] actual = BytesInternal.toByteArray(out);
+            assertEquals(text, new String(actual, StandardCharsets.UTF_8));
+            assertEquals(endOffset, out.writePosition());
+        } finally {
+            out.releaseLast();
+        }
+    }
+
+    @Test
+    public void parseUtf8WithExplicitLengthHonoursUtfFlag() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(64);
+        try {
+            String text = "\u00A3elastic";
+            BytesInternal.appendUtf8(bytes, text, 0, text.length());
+            bytes.readLimit(bytes.writePosition());
+            bytes.readPosition(0);
+
+            StringBuilder utfBuilder = new StringBuilder();
+            BytesInternal.parseUtf8(bytes, utfBuilder, true, (int) bytes.readRemaining());
+            assertEquals(text, utfBuilder.toString());
+
+            bytes.readPosition(0);
+            StringBuilder latinBuilder = new StringBuilder();
+            BytesInternal.parseUtf8(bytes, latinBuilder, false, (int) bytes.readRemaining());
+            assertEquals(text, latinBuilder.toString());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void parseUtf8StopsAtTesterBoundary() {
+        Bytes<?> source = Bytes.allocateElasticOnHeap(64);
+        try {
+            String payload = "token1,token2";
+            BytesInternal.appendUtf8(source, payload, 0, payload.length());
+            source.readLimit(source.writePosition());
+            source.readPosition(0);
+
+            StringBuilder sb = new StringBuilder();
+            BytesInternal.parseUtf8(source, sb, StopCharTesters.COMMA_STOP);
+            assertEquals("token1", sb.toString());
+            assertTrue(source.readRemaining() > 0);
+        } finally {
+            source.releaseLast();
+        }
+    }
+
+    @Test
+    public void parseUtf8IntoBytesBuilder() {
+        Bytes<?> t1 = Bytes.from("token1");
+        Bytes<?> t2 = Bytes.from("token2");
+        Bytes<?> builder = Bytes.allocateElasticOnHeap(32);
+        try {
+            BytesInternal.parseUtf8(t1, builder, StopCharTesters.NON_ALPHA_DIGIT);
+            assertEquals("token1", builder.toString());
+            builder.clear();
+            BytesInternal.parseUtf8(t2, builder, StopCharTesters.NON_ALPHA_DIGIT);
+            assertEquals("token2", builder.toString());
+        } finally {
+            builder.releaseLast();
+            t1.releaseLast();
+            t2.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalUtf8MoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalUtf8MoreTest.java
@@ -19,7 +19,7 @@ public class BytesInternalUtf8MoreTest extends BytesTestCommon {
     public void appendUtf8WithLatin1MultibyteChars() {
         Bytes<?> out = Bytes.allocateElasticOnHeap(64);
         try {
-            String s = "ab\u00A3\u00E9cd"; // contains '£' and 'é'
+            String s = "ab£écd"; // contains '£' and 'é'
             BytesInternal.appendUtf8(out, s, 0, s.length());
             // Bytes.toString decodes ISO-8859-1; compare using the same codec on the UTF-8 bytes
             String expected = new String(s.getBytes(java.nio.charset.StandardCharsets.UTF_8),
@@ -34,7 +34,7 @@ public class BytesInternalUtf8MoreTest extends BytesTestCommon {
     public void appendUtf8ToRandomDataOutputHandlesSupplementaryChars() {
         Bytes<?> out = Bytes.allocateElasticOnHeap(64);
         try {
-            String text = "ascii \u00A3 \u20AC";
+            String text = "ascii £ €";
             long endOffset = BytesInternal.appendUtf8(out, out.writePosition(), text, 0, text.length());
             out.writePosition(endOffset);
             out.readLimit(endOffset);
@@ -51,7 +51,7 @@ public class BytesInternalUtf8MoreTest extends BytesTestCommon {
     public void parseUtf8WithExplicitLengthHonoursUtfFlag() {
         Bytes<?> bytes = Bytes.allocateElasticOnHeap(64);
         try {
-            String text = "\u00A3elastic";
+            String text = "£elastic";
             BytesInternal.appendUtf8(bytes, text, 0, text.length());
             bytes.readLimit(bytes.writePosition());
             bytes.readPosition(0);

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalUtf8Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalUtf8Test.java
@@ -10,7 +10,6 @@ import net.openhft.chronicle.bytes.StreamingDataOutput;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class BytesInternalUtf8Test extends BytesTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalUtf8Test.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalUtf8Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import net.openhft.chronicle.bytes.StopCharTesters;
+import net.openhft.chronicle.bytes.StreamingDataOutput;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BytesInternalUtf8Test extends BytesTestCommon {
+
+    @Test
+    public void appendUtf8CharSequenceVariants() {
+        Bytes<?> out = Bytes.allocateElasticOnHeap(32);
+        try {
+            CharSequence cs = "hello-world";
+            BytesInternal.appendUtf8((StreamingDataOutput) out, cs, 0, cs.length());
+            assertEquals("hello-world", out.toString());
+
+            out.clear();
+            char[] chars = "abcdef".toCharArray();
+            // use end index exclusive one less to avoid inclusive access
+            BytesInternal.appendUtf8(out, (CharSequence) new String(chars), 1, chars.length - 1);
+            assertEquals("bcdef", out.toString());
+
+            // long string across internal buffers
+            out.clear();
+            String longStr = new String(new char[1024]).replace('\0', 'x');
+            BytesInternal.appendUtf8(out, longStr, 0, longStr.length());
+            assertEquals(longStr.length(), out.length());
+        } finally {
+            out.releaseLast();
+        }
+    }
+
+    @Test
+    public void parseUtf8And8bitWithStopTesters() {
+        Bytes<?> a = Bytes.from("alpha");
+        Bytes<?> b = Bytes.from("beta");
+        try {
+            StringBuilder sb = new StringBuilder();
+            BytesInternal.parseUtf8(a, sb, StopCharTesters.NON_ALPHA_DIGIT);
+            assertEquals("alpha", sb.toString());
+
+            sb.setLength(0);
+            BytesInternal.parseUtf8(b, sb, StopCharTesters.NON_ALPHA_DIGIT);
+            assertEquals("beta", sb.toString());
+        } finally {
+            a.releaseLast();
+            b.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalWireUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalWireUsageTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import net.openhft.chronicle.bytes.StopCharTesters;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BytesInternalWireUsageTest extends BytesTestCommon {
+
+    @Test
+    public void parseUtf8UsingNativeStoreOptimisation() {
+        Bytes<?> direct = Bytes.allocateElasticDirect(64);
+        try {
+            String text = "wire-field-name";
+            BytesInternal.appendUtf8(direct, text, 0, text.length());
+            long utfLength = direct.writePosition();
+
+            StringBuilder builder = new StringBuilder();
+            BytesInternal.parseUtf8(direct.bytesStore(), 0L, builder, true, (int) utfLength);
+
+            assertEquals(text, builder.toString());
+            direct.readPosition(utfLength);
+            assertEquals(0, direct.readRemaining());
+        } finally {
+            direct.releaseLast();
+        }
+    }
+
+    @Test
+    public void parseUtf8WithEqualsDelimiterMimicsQueryParsers() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(64);
+        try {
+            String payload = "exchange=EUREX,side=SELL";
+            BytesInternal.appendUtf8(bytes, payload, 0, payload.length());
+            bytes.readLimit(bytes.writePosition());
+            bytes.readPosition(0);
+
+            StringBuilder symbol = new StringBuilder();
+            BytesInternal.parseUtf8(bytes, symbol, StopCharTesters.EQUALS);
+            assertEquals("exchange", symbol.toString());
+
+            StringBuilder venue = new StringBuilder();
+            BytesInternal.parseUtf8(bytes, venue, StopCharTesters.COMMA_STOP);
+            assertEquals("EUREX", venue.toString());
+
+            StringBuilder sideKey = new StringBuilder();
+            BytesInternal.parseUtf8(bytes, sideKey, StopCharTesters.EQUALS);
+            assertEquals("side", sideKey.toString());
+
+            StringBuilder sideValue = new StringBuilder();
+            BytesInternal.parseUtf8(bytes, sideValue, StopCharTesters.ALL);
+            assertEquals("SELL", sideValue.toString());
+
+            assertTrue("All bytes consumed", bytes.readRemaining() <= 1);
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void parseUtf8StopsAtQuotesForEscapedFields() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(64);
+        try {
+            String payload = "\"Best,Trader\" remainder";
+            BytesInternal.appendUtf8(bytes, payload, 0, payload.length());
+            bytes.readLimit(bytes.writePosition());
+
+            bytes.readPosition(1); // skip leading quote as TextWire/CSVWire do
+            StringBuilder quoted = new StringBuilder();
+            BytesInternal.parseUtf8(bytes, quoted, StopCharTesters.QUOTES);
+            assertEquals("Best,Trader", quoted.toString());
+
+            // Move past the separator space and confirm remaining text is intact
+            bytes.readSkip(1);
+            StringBuilder rest = new StringBuilder();
+            BytesInternal.parseUtf8(bytes, rest, StopCharTesters.ALL);
+            assertEquals("remainder", rest.toString().trim());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/internal/CanonicalPathUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/CanonicalPathUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import net.openhft.chronicle.core.OS;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class CanonicalPathUtilTest extends BytesTestCommon {
+
+    @Test
+    public void returnsInternedCanonicalPath() throws IOException {
+        File dir = new File(OS.getTarget(), "canon-test");
+        assertTrue(dir.mkdirs() || dir.isDirectory());
+        File f1 = new File(dir, "a/.././file.txt");
+        File f2 = new File(dir, "./file.txt");
+
+        // ensure file exists
+        File parent = f2.getParentFile();
+        assertTrue(parent.mkdirs() || parent.isDirectory());
+        try (FileWriter fw = new FileWriter(f2)) {
+            fw.write("x");
+        }
+
+        String p1 = CanonicalPathUtil.of(f1);
+        String p2 = CanonicalPathUtil.of(f2);
+
+        assertEquals(p1, p2);
+        assertSame("String must be interned", p1, p1.intern());
+        assertSame("Same canonical path must be same instance", p1, p2);
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/internal/HeapBytesStoreOpsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/HeapBytesStoreOpsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HeapBytesStoreOpsTest extends BytesTestCommon {
+
+    @Test
+    public void heapStorePrimitiveOps() {
+        Bytes<?> heap = Bytes.allocateElasticOnHeap(32);
+        try {
+            BytesStore<?, ?> store = heap.bytesStore();
+            long off = heap.start();
+            store.writeInt(off, 0x11223344);
+            assertEquals(0x11223344, store.readInt(off));
+            store.writeOrderedInt(off, 0x55667788);
+            assertEquals(0x55667788, store.readInt(off));
+        } finally {
+            heap.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/internal/NativeBytesStoreOpsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/NativeBytesStoreOpsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NativeBytesStoreOpsTest extends BytesTestCommon {
+
+    @Test
+    public void readWriteAndVolatileOrderedOps() {
+        BytesStore<?, ?> store = BytesStore.nativeStore(32);
+        try {
+            long off = 0;
+            store.writeLong(off, 0x0102030405060708L);
+            assertEquals(0x0102030405060708L, store.readLong(off));
+            store.writeInt(off + 8, 0x11223344);
+            assertEquals(0x11223344, store.readInt(off + 8));
+
+            store.writeVolatileLong(off, 9L);
+            assertEquals(9L, store.readVolatileLong(off));
+            store.writeOrderedLong(off, 10L);
+            assertEquals(10L, store.readLong(off));
+            assertEquals(15L, store.addAndGetLong(off, 5L));
+        } finally {
+            store.releaseLast();
+        }
+    }
+}
+

--- a/src/test/java/net/openhft/chronicle/bytes/internal/Parse8bitVariantsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/Parse8bitVariantsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import net.openhft.chronicle.bytes.StopCharTesters;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class Parse8bitVariantsTest extends BytesTestCommon {
+
+    @Test
+    public void parse8bitIntoStringBuilderAndBytes() {
+        Bytes<?> alpha = Bytes.from("alpha");
+        Bytes<?> beta = Bytes.from("beta");
+        try {
+            StringBuilder sb = new StringBuilder();
+            BytesInternal.parse8bit(alpha, sb, StopCharTesters.NON_ALPHA_DIGIT);
+            assertEquals("alpha", sb.toString());
+            Bytes<?> out = Bytes.allocateElasticOnHeap(8);
+            try {
+                BytesInternal.parse8bit(beta, out, StopCharTesters.NON_ALPHA_DIGIT);
+                assertEquals("beta", out.toString());
+            } finally {
+                out.releaseLast();
+            }
+        } finally {
+            alpha.releaseLast();
+            beta.releaseLast();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/bytes/ref/ReferenceTypesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ref/ReferenceTypesTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.bytes.ref;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.BytesTestCommon;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ReferenceTypesTest extends BytesTestCommon {
+
+    @Test
+    public void textIntReferenceRoundTrip() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(128);
+        TextIntReference ref = null;
+        try {
+            // Prepare backing store with template and bind reference
+            TextIntReference.write(b, 42);
+            ref = new TextIntReference();
+            BytesStore<?, ?> store = b.bytesStore();
+            ref.bytesStore(store, b.start(), ref.maxSize());
+
+            assertEquals(42, ref.getValue());
+
+            ref.setValue(1234);
+            assertEquals(1234, ref.getValue());
+
+            assertTrue(ref.compareAndSwapValue(1234, 5678));
+            assertEquals(5678, ref.getValue());
+
+            assertEquals(5680, ref.addValue(2));
+            assertEquals(5680, ref.getVolatileValue());
+            ref.setOrderedValue(99);
+            assertEquals(99, ref.getValue());
+        } finally {
+            // ensure reference is closed for leak checks
+            if (ref != null) ref.close();
+            b.releaseLast();
+        }
+    }
+
+    @Test
+    public void binaryLongReferenceOps() {
+        Bytes<?> b = Bytes.allocateElasticOnHeap(16);
+        try {
+            BinaryLongReference ref = new BinaryLongReference();
+            ref.bytesStore(b.bytesStore(), b.start(), ref.maxSize());
+            ref.setValue(7L);
+            assertEquals(7L, ref.getValue());
+            assertEquals(7L, ref.getVolatileValue());
+            ref.setVolatileValue(8L);
+            assertEquals(8L, ref.getValue());
+            ref.setOrderedValue(9L);
+            assertEquals(9L, ref.getValue());
+            assertEquals(19L, ref.addValue(10L));
+            assertEquals(29L, ref.addAtomicValue(10L));
+            assertTrue(ref.toString().contains("value:"));
+            ref.close();
+        } finally {
+            b.releaseLast();
+        }
+    }
+}


### PR DESCRIPTION

* `pom.xml`: Sonar-scoped JaCoCo agent, report and **coverage check** (driven by properties) with Surefire wired to `${surefireArgLine}`.
* Tests: New/expanded JUnit cases cover write/read limits, stop-bit boundaries, 8-bit/UTF-8 round-trips, chunk-boundary mapping, rollback on method-writer failures, content equality, parsing helpers, and reference types.

---

## Motivation

* Keep developer builds fast and unchanged; **enforce coverage only in CI** (`-Psonar`), consistent with Core/Wire/Queue.
* Fix the common pitfall where `${argLine}` shadows the JaCoCo agent. Using `${surefireArgLine}` guarantees the agent is injected.
* Raise confidence in tricky paths (mapping boundaries, unchecked wrappers, UTF-8 parsing, rollback semantics) with targeted tests.

---

## Build Changes

**Sonar profile (`-Psonar`)**

* Properties (overridable thresholds):

  * `jacoco.line.coverage=0.7`
  * `jacoco.branch.coverage=0.6`
* `maven-surefire-plugin`:

  * `argLine=${surefireArgLine} ${jvm.requiredArgs} -Djvm.coverage=true`
  * `forkCount=1`, `reuseForks=false` (reliable exec data write)
* `jacoco-maven-plugin` `0.8.14`:

  * `prepare-agent` → publishes `surefireArgLine` (with module-specific excludes for low-level helpers)
  * `report` bound to `verify`
  * `check` bound to `verify` with BUNDLE rules:

    ```
    LINE   COVEREDRATIO >= ${jacoco.line.coverage}
    BRANCH COVEREDRATIO >= ${jacoco.branch.coverage}
    ```
* Top-level defaults documented:

  * `jacoco.line.coverage=0.8`, `jacoco.branch.coverage=0.7`

**Outcome:** normal builds unaffected; CI runs fail when coverage drops below the thresholds.

---

## Test Additions (highlights)

* **Bounds & limits:** overflow/underflow on write/read limits; `clear`/`zeroOut`.
* **Copy & equality:** `BytesUtil.copyOf`, `BytesUtil.bytesEqual` (long/int/short/byte paths), content equality heap↔direct.
* **UTF-8/8-bit:** append/parse (explicit length, stop chars, null sequences), round-trip `write8bit` on heap/direct; boundary/over-length cases.
* **Mapped bytes:** write across chunk boundary; read-only mapping behaviour; `writeSkip` reservation; crossing boundary with `write8bit`.
* **Unchecked wrappers:** `unchecked(true)` behaviour and CAS/offset passthroughs.
* **Hex dump:** wrap widths, nested descriptions, offset formatting/indentation.
* **Method writer safety:** verify **writePosition rollback** on `Throwable`.
* **Internal IO & parsing:** stream copy, `toByteArray`, sub-views and error paths, boolean token parsing, UTF-8 into `Bytes`/`StringBuilder`.
* **Utilities:** stop-bit length edges; padding/align helpers; canonical path interning.
* **References:** `TextIntReference` and `BinaryLongReference` read/modify/CAS/ordered/volatile semantics.