### PR TITLE
Close the scanner used to read property-replacement resources

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
+++ b/src/main/java/net/openhft/chronicle/bytes/util/PropertyReplacer.java
@@ -103,7 +103,8 @@ public enum PropertyReplacer {
      */
     @NotNull
     private static String convertStreamToString(@NotNull java.io.InputStream is) {
-        java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
-        return s.hasNext() ? s.next() : "";
+        try (java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A")) {
+	        return s.hasNext() ? s.next() : "";
+        }
     }
 }


### PR DESCRIPTION
Use try-with-resources around the `Scanner` in `PropertyReplacer.convertStreamToString`, closing it after whole-stream conversion, including exceptional exits. Closing the scanner also closes the supplied input stream; the existing empty-input result is retained.

Confirm input-stream ownership at the callers and exercise empty and non-empty resources.

Validation: the diff and recorded review/check history were inspected at `b1548554613b`. No build, test or benchmark was rerun for this metadata edit. No CI result was returned for this head.
