### PR TITLE
Lower mapped-time throughput thresholds for slower test hosts

### DIFF
--- a/src/test/java/net/openhft/chronicle/bytes/MappedUniqueTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MappedUniqueTimeProviderTest.java
@@ -65,7 +65,7 @@ public class MappedUniqueTimeProviderTest extends BytesTestCommon {
             count += 1000;
         } while (System.currentTimeMillis() < start + 500);
         System.out.println("currentTimeMillisPerf count/sec: " + count * 2);
-        assertTrue(count > 1_000_000 / 2); // half the speed of Rasberry Pi
+        assertTrue(count > 200_000 / 2); // half the speed of Rasberry Pi
     }
 
     @Test
@@ -129,7 +129,7 @@ public class MappedUniqueTimeProviderTest extends BytesTestCommon {
                 break;
         }
         System.out.printf("count: %,d%n", count);
-        assertTrue(count > 1_000_000);
+        assertTrue(count > 200_000);
     }
 
     @Test


### PR DESCRIPTION
Reduce the minimum operation counts in `MappedUniqueTimeProviderTest`: 500,000 to 100,000 for milliseconds and 1,000,000 to 200,000 for nanoseconds over the existing measurement interval. The author reports that the previous limits fail on a slower development host.

This changes test thresholds; it does not change the time provider or demonstrate a performance improvement.

Agree the portability expectation for these throughput assertions and record representative measurements before relying on the relaxed limits.

Validation: the diff and recorded review/check history were inspected at `96910fc11900`. No build, test or benchmark was rerun for this metadata edit. No CI result was returned for this head.

---

## Existing author and review notes

Lower performance assertions to get tests passing on my (apparently) slow desktop.
