### PR TITLE
Add arbitrary-timestamp ID generation to DistributedUniqueTimeProvider

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProvider.java
@@ -252,6 +252,79 @@ public class DistributedUniqueTimeProvider extends SimpleCloseable implements Ti
         }
     }
 
+    /**
+     * Generates a unique nanosecond-resolution ID for the given timestamp, embedding the host id.
+     * This is useful for producing identifiers for events that occurred at a known time rather than "now".
+     * <p>
+     * The provided timestamp is an absolute nanosecond value (not epoch-adjusted).
+     * Uniqueness is still guaranteed via CAS on the shared memory-mapped file:
+     * if the requested timestamp would collide with a previously issued ID, it is advanced forward.
+     *
+     * @param timestampNanos the absolute nanosecond timestamp to base the ID on
+     * @return a unique ID with the host id embedded in the lower two digits
+     */
+    public long uniqueIdForNanos(long timestampNanos) {
+        long time0 = bytes.readVolatileLong(LAST_TIME);
+        long timeN = timestampFor(timestampNanos) + hostId;
+
+        if (timeN > time0 && bytes.compareAndSwapLong(LAST_TIME, time0, timeN))
+            return timeN;
+
+        return uniqueIdForNanosLoop(timestampNanos);
+    }
+
+    /**
+     * Loop variant of {@link #uniqueIdForNanos(long)} that finds the next available slot
+     * when the fast path fails due to contention or a timestamp in the past.
+     */
+    private long uniqueIdForNanosLoop(long timestampNanos) {
+        while (true) {
+            long time0 = bytes.readVolatileLong(LAST_TIME);
+            long next = timestampFor(timestampNanos) + hostId;
+
+            // If the proposed ID is not greater than the last issued one, advance
+            if (next <= time0) {
+                next = timestampFor(time0) + hostId;
+                if (next <= time0)
+                    next += HOST_IDS;
+            }
+
+            if (bytes.compareAndSwapLong(LAST_TIME, time0, next))
+                return next;
+
+            Jvm.nanoPause();
+        }
+    }
+
+    /**
+     * Generates a unique microsecond-resolution ID for the given timestamp, embedding the host id.
+     * This is useful for producing identifiers for events that occurred at a known time rather than "now".
+     * <p>
+     * The provided timestamp is an absolute microsecond value (not epoch-adjusted).
+     *
+     * @param timestampMicros the absolute microsecond timestamp to base the ID on
+     * @return a unique ID in microseconds with the host id embedded in the lower two digits
+     */
+    public long uniqueIdForMicros(long timestampMicros) {
+        long timeus = timestampMicros / HOST_IDS;
+
+        while (true) {
+            long time0 = bytes.readVolatileLong(LAST_TIME);
+            long time0us = time0 / (HOST_IDS * NANOS_PER_MICRO);
+            long time;
+
+            if (time0us >= timeus)
+                time = (time0us + 1) * (HOST_IDS * NANOS_PER_MICRO);
+            else
+                time = timeus * (HOST_IDS * NANOS_PER_MICRO);
+
+            if (bytes.compareAndSwapLong(LAST_TIME, time0, time))
+                return time / NANOS_PER_MICRO + hostId;
+
+            Jvm.nanoPause();
+        }
+    }
+
     @Override
     public void unmonitor() {
         Monitorable.unmonitor(file);

--- a/src/test/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/DistributedUniqueTimeProviderTest.java
@@ -290,4 +290,58 @@ public class DistributedUniqueTimeProviderTest extends BytesTestCommon {
             lastTimeNanos = currentTimeNanos / 1000;
         }
     }
+
+    @Test
+    public void uniqueIdForNanosShouldBeUniqueAndMonotonic() {
+        long baseTime = setTimeProvider.currentTimeNanos();
+        long last = 0;
+
+        for (int i = 0; i < 1_000; i++) {
+            long id = timeProvider.uniqueIdForNanos(baseTime + i * 100L);
+            assertTrue("IDs must be monotonically increasing", id > last);
+            assertEquals(0, DistributedUniqueTimeProvider.hostIdFor(id));
+            last = id;
+        }
+    }
+
+    @Test
+    public void uniqueIdForNanosShouldAdvanceWhenTimestampInPast() {
+        // Generate a current ID to advance LAST_TIME
+        long now = timeProvider.currentTimeNanos();
+
+        // Now request an ID for a timestamp in the past
+        long pastTime = now - 1_000_000_000L; // 1 second ago
+        long id = timeProvider.uniqueIdForNanos(pastTime);
+
+        // Should still be greater than the last issued ID
+        assertTrue("ID for past timestamp should be advanced to maintain uniqueness", id > now);
+    }
+
+    @Test
+    public void uniqueIdForMicrosShouldBeUniqueAndMonotonic() {
+        long baseTime = setTimeProvider.currentTimeMicros();
+        long last = 0;
+
+        for (int i = 0; i < 1_000; i++) {
+            long id = timeProvider.uniqueIdForMicros(baseTime + i);
+            assertTrue("IDs must be monotonically increasing", id > last);
+            assertEquals(0, DistributedUniqueTimeProvider.hostIdFor(id));
+            last = id;
+        }
+    }
+
+    @Test
+    public void uniqueIdForNanosWithDifferentHostIds() {
+        try (DistributedUniqueTimeProvider tp1 = DistributedUniqueTimeProvider.forHostId(1);
+             DistributedUniqueTimeProvider tp2 = DistributedUniqueTimeProvider.forHostId(2)) {
+            long baseTime = System.nanoTime();
+
+            long id1 = tp1.uniqueIdForNanos(baseTime);
+            long id2 = tp2.uniqueIdForNanos(baseTime);
+
+            assertEquals(1, DistributedUniqueTimeProvider.hostIdFor(id1));
+            assertEquals(2, DistributedUniqueTimeProvider.hostIdFor(id2));
+            assertNotEquals("IDs from different hosts must differ", id1, id2);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- **Arbitrary-timestamp ID generation**: new `uniqueIdForNanos(long)` and `uniqueIdForMicros(long)` methods that generate unique IDs based on a caller-supplied timestamp instead of the current wall-clock time — useful for event replay, back-filling, or importing historical data.
- Preserves the existing CAS-based uniqueness and monotonicity guarantees via the shared memory-mapped file.
- New tests covering unique ID generation from custom timestamps (monotonicity, past-timestamp advancement, multi-host uniqueness).

## Test plan
- [x] All existing + new tests pass (`mvn test -Dtest=DistributedUniqueTimeProviderTest`)
- [ ] Benchmark `uniqueIdForNanos` performance under contention