### PR TITLE
CORE-62: Fix StringBuilder corruption after non-Latin-1 content

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -771,10 +771,21 @@ enum BytesInternal {
         sb.ensureCapacity(utflen);
 
         if (Jvm.isJava9Plus() && Jvm.maxDirectMemory() > 0) {
-            byte[] sbBytes = extractBytes(sb);
-            for (int count = 0; count < utflen; count++) {
-                int c = bytes.readUnsignedByte();
-                sbBytes[count] = (byte) c;
+            byte coder = getStringCoder(sb);
+            if (coder == JAVA9_STRING_CODER_LATIN) {
+                byte[] sbBytes = extractBytes(sb);
+                for (int count = 0; count < utflen; count++) {
+                    int c = bytes.readUnsignedByte();
+                    sbBytes[count] = (byte) c;
+                }
+                StringUtils.setLength(sb, utflen);
+            } else {
+                assert coder == JAVA9_STRING_CODER_UTF16;
+                sb.setLength(utflen);
+                for (int count = 0; count < utflen; count++) {
+                    int c = bytes.readUnsignedByte();
+                    sb.setCharAt(count, (char) c);
+                }
             }
         } else {
             char[] chars = StringUtils.extractChars(sb);
@@ -782,8 +793,8 @@ enum BytesInternal {
                 int c = bytes.readUnsignedByte();
                 chars[count] = (char) c;
             }
+            StringUtils.setLength(sb, utflen);
         }
-        StringUtils.setLength(sb, utflen);
     }
 
     public static void parse8bit1(@NotNull StreamingDataInput bytes, @NotNull Appendable appendable, @NonNegative int utflen)
@@ -938,7 +949,7 @@ enum BytesInternal {
                 assert coder == JAVA9_STRING_CODER_UTF16;
                 sb.setLength(length);
                 while (count < length) {
-                    byte b = memory.readByte(address + count);
+                    int b = memory.readByte(address + count) & 0xFF;
                     sb.setCharAt(count++, (char) b);
                 }
             }

--- a/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
@@ -11,6 +11,7 @@ import java.nio.BufferUnderflowException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class AppendableUtilTest extends BytesTestCommon {
@@ -63,6 +64,52 @@ public class AppendableUtilTest extends BytesTestCommon {
         StringBuilder sb = new StringBuilder();
         AppendableUtil.parseUtf8(bs, sb, true, 11);
         Assertions.assertEquals("Hello World", sb.toString());
+    }
+
+    @Test
+    public void read8bitPreservesTextWhenStringBuilderUsesUtf16Storage() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            bytes.write8bit("field");
+
+            StringBuilder sb = utf16StringBuilder();
+            assertTrue(bytes.read8bit(sb));
+
+            assertEquals("field", sb.toString());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void parse8bitPreservesExtendedByteWhenStringBuilderUsesUtf16Storage() throws Exception {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            bytes.writeUnsignedByte(0xA3);
+
+            StringBuilder sb = utf16StringBuilder();
+            AppendableUtil.parse8bit(bytes, sb, 1);
+
+            assertEquals("\u00A3", sb.toString());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void parse8bitFromNativeBytesPreservesExtendedByteWhenStringBuilderUsesUtf16Storage() throws Exception {
+        assumeFalse(NativeBytes.areNewGuarded());
+        Bytes<?> bytes = Bytes.allocateElasticDirect();
+        try {
+            bytes.writeUnsignedByte(0xA3);
+
+            StringBuilder sb = utf16StringBuilder();
+            AppendableUtil.parse8bit(bytes, sb, 1);
+
+            assertEquals("\u00A3", sb.toString());
+        } finally {
+            bytes.releaseLast();
+        }
     }
 
     @Test
@@ -151,5 +198,11 @@ public class AppendableUtilTest extends BytesTestCommon {
         assertEquals("helloXworld", sb.toString());
         assertEquals("HelloXWorld", b.toString());
         b.releaseLast();
+    }
+
+    private static StringBuilder utf16StringBuilder() {
+        StringBuilder sb = new StringBuilder("\u221A");
+        sb.setLength(0);
+        return sb;
     }
 }


### PR DESCRIPTION
This PR fixes CORE-62, where a reused `StringBuilder` could corrupt subsequent Latin-1 content after previously containing a non-Latin-1 character.

On Java 9+, `StringBuilder` can retain UTF-16 internal storage after holding a multi-byte character. Chronicle’s fast 8-bit parsing paths write directly into the builder’s backing storage, so reusing a builder in this state could write Latin-1 bytes into UTF-16 storage incorrectly. This caused binary wire decoding to truncate or corrupt field names/values, with the rest of a DTO potentially being ignored after a multi-byte string field.

### Changes

* Updated `StringUtils.setLength` to handle Java 9+ compact-string coder state correctly.
* Added `forceLatin1Coder(...)` before using the direct byte-fill path so reused builders are prepared for Latin-1 writes.
* Preserved the safe fallback to `StringBuilder.setLength(...)` when compact-string internals are unavailable or direct memory is disabled.
* Updated `BytesInternal.parse8bit1(...)` to distinguish between Latin-1 and UTF-16 `StringBuilder` storage before writing parsed 8-bit data.
* Fixed native/direct byte parsing to treat bytes as unsigned when converting to chars.
* Added regression coverage for reused UTF-16-backed `StringBuilder` instances receiving Latin-1 / 8-bit data. 
* Added `BinaryMultiByteStringTruncationTest` to verify binary wire round-tripping preserves all DTO fields after a multi-byte string value.
* Covered on-heap binary wire, direct-memory binary wire, ASCII binary wire, long field names, and text wire round-tripping.

### Related PRs

* Chronicle-Bytes: OpenHFT/Chronicle-Bytes#724
* Chronicle-Wire: OpenHFT/Chronicle-Wire#1260
* Chronicle-Core: OpenHFT/Chronicle-Core#853

### Testing

Added regression tests covering the original corruption scenario:

* `StringUtilsTest.setLengthPreparesLatin1BufferForReusedUtf16Builder`
* `AppendableUtilTest.read8bitPreservesTextWhenStringBuilderUsesUtf16Storage`
* `AppendableUtilTest.parse8bitPreservesExtendedByteWhenStringBuilderUsesUtf16Storage`
* `AppendableUtilTest.parse8bitFromNativeBytesPreservesExtendedByteWhenStringBuilderUsesUtf16Storage`
* `BinaryMultiByteStringTruncationTest`

These tests verify that reused builders previously containing `√` correctly decode subsequent Latin-1 / ASCII content and that binary wire DTO decoding no longer drops fields after a multi-byte string.
