### PR TITLE
Revert "CORE-62: Fix StringBuilder corruption after non-Latin-1 content"

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -771,21 +771,10 @@ enum BytesInternal {
         sb.ensureCapacity(utflen);
 
         if (Jvm.isJava9Plus() && Jvm.maxDirectMemory() > 0) {
-            byte coder = getStringCoder(sb);
-            if (coder == JAVA9_STRING_CODER_LATIN) {
-                byte[] sbBytes = extractBytes(sb);
-                for (int count = 0; count < utflen; count++) {
-                    int c = bytes.readUnsignedByte();
-                    sbBytes[count] = (byte) c;
-                }
-                StringUtils.setLength(sb, utflen);
-            } else {
-                assert coder == JAVA9_STRING_CODER_UTF16;
-                sb.setLength(utflen);
-                for (int count = 0; count < utflen; count++) {
-                    int c = bytes.readUnsignedByte();
-                    sb.setCharAt(count, (char) c);
-                }
+            byte[] sbBytes = extractBytes(sb);
+            for (int count = 0; count < utflen; count++) {
+                int c = bytes.readUnsignedByte();
+                sbBytes[count] = (byte) c;
             }
         } else {
             char[] chars = StringUtils.extractChars(sb);
@@ -793,8 +782,8 @@ enum BytesInternal {
                 int c = bytes.readUnsignedByte();
                 chars[count] = (char) c;
             }
-            StringUtils.setLength(sb, utflen);
         }
+        StringUtils.setLength(sb, utflen);
     }
 
     public static void parse8bit1(@NotNull StreamingDataInput bytes, @NotNull Appendable appendable, @NonNegative int utflen)
@@ -949,7 +938,7 @@ enum BytesInternal {
                 assert coder == JAVA9_STRING_CODER_UTF16;
                 sb.setLength(length);
                 while (count < length) {
-                    int b = memory.readByte(address + count) & 0xFF;
+                    byte b = memory.readByte(address + count);
                     sb.setCharAt(count++, (char) b);
                 }
             }

--- a/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
@@ -11,7 +11,6 @@ import java.nio.BufferUnderflowException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class AppendableUtilTest extends BytesTestCommon {
@@ -64,52 +63,6 @@ public class AppendableUtilTest extends BytesTestCommon {
         StringBuilder sb = new StringBuilder();
         AppendableUtil.parseUtf8(bs, sb, true, 11);
         Assertions.assertEquals("Hello World", sb.toString());
-    }
-
-    @Test
-    public void read8bitPreservesTextWhenStringBuilderUsesUtf16Storage() {
-        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
-        try {
-            bytes.write8bit("field");
-
-            StringBuilder sb = utf16StringBuilder();
-            assertTrue(bytes.read8bit(sb));
-
-            assertEquals("field", sb.toString());
-        } finally {
-            bytes.releaseLast();
-        }
-    }
-
-    @Test
-    public void parse8bitPreservesExtendedByteWhenStringBuilderUsesUtf16Storage() throws Exception {
-        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
-        try {
-            bytes.writeUnsignedByte(0xA3);
-
-            StringBuilder sb = utf16StringBuilder();
-            AppendableUtil.parse8bit(bytes, sb, 1);
-
-            assertEquals("\u00A3", sb.toString());
-        } finally {
-            bytes.releaseLast();
-        }
-    }
-
-    @Test
-    public void parse8bitFromNativeBytesPreservesExtendedByteWhenStringBuilderUsesUtf16Storage() throws Exception {
-        assumeFalse(NativeBytes.areNewGuarded());
-        Bytes<?> bytes = Bytes.allocateElasticDirect();
-        try {
-            bytes.writeUnsignedByte(0xA3);
-
-            StringBuilder sb = utf16StringBuilder();
-            AppendableUtil.parse8bit(bytes, sb, 1);
-
-            assertEquals("\u00A3", sb.toString());
-        } finally {
-            bytes.releaseLast();
-        }
     }
 
     @Test
@@ -198,11 +151,5 @@ public class AppendableUtilTest extends BytesTestCommon {
         assertEquals("helloXworld", sb.toString());
         assertEquals("HelloXWorld", b.toString());
         b.releaseLast();
-    }
-
-    private static StringBuilder utf16StringBuilder() {
-        StringBuilder sb = new StringBuilder("\u221A");
-        sb.setLength(0);
-        return sb;
     }
 }


### PR DESCRIPTION
Reverts OpenHFT/Chronicle-Bytes#724