### PR TITLE
CORE-62: Fix StringBuilder 8-bit parsing and subsequence append bounds

### DIFF
--- a/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
+++ b/src/main/java/net/openhft/chronicle/bytes/AppendableUtil.java
@@ -305,10 +305,12 @@ public enum AppendableUtil {
     public static <C extends Appendable & CharSequence> void append(C a, CharSequence cs, @NonNegative long start, @NonNegative long len)
             throws ArithmeticException, BufferUnderflowException, ClosedIllegalStateException, BufferOverflowException {
         if (a instanceof StringBuilder) {
-            if (cs instanceof Bytes)
+            if (cs instanceof Bytes) {
                 ((StringBuilder) a).append(Bytes.toString(((Bytes) cs), start, len));
-            else
-                ((StringBuilder) a).append(cs.subSequence(Maths.toInt32(start), Maths.toInt32(len)));
+            } else {
+                int end = Maths.toInt32(Math.addExact(start, len));
+                ((StringBuilder) a).append(cs.subSequence(Maths.toInt32(start), end));
+            }
         } else if (a instanceof Bytes) {
             ((Bytes) a).appendUtf8(cs, Maths.toInt32(start), Maths.toInt32(len));
         } else {

--- a/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
+++ b/src/main/java/net/openhft/chronicle/bytes/internal/BytesInternal.java
@@ -768,32 +768,41 @@ enum BytesInternal {
         throwExceptionIfReleased(bytes);
         if (bytes.readRemaining() < utflen)
             throw new IllegalArgumentException();
-        sb.ensureCapacity(utflen);
-
-        if (Jvm.isJava9Plus() && Jvm.maxDirectMemory() > 0) {
-            byte coder = getStringCoder(sb);
-            if (coder == JAVA9_STRING_CODER_LATIN) {
-                byte[] sbBytes = extractBytes(sb);
-                for (int count = 0; count < utflen; count++) {
-                    int c = bytes.readUnsignedByte();
-                    sbBytes[count] = (byte) c;
-                }
-                StringUtils.setLength(sb, utflen);
-            } else {
-                assert coder == JAVA9_STRING_CODER_UTF16;
-                sb.setLength(utflen);
-                for (int count = 0; count < utflen; count++) {
-                    int c = bytes.readUnsignedByte();
-                    sb.setCharAt(count, (char) c);
-                }
-            }
+        // defensive code for when reflection isn't available
+        if (Jvm.maxDirectMemory() <= 0) {
+            noReflectionParse8bit(bytes, sb, utflen);
         } else {
-            char[] chars = StringUtils.extractChars(sb);
-            for (int count = 0; count < utflen; count++) {
-                int c = bytes.readUnsignedByte();
-                chars[count] = (char) c;
-            }
             StringUtils.setLength(sb, utflen);
+            if (Jvm.isJava9Plus()) {
+                java9Parse8bit(bytes, sb, utflen);
+            } else {
+                java8Parse8bit(bytes, sb, utflen);
+            }
+        }
+    }
+
+    private static void noReflectionParse8bit(@NotNull StreamingDataInput bytes, @NotNull StringBuilder sb, int utflen) {
+        sb.setLength(utflen);
+        for (int count = 0; count < utflen; count++) {
+            int c = bytes.readUnsignedByte();
+            sb.setCharAt(count, (char) c);
+        }
+    }
+
+    private static void java9Parse8bit(@NotNull StreamingDataInput bytes, @NotNull StringBuilder sb, int utflen) {
+        assert getStringCoder(sb) == JAVA9_STRING_CODER_LATIN;
+        byte[] sbBytes = extractBytes(sb);
+        for (int count = 0; count < utflen; count++) {
+            int c = bytes.readUnsignedByte();
+            sbBytes[count] = (byte) c;
+        }
+    }
+
+    private static void java8Parse8bit(@NotNull StreamingDataInput bytes, @NotNull StringBuilder sb, int utflen) {
+        char[] chars = StringUtils.extractChars(sb);
+        for (int count = 0; count < utflen; count++) {
+            int c = bytes.readUnsignedByte();
+            chars[count] = (char) c;
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/AppendableUtilTest.java
@@ -39,16 +39,34 @@ public class AppendableUtilTest extends BytesTestCommon {
 
     @Test
     public void testAppendDouble() {
-        StringBuilder sb = new StringBuilder();
-        AppendableUtil.append(sb, 3.14);
-        assertEquals("3.14", sb.toString());
+        Bytes<?> bytes = Bytes.elasticByteBuffer();
+        try {
+            AppendableUtil.append(bytes, 2.718);
+            bytes.append(',');
+            AppendableUtil.append(bytes, 3.14);
+            assertEquals("2.718,3.14", bytes.toString());
+        } finally {
+            bytes.releaseLast();
+        }
     }
 
     @Test
     public void testAppendLong() {
         StringBuilder sb = new StringBuilder();
         AppendableUtil.append(sb, 42L);
-        assertEquals("42", sb.toString());
+        sb.append(',');
+        AppendableUtil.append(sb, 128L);
+        assertEquals("42,128", sb.toString());
+
+        Bytes<?> bytes = Bytes.elasticByteBuffer();
+        try {
+            AppendableUtil.append(bytes, 42L);
+            bytes.append(',');
+            AppendableUtil.append(bytes, 128L);
+            assertEquals("42,128", bytes.toString());
+        } finally {
+            bytes.releaseLast();
+        }
     }
 
     @Test
@@ -68,14 +86,27 @@ public class AppendableUtilTest extends BytesTestCommon {
 
     @Test
     public void read8bitPreservesTextWhenStringBuilderUsesUtf16Storage() {
+        requireMaxDirectMemory();
         Bytes<?> bytes = Bytes.allocateElasticOnHeap();
         try {
             bytes.write8bit("field");
+            bytes.write8bit("another");
+            bytes.write8bit(null);
 
             StringBuilder sb = utf16StringBuilder();
             assertTrue(bytes.read8bit(sb));
 
             assertEquals("field", sb.toString());
+
+            assertTrue(bytes.read8bit(sb));
+
+            assertEquals("another", sb.toString());
+
+            assertFalse(bytes.read8bit(sb));
+
+            // end of input == ""
+            assertTrue(bytes.read8bit(sb));
+            assertEquals("", sb.toString());
         } finally {
             bytes.releaseLast();
         }
@@ -83,14 +114,19 @@ public class AppendableUtilTest extends BytesTestCommon {
 
     @Test
     public void parse8bitPreservesExtendedByteWhenStringBuilderUsesUtf16Storage() throws Exception {
+        requireMaxDirectMemory();
         Bytes<?> bytes = Bytes.allocateElasticOnHeap();
         try {
             bytes.writeUnsignedByte(0xA3);
+            bytes.writeUnsignedByte(0xFF);
 
             StringBuilder sb = utf16StringBuilder();
-            AppendableUtil.parse8bit(bytes, sb, 1);
 
+            AppendableUtil.parse8bit(bytes, sb, 1);
             assertEquals("\u00A3", sb.toString());
+
+            AppendableUtil.parse8bit(bytes, sb, 1);
+            assertEquals("\u00FF", sb.toString());
         } finally {
             bytes.releaseLast();
         }
@@ -99,14 +135,19 @@ public class AppendableUtilTest extends BytesTestCommon {
     @Test
     public void parse8bitFromNativeBytesPreservesExtendedByteWhenStringBuilderUsesUtf16Storage() throws Exception {
         assumeFalse(NativeBytes.areNewGuarded());
+        requireMaxDirectMemory();
         Bytes<?> bytes = Bytes.allocateElasticDirect();
         try {
             bytes.writeUnsignedByte(0xA3);
+            bytes.writeUnsignedByte(0xFE);
 
             StringBuilder sb = utf16StringBuilder();
-            AppendableUtil.parse8bit(bytes, sb, 1);
 
+            AppendableUtil.parse8bit(bytes, sb, 1);
             assertEquals("\u00A3", sb.toString());
+
+            AppendableUtil.parse8bit(bytes, sb, 1);
+            assertEquals("\u00FE", sb.toString());
         } finally {
             bytes.releaseLast();
         }
@@ -122,8 +163,10 @@ public class AppendableUtilTest extends BytesTestCommon {
     @Test
     public void testAppendDoubleWithStringBuilder() {
         StringBuilder sb = new StringBuilder();
+        AppendableUtil.append(sb, 2.718);
+        sb.append(',');
         AppendableUtil.append(sb, 3.14);
-        Assertions.assertEquals("3.14", sb.toString());
+        Assertions.assertEquals("2.718,3.14", sb.toString());
     }
 
     @Test
@@ -155,17 +198,51 @@ public class AppendableUtilTest extends BytesTestCommon {
     }
 
     @Test
-    public void appendDoubleToStringBuilder() {
-        StringBuilder sb = new StringBuilder();
-        AppendableUtil.append(sb, 3.14);
-        assertEquals("3.14", sb.toString());
-    }
-
-    @Test
     public void appendStringToAppendableAndCharSequence() {
         StringBuilder sb = new StringBuilder();
         AppendableUtil.append(sb, "test");
-        assertEquals("test", sb.toString());
+        AppendableUtil.append(sb, " words");
+        assertEquals("test words", sb.toString());
+
+        Bytes<?> bytes = Bytes.elasticByteBuffer();
+        try {
+            AppendableUtil.append(bytes, "test");
+            AppendableUtil.append(bytes, " words");
+            assertEquals("test words", bytes.toString());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void appendSubsequenceToAppendableAndCharSequence() {
+        String text = "prefix text";
+        StringBuilder sb = new StringBuilder();
+        AppendableUtil.append(sb, text, 1, 4);
+        AppendableUtil.append(sb, text, 6, 3);
+        assertEquals("refi te", sb.toString());
+
+        Bytes<?> bytes = Bytes.elasticByteBuffer();
+        try {
+            AppendableUtil.append(bytes, text, 1, 4);
+            AppendableUtil.append(bytes, text, 6, 3);
+            assertEquals("refi te", bytes.toString());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void appendSubsequenceFromBytesToStringBuilder() {
+        Bytes<?> source = Bytes.from("prefix text");
+        try {
+            StringBuilder sb = new StringBuilder();
+            AppendableUtil.append(sb, source, 1, 4);
+            AppendableUtil.append(sb, source, 6, 3);
+            assertEquals("refi te", sb.toString());
+        } finally {
+            source.releaseLast();
+        }
     }
 
     @SuppressWarnings("rawtypes")

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
@@ -989,6 +989,7 @@ public class BytesTest extends BytesTestCommon {
     @Test
     public void write8BitCharSequence() {
         assumeFalse(alloc1 == HEAP_EMBEDDED);
+        requireMaxDirectMemory();
 
         @NotNull Bytes<?> bytes = alloc1.elasticBytes(703);
         StringBuilder sb = new StringBuilder();

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTestCommon.java
@@ -43,6 +43,11 @@ public class BytesTestCommon {
         return text != null && text.contains(message);
     }
 
+    protected static void requireMaxDirectMemory() {
+        if (Jvm.maxDirectMemory() <= 0)
+            throw new AssertionError("Jvm.maxDirectMemory() must be > 0; ensure root-parent-pom JVM args are applied");
+    }
+
     @Before
     @BeforeEach
     public void enableReferenceTracing() {


### PR DESCRIPTION
NOTE: This relies on a fix in Core so fails, however the Build All Bumped Branch passes end to end.

This PR fixes two StringBuilder-related byte/string handling issues in Chronicle Bytes:

* Reworks `BytesInternal.parse8bit1(...)` so 8-bit reads into a `StringBuilder` remain correct when the builder has previously used UTF-16 backing storage.
* Adds a defensive no-reflection parsing path when direct-memory/reflection support is unavailable.
* Splits the Java 9+ and Java 8 parsing paths to make the storage-specific behaviour explicit.
* Corrects `AppendableUtil.append(..., start, len)` so the `StringBuilder` path treats `len` as a length, not as the `subSequence` end index.

### Details

The 8-bit parsing path now sets the `StringBuilder` length before writing directly into the backing storage, then uses the appropriate Java-version-specific implementation. This avoids corruption when reusing a `StringBuilder` that has been promoted to UTF-16 storage after containing non-Latin characters.

The previous `StringBuilder` append path passed `len` directly as the `subSequence` end position. That worked only when `start == 0`; non-zero starts produced the wrong range. The fix computes `end = start + len` and uses that as the exclusive end index.

### Tests

Adds and extends coverage for:

* Reusing UTF-16-backed `StringBuilder` instances across repeated `read8bit` calls.
* Preserving extended 8-bit byte values such as `0xA3`, `0xFE`, and `0xFF`.
* Heap and native/direct bytes parsing paths.
* Guarding reflection-dependent tests with an explicit `Jvm.maxDirectMemory()` requirement.
* Appending longs, doubles, strings, and subsequences to both `StringBuilder` and `Bytes`.
* Appending subsequences from `Bytes` into a `StringBuilder`.

### Risk

Low to medium. The changes touch low-level text/byte parsing and append paths, but the behavioural changes are targeted and covered by focused regression tests.
