### PR TITLE
Scope Bytes bounds rejection assertions to the intended operations

### DIFF
--- a/src/test/java/net/openhft/chronicle/bytes/BytesBoundsAndLimitsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesBoundsAndLimitsTest.java
@@ -12,24 +12,24 @@ import static org.junit.Assert.*;
 
 public class BytesBoundsAndLimitsTest extends BytesTestCommon {
 
-    @Test(expected = BufferOverflowException.class)
+    @Test
     public void writeBeyondWriteLimitThrows() {
         Bytes<?> b = Bytes.allocateElasticOnHeap(8);
         try {
             b.writeLimit(4);
-            b.writeLong(1L); // 8 bytes > writeLimit
+            assertThrows(BufferOverflowException.class, () -> b.writeLong(1L));
         } finally {
             b.releaseLast();
         }
     }
 
-    @Test(expected = BufferUnderflowException.class)
+    @Test
     public void readBeyondReadLimitThrows() {
         Bytes<?> b = Bytes.allocateElasticOnHeap(8);
         try {
             b.writeInt(123);
             b.readPosition(0);
-            b.readLong(); // 8 bytes > available 4
+            assertThrows(BufferUnderflowException.class, b::readLong);
         } finally {
             b.releaseLast();
         }


### PR DESCRIPTION
## Summary

Extract two narrower rejection assertions from [migration #719](https://github.com/OpenHFT/Chronicle-Bytes/pull/719), using the existing JUnit 4.13.2 API.

The whole-method expected-exception annotations in `BytesBoundsAndLimitsTest` could accept a matching exception from preparation or cleanup. Assert only the forbidden `writeLong(1L)` or `readLong()` call, so a passing test establishes that the intended operation was rejected and that preparation and release completed successfully.

- One test file, four changed lines; all three existing scenarios remain.
- Keep the existing `finally` releases, `BytesTestCommon`, POM and production code unchanged.
- This strengthens assertion scope; it does not add boundary cases or new cleanup.
- Based directly on develop `24d2e74af3fb8786f6bca0250dcc341cd614438d`.

## Verification

Fresh full publication check on Linux amd64, OpenJDK 21.0.12, Maven 3.9.11:

```sh
mvn -o -B clean verify -l bytes-full-java21-verify.log
```

4,076 tests reported, zero failures/errors, 103 skips. All three `BytesBoundsAndLimitsTest` cases ran and passed; their combined class time was 0.018 seconds. Checkstyle, packaging, Javadoc, binary compatibility and licence checks passed. No existing skips were changed or extra test exclusions supplied.

Earlier class-scoped clean verification on this same source also passed on Java 8u502 and Java 21.0.12. Before/after controls ran the real methods through JUnit 4 and the inherited fixture:

| Control, for each method | Original | Extraction |
| --- | --- | --- |
| Normal execution | Pass | Pass |
| Expected exception during preparation | Incorrect pass | Fail |
| Forbidden operation unexpectedly succeeds | Fail | Fail |
| Expected exception after actual release in cleanup | Incorrect pass | Fail |

All 16 control outcomes were confirmed. The control injections are diagnostic only and are not included in this PR. Java 8 evidence is focused, not a full Java 8 suite; other platforms remain for CI.

## Review focus

Check that only the intended bounds violation can satisfy each assertion and that the original ownership and shared test checks remain intact. The broader framework migration and parser lifecycle repair are separate.
