### PR TITLE
Scope twelve Bytes rejection assertions to the intended calls

### DIFF
--- a/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/ByteStoreTest.java
@@ -656,11 +656,11 @@ public class ByteStoreTest extends BytesTestCommon {
         assertEquals(0, BytesStore.empty().realCapacity());
     }
 
-    @Test(expected = DecoratedBufferOverflowException.class)
+    @Test
     public void testClearAndPadTooMuch() {
         final Bytes<?> b = bytesStore.bytesForWrite();
         try {
-            b.clearAndPad(SIZE + 1);
+            assertThrows(DecoratedBufferOverflowException.class, () -> b.clearAndPad(SIZE + 1));
         } finally {
             b.releaseLast();
         }

--- a/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/BytesTest.java
@@ -337,13 +337,13 @@ public class BytesTest extends BytesTestCommon {
         }
     }
 
-    @Test(expected = BufferOverflowException.class)
+    @Test
     public void testPartialWriteArray() {
         assumeFalse(alloc1 == HEX_DUMP);
         @NotNull byte[] array = "Hello World".getBytes(ISO_8859_1);
         Bytes<?> to = alloc1.fixedBytes(6);
         try {
-            to.write(array);
+            assertThrows(BufferOverflowException.class, () -> to.write(array));
         } finally {
             postTest(to);
         }
@@ -423,7 +423,7 @@ public class BytesTest extends BytesTestCommon {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testExpectNegativeOffsetAbsoluteWriteOnElasticBytesThrowsIllegalArgumentException()
             throws BufferOverflowException, IllegalStateException {
         assumeFalse(alloc1 == HEX_DUMP);
@@ -432,13 +432,13 @@ public class BytesTest extends BytesTestCommon {
         try {
             assumeFalse(bytes.unchecked());
 
-            bytes.writeInt(-1, 1);
+            assertThrows(IllegalArgumentException.class, () -> bytes.writeInt(-1, 1));
         } finally {
             postTest(bytes);
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testExpectNegativeOffsetAbsoluteWriteOnElasticBytesOfInsufficientCapacityThrowsIllegalArgumentException()
             throws IllegalStateException, BufferOverflowException {
         assumeFalse(alloc1 == HEX_DUMP);
@@ -446,29 +446,29 @@ public class BytesTest extends BytesTestCommon {
 
         try {
             assumeFalse(bytes.unchecked());
-            bytes.writeInt(-1, 1);
+            assertThrows(IllegalArgumentException.class, () -> bytes.writeInt(-1, 1));
         } finally {
             postTest(bytes);
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testExpectNegativeOffsetAbsoluteWriteOnFixedBytesThrowsIllegalArgumentException() {
         assumeFalse(alloc1 == HEX_DUMP);
         Bytes<?> bytes = alloc1.fixedBytes(4);
         try {
-            bytes.writeInt(-1, 1);
+            assertThrows(IllegalArgumentException.class, () -> bytes.writeInt(-1, 1));
         } finally {
             postTest(bytes);
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testExpectNegativeOffsetAbsoluteWriteOnFixedBytesOfInsufficientCapacityThrowsIllegalArgumentException() {
         assumeFalse(alloc1 == HEX_DUMP);
         Bytes<?> bytes = alloc1.fixedBytes(1);
         try {
-            bytes.writeInt(-1, 1);
+            assertThrows(IllegalArgumentException.class, () -> bytes.writeInt(-1, 1));
         } finally {
             postTest(bytes);
         }

--- a/src/test/java/net/openhft/chronicle/bytes/LockingByteableTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/LockingByteableTest.java
@@ -14,15 +14,16 @@ import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 public class LockingByteableTest extends BytesTestCommon {
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void notLockable() throws IOException {
         try (BinaryLongReference blr = new BinaryLongReference()) {
             blr.bytesStore(Bytes.from("Hello World"), 0, 8);
-            blr.lock(false);
+            assertThrows(UnsupportedOperationException.class, () -> blr.lock(false));
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/bytes/MoreBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/MoreBytesTest.java
@@ -149,13 +149,13 @@ public class MoreBytesTest extends BytesTestCommon {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAppendDoubleRandomPositionShouldThrowIllegalArgumentException() {
 
         final byte[] bytes = "000000".getBytes(ISO_8859_1);
         final Bytes<?> to = Bytes.wrapForWrite(bytes);
         try {
-            to.append(0, 33333.14, 2, 6);
+            assertThrows(IllegalArgumentException.class, () -> to.append(0, 33333.14, 2, 6));
         } finally {
             to.releaseLast();
         }

--- a/src/test/java/net/openhft/chronicle/bytes/NativeBytesOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/NativeBytesOverflowTest.java
@@ -10,42 +10,43 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 
 import static net.openhft.chronicle.bytes.BytesStore.wrap;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 public class NativeBytesOverflowTest extends BytesTestCommon {
 
-    @Test(expected = BufferOverflowException.class)
+    @Test
     public void testExceedWriteLimitNativeWriteBytes() {
         BytesStore<?, ByteBuffer> store = wrap(ByteBuffer.allocate(128));
         Bytes<?> nb = new NativeBytes<>(store);
         try {
             nb.writeLimit(2).writePosition(0);
-            nb.writeLong(10L);
+            assertThrows(BufferOverflowException.class, () -> nb.writeLong(10L));
         } finally {
             nb.releaseLast();
         }
     }
 
-    @Test(expected = BufferOverflowException.class)
+    @Test
     public void testExceedWriteLimitGuardedBytes() {
         Bytes<?> guardedNativeBytes = new GuardedNativeBytes<>(wrap(ByteBuffer.allocate(128)), 128);
         try {
             guardedNativeBytes.writeLimit(2).writePosition(0);
-            guardedNativeBytes.writeLong(10L);
+            assertThrows(BufferOverflowException.class, () -> guardedNativeBytes.writeLong(10L));
         } finally {
             guardedNativeBytes.releaseLast();
         }
     }
 
-    @Test(expected = BufferOverflowException.class)
+    @Test
     public void testElastic() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
         Bytes<?> bytes = Bytes.elasticByteBuffer();
         try {
             bytes.writeLimit(2).writePosition(0);
-            bytes.writeLong(10L);
+            assertThrows(BufferOverflowException.class, () -> bytes.writeLong(10L));
         } finally {
             bytes.releaseLast();
         }

--- a/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalSubBytesErrorsTest.java
+++ b/src/test/java/net/openhft/chronicle/bytes/internal/BytesInternalSubBytesErrorsTest.java
@@ -9,17 +9,18 @@ import org.junit.Test;
 
 import java.nio.BufferUnderflowException;
 
+import static org.junit.Assert.assertThrows;
+
 public class BytesInternalSubBytesErrorsTest extends BytesTestCommon {
 
-    @Test(expected = BufferUnderflowException.class)
+    @Test
     public void subBytesThrowsWhenLengthTooLarge() {
         Bytes<?> src = Bytes.from("abc");
         try {
             // request a sub view longer than remaining
-            BytesInternal.subBytes(src, 0, 10);
+            assertThrows(BufferUnderflowException.class, () -> BytesInternal.subBytes(src, 0, 10));
         } finally {
             src.releaseLast();
         }
     }
 }
-


### PR DESCRIPTION
Twelve rejection tests use whole-method expected-exception annotations, so a matching exception from preparation or cleanup can satisfy the test without establishing that the intended operation was rejected. Scope each assertion to that operation using JUnit 4.13.2 `assertThrows`, leaving preparation and resource release outside it.

Extract these test-quality changes from #719:

- Three native/guarded/elastic write-limit tests in `NativeBytesOverflowTest`.
- Partial array writes and four negative-offset writes in `BytesTest`.
- Oversized padding in `ByteStoreTest`, fixed-width double formatting in `MoreBytesTest`, unsupported locking in `LockingByteableTest`, and oversized subviews in `BytesInternalSubBytesErrorsTest`.

The six-file change retains the existing allocator cases and framework. It is independent of the two bounds assertions in #733 and the separate shared-fixture correction. It supports the existing bounds-test obligation CB-TEST-006.

Validation on Linux amd64, OpenJDK 21.0.12, Maven 3.9.11:

- Full `mvn -o -B clean verify`: **4,076 tests reported, zero failures/errors, 103 existing skips**. Checkstyle, packaging, Javadoc, binary compatibility and licence checks passed.
- Focused clean verification before/after matches all 47 reported outcomes: 38 passes and nine existing assumption skips.
- Real JUnit 4 negative controls for the three native-overflow methods: a preparatory overflow falsely passes the original tests and fails these assertions; allowing the forbidden write makes both versions fail. Diagnostic injections are excluded from the PR.

Both this branch and the comparison use develop `24d2e74af3fb8786f6bca0250dcc341cd614438d`. Platform CI remains to run.
