### PR TITLE
Disable Surefire retries even when requested on the command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,8 @@
                     <argLine>${surefireArgLine} ${jvm.requiredArgs}</argLine>
                     <forkCount>4</forkCount>
                     <reuseForks>true</reuseForks>
+                    <!-- Keep the first failure visible, including when CI requests retries. -->
+                    <rerunFailingTestsCount>0</rerunFailingTestsCount>
                     <runOrder>hourly</runOrder>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Set Surefire's `rerunFailingTestsCount` directly to `0`, so a command-line option such as `-Dsurefire.rerunFailingTestsCount=3` cannot cause a failed test to be retried. This preserves the first failure on every platform.

Validation:

- Maven's effective configuration resolves zero retries with both default arguments and an explicit command-line retry count of three.
- Java 11: `mvn clean verify -Dsurefire.rerunFailingTestsCount=3` passed, with 3,957 tests passing, 102 skipped, and no failures, errors or retries.
